### PR TITLE
Filter out unknown modules in configuration

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -27,6 +27,7 @@ from .coordinator import PawControlCoordinator
 from .modules import ModuleManager
 from .services import async_register_services, async_unregister_services
 from .setup_manager import PawControlSetupManager
+from .utils import filter_invalid_modules
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -72,9 +73,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         dog_name = dog_config.get(CONF_DOG_NAME)
         if not dog_name:
             continue
-            
+
+        modules = dog_config.get(CONF_MODULES, {})
+        dog_config[CONF_MODULES] = filter_invalid_modules(modules)
+
         _LOGGER.info(f"Initializing coordinator for dog: {dog_name}")
-        
+
         # Create coordinator for this dog
         coordinator = PawControlCoordinator(hass, entry, dog_config)
         

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for PawControl integration."""
 from __future__ import annotations
 
+import logging
 import re
 from datetime import datetime, timedelta
 from math import radians, sin, cos, sqrt, atan2
@@ -23,7 +24,11 @@ from .const import (
     SIZE_LARGE,
     SIZE_GIANT,
     EARTH_RADIUS_M,
+    ALL_MODULES,
 )
+
+
+_LOGGER = logging.getLogger(__name__)
 
 
 # Validation Functions
@@ -81,6 +86,28 @@ def validate_gps_accuracy(accuracy: float) -> bool:
         return 0 <= acc <= 1000  # meters
     except (ValueError, TypeError):
         return False
+
+
+# Configuration Utilities
+def filter_invalid_modules(modules: dict[str, Any]) -> dict[str, Any]:
+    """Remove unknown modules from configuration.
+
+    Returns a new dictionary containing only modules defined in
+    :const:`ALL_MODULES`. Unknown modules are logged and discarded to avoid
+    setup errors when the configuration was manually edited or imported from
+    an older version.
+    """
+    if not isinstance(modules, dict):
+        return {}
+
+    valid: dict[str, Any] = {}
+    for module_id, config in modules.items():
+        if module_id in ALL_MODULES:
+            valid[module_id] = config
+        else:
+            _LOGGER.warning("Unknown module '%s' removed from configuration", module_id)
+
+    return valid
 
 
 # Calculation Functions

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -45,3 +45,14 @@ def test_validate_dog_name_valid_characters():
 
 def test_validate_dog_name_invalid_characters():
     assert not utils.validate_dog_name("Bad*Name!")
+
+
+def test_filter_invalid_modules_removes_unknown():
+    modules = {"feeding": {"enabled": True}, "unknown": {"enabled": True}}
+    filtered = utils.filter_invalid_modules(modules)
+    assert "feeding" in filtered
+    assert "unknown" not in filtered
+
+
+def test_filter_invalid_modules_handles_non_dict():
+    assert utils.filter_invalid_modules([]) == {}


### PR DESCRIPTION
## Summary
- ignore unsupported modules in PawControl configuration
- use new filtering during integration setup
- add tests for module filtering utility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f174e7448331a22e100dac1dfd50