### PR TITLE
Validate input select initial option

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -293,6 +293,14 @@ class ImprovedModuleManager:
         
         if initial is None:
             initial = options[0]
+        elif initial not in options:
+            _LOGGER.warning(
+                "Initial value '%s' not in options for %s; using '%s'",
+                initial,
+                entity_id,
+                options[0],
+            )
+            initial = options[0]
         
         # Create the input select configuration
         config = {

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
+import asyncio
 import importlib.util
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, AsyncMock
 
 HELPERS_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pawcontrol" / "helpers.py"
 spec = importlib.util.spec_from_file_location("helpers", HELPERS_PATH)
@@ -25,3 +26,22 @@ def test_sanitize_name_invalid_returns_unknown():
     hass = MagicMock()
     manager = ImprovedModuleManager(hass, None, None, {"dog_name": "!@#$"})
     assert manager.dog_id == "unknown"
+
+
+def test_input_select_initial_falls_back(monkeypatch):
+    """Ensure invalid initial option falls back to first available option."""
+    hass = MagicMock()
+    manager = ImprovedModuleManager(hass, None, None, {"dog_name": "Fido"})
+    registry = MagicMock()
+    registry.async_get.return_value = None
+    monkeypatch.setattr(helpers.er, "async_get", MagicMock(return_value=registry))
+    monkeypatch.setattr(manager, "_add_helper_to_config", AsyncMock())
+    monkeypatch.setattr(manager, "_save_helpers", AsyncMock())
+
+    entity_id = asyncio.run(
+        manager.async_create_input_select(
+            "walk_type", "Walk Type", ["short", "long"], initial="unknown"
+        )
+    )
+
+    assert manager._created_helpers[entity_id]["config"]["initial"] == "short"


### PR DESCRIPTION
## Summary
- ensure input select helpers fall back to a valid option
- cover invalid initial value with a unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f174e7448331a22e100dac1dfd50