### PR TITLE
Refactor helper storage setup

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -380,18 +380,25 @@ class ImprovedModuleManager:
         # This needs to be properly integrated with HA's helper infrastructure
         
         full_entity_id = f"{domain}.pawcontrol_{entity_id}"
-        
-        # Store in the integration's data for entity platforms to use
-        if "helpers" not in self.hass.data.get("pawcontrol", {}):
-            if "pawcontrol" not in self.hass.data:
-                self.hass.data["pawcontrol"] = {}
-            self.hass.data["pawcontrol"]["helpers"] = {}
-        
-        self.hass.data["pawcontrol"]["helpers"][full_entity_id] = config
-        
+
+        helpers = self._get_helpers_storage()
+        helpers[full_entity_id] = config
+
         # Trigger a config entry reload to create the entities
         # This is a simplified approach - actual implementation would be more complex
-        _LOGGER.debug(f"Added helper config for {full_entity_id}")
+        _LOGGER.debug("Added helper config for %s", full_entity_id)
+
+    def _get_helpers_storage(self) -> dict[str, Any]:
+        """Return a writable helpers storage mapping.
+
+        This accessor ensures that the nested ``hass.data`` structure used
+        for PawControl helper tracking exists, creating any missing levels
+        as needed, and always returns a mutable dictionary. Callers may
+        freely read from or update the returned mapping to manage helper
+        configuration internally.
+        """
+        pawcontrol_data = self.hass.data.setdefault("pawcontrol", {})
+        return pawcontrol_data.setdefault("helpers", {})
     
     async def async_remove_all_helpers(self) -> None:
         """Remove all helpers for this dog."""

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 import importlib.util
 from unittest.mock import MagicMock
+import asyncio
 
 HELPERS_PATH = Path(__file__).resolve().parents[1] / "custom_components" / "pawcontrol" / "helpers.py"
 spec = importlib.util.spec_from_file_location("helpers", HELPERS_PATH)
@@ -25,3 +26,14 @@ def test_sanitize_name_invalid_returns_unknown():
     hass = MagicMock()
     manager = ImprovedModuleManager(hass, None, None, {"dog_name": "!@#$"})
     assert manager.dog_id == "unknown"
+
+
+def test_add_helper_creates_storage():
+    hass = MagicMock()
+    hass.data = {}
+    manager = ImprovedModuleManager(hass, None, None, {"dog_name": "Fido"})
+    asyncio.run(manager._add_helper_to_config("input_boolean", "play", {"name": "Play"}))
+
+    assert "pawcontrol" in hass.data
+    assert "helpers" in hass.data["pawcontrol"]
+    assert "input_boolean.pawcontrol_play" in hass.data["pawcontrol"]["helpers"]


### PR DESCRIPTION
## Summary
- centralize helper storage initialization for the PawControl integration
- add regression test for helper storage creation
- document helper storage accessor to clarify internal usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f174e7448331a22e100dac1dfd50