### PR TITLE
Improve dog name validation

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -28,10 +28,19 @@ from .const import (
 
 # Validation Functions
 def validate_dog_name(name: str) -> bool:
-    """Validate dog name."""
+    """Validate dog name.
+
+    Leading and trailing whitespace is ignored so that names entered with
+    accidental spaces are still considered valid. Non-string inputs are
+    rejected early.
+    """
+    if not isinstance(name, str):
+        return False
+
+    name = name.strip()
     if not name or len(name) < MIN_DOG_NAME_LENGTH or len(name) > MAX_DOG_NAME_LENGTH:
         return False
-    
+
     # Allow letters, numbers, spaces, hyphens, underscores, and umlauts
     pattern = r"^[a-zA-ZäöüÄÖÜß0-9\s\-_.]+$"
     return bool(re.match(pattern, name))

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,15 @@ def test_validate_dog_name_valid_characters():
 
 def test_validate_dog_name_invalid_characters():
     assert not utils.validate_dog_name("Bad*Name!")
+
+
+def test_validate_dog_name_strips_whitespace():
+    assert utils.validate_dog_name("  Fido  ")
+
+
+def test_validate_dog_name_whitespace_only():
+    assert not utils.validate_dog_name("   ")
+
+
+def test_validate_dog_name_rejects_non_string():
+    assert not utils.validate_dog_name(None)


### PR DESCRIPTION
## Summary
- handle leading/trailing whitespace in dog names
- reject non-string inputs for dog name validation
- expand tests for dog name validation edge cases

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895f174e7448331a22e100dac1dfd50