### PR TITLE
Use slugify for helper IDs

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -31,6 +31,7 @@ from homeassistant.components.counter import (
     DOMAIN as COUNTER_DOMAIN,
     Counter,
 )
+from homeassistant.util import slugify
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,7 +40,13 @@ STORAGE_KEY_PREFIX = "pawcontrol_helpers"
 
 
 class ImprovedModuleManager:
-    """Improved module manager with proper helper creation."""
+    """Improved module manager with proper helper creation.
+
+    The ``dog_id`` attribute is generated using Home Assistant's
+    :func:`slugify <homeassistant.util.slugify>` utility, which strips
+    invalid characters to produce a safe identifier. If slugification
+    results in an empty string, the manager falls back to ``"unknown"``.
+    """
     
     def __init__(
         self,
@@ -67,8 +74,8 @@ class ImprovedModuleManager:
         self._created_helpers: dict[str, dict] = {}
         
     def _sanitize_name(self, name: str) -> str:
-        """Sanitize name for entity IDs."""
-        return name.lower().replace(" ", "_").replace("-", "_")
+        """Generate a slugified name for entity IDs."""
+        return slugify(name) or "unknown"
     
     async def async_initialize(self) -> None:
         """Initialize the module manager and load existing helpers."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+import importlib.util
+from unittest.mock import MagicMock
+
+HELPERS_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pawcontrol" / "helpers.py"
+spec = importlib.util.spec_from_file_location("helpers", HELPERS_PATH)
+helpers = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(helpers)  # type: ignore[attr-defined]
+ImprovedModuleManager = helpers.ImprovedModuleManager
+
+
+def test_sanitize_name_slugifies_simple():
+    hass = MagicMock()
+    manager = ImprovedModuleManager(hass, None, None, {"dog_name": "Fido Mc Dog"})
+    assert manager.dog_id == "fido_mc_dog"
+
+
+def test_sanitize_name_special_chars():
+    hass = MagicMock()
+    manager = ImprovedModuleManager(hass, None, None, {"dog_name": "Ärger & Spaß"})
+    assert manager.dog_id == "arger_spass"
+
+
+def test_sanitize_name_invalid_returns_unknown():
+    hass = MagicMock()
+    manager = ImprovedModuleManager(hass, None, None, {"dog_name": "!@#$"})
+    assert manager.dog_id == "unknown"


### PR DESCRIPTION
## Summary
- slugify dog names when generating helper IDs
- add tests for slugified helper IDs
- document slugified `dog_id` generation in helper manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895e8c7cb888331babae53627bfa9e1