### PR TITLE
Improve dog name validation in PawControl integration

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -37,3 +37,11 @@ def test_calculate_distance_valid():
 
 def test_calculate_distance_invalid():
     assert utils.calculate_distance(91, 0, 0, 1) == 0.0
+
+
+def test_validate_dog_name_valid_characters():
+    assert utils.validate_dog_name("Fido_Ä")
+
+
+def test_validate_dog_name_invalid_characters():
+    assert not utils.validate_dog_name("Bad*Name!")


### PR DESCRIPTION
## Summary
- reuse shared dog name validator in config flow to ensure consistent input checks
- add tests covering valid and invalid dog names

## Testing
- `pytest`
- `flake8` *(fails: command not found; attempted installation but dependency unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_6895ef137a10833186f060f7231bf156