### PR TITLE
Improve distance calculation with coordinate validation

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -252,6 +252,7 @@ MIN_TEMPERATURE: Final = 35.0
 MAX_TEMPERATURE: Final = 42.0
 
 # GPS Constants
+EARTH_RADIUS_M: Final = 6_371_000  # Earth's radius in meters
 GPS_ACCURACY_EXCELLENT: Final = 5  # meters
 GPS_ACCURACY_GOOD: Final = 15
 GPS_ACCURACY_ACCEPTABLE: Final = 50

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -22,6 +22,7 @@ from .const import (
     SIZE_MEDIUM,
     SIZE_LARGE,
     SIZE_GIANT,
+    EARTH_RADIUS_M,
 )
 
 
@@ -86,20 +87,20 @@ def validate_gps_accuracy(accuracy: float) -> bool:
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Calculate distance between two GPS coordinates using Haversine formula."""
     try:
+        if not validate_coordinates(lat1, lon1) or not validate_coordinates(lat2, lon2):
+            return 0.0
+
         # Convert to radians
         lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
-        
+
         # Haversine formula
         dlat = lat2 - lat1
         dlon = lon2 - lon1
-        a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
-        c = 2 * atan2(sqrt(a), sqrt(1-a))
-        
-        # Earth's radius in meters
-        radius = 6371000
-        
-        return radius * c
-    except Exception:
+        a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
+        c = 2 * atan2(sqrt(a), sqrt(1 - a))
+
+        return EARTH_RADIUS_M * c
+    except (ValueError, TypeError):
         return 0.0
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,39 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Set up package structure for relative imports
+BASE_PATH = Path(__file__).resolve().parent.parent / "custom_components" / "pawcontrol"
+
+custom_components = types.ModuleType("custom_components")
+custom_components.__path__ = [str(BASE_PATH.parent)]
+sys.modules["custom_components"] = custom_components
+
+pawcontrol_pkg = types.ModuleType("custom_components.pawcontrol")
+pawcontrol_pkg.__path__ = [str(BASE_PATH)]
+sys.modules["custom_components.pawcontrol"] = pawcontrol_pkg
+
+const_spec = importlib.util.spec_from_file_location(
+    "custom_components.pawcontrol.const", BASE_PATH / "const.py"
+)
+const_mod = importlib.util.module_from_spec(const_spec)
+const_spec.loader.exec_module(const_mod)
+sys.modules["custom_components.pawcontrol.const"] = const_mod
+
+utils_spec = importlib.util.spec_from_file_location(
+    "custom_components.pawcontrol.utils", BASE_PATH / "utils.py"
+)
+utils = importlib.util.module_from_spec(utils_spec)
+utils_spec.loader.exec_module(utils)
+
+
+def test_calculate_distance_valid():
+    dist = utils.calculate_distance(0, 0, 0, 1)
+    assert dist == pytest.approx(111195, rel=1e-5)
+
+
+def test_calculate_distance_invalid():
+    assert utils.calculate_distance(91, 0, 0, 1) == 0.0


### PR DESCRIPTION
## Summary
- add Earth radius constant for reuse
- validate GPS coordinates and use shared constant in distance calculation
- cover distance helper with tests

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895e58bfaec8331879392fd4cb22810