### PR TITLE
Use shared sanitizer for module IDs

### DIFF
--- a/custom_components/pawcontrol/modules.py
+++ b/custom_components/pawcontrol/modules.py
@@ -25,6 +25,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .helper_factory import HelperFactory
+from .utils import sanitize_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -78,8 +79,12 @@ class ModuleManager:
         await self.helper_factory.async_initialize()
 
     def _sanitize_name(self, name: str) -> str:
-        """Sanitize name for entity IDs."""
-        return name.lower().replace(" ", "_").replace("-", "_")
+        """Sanitize name for entity IDs.
+
+        Delegates to :func:`sanitize_entity_id` to ensure consistent rules
+        across the integration and properly handle special characters.
+        """
+        return sanitize_entity_id(name)
 
     async def async_enable_module(
         self, module_id: str, module_config: dict[str, Any]

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -509,20 +509,26 @@ def get_activity_status_emoji(activity_type: str, status: str = "active") -> str
 
 
 def sanitize_entity_id(name: str) -> str:
-    """Sanitize a name for use in entity IDs."""
+    """Sanitize a name for use in Home Assistant entity IDs.
+
+    Ensures a valid string is returned by removing unsupported characters,
+    collapsing whitespace and providing a sensible fallback when the name
+    would otherwise be empty.
+    """
     # Convert to lowercase
     name = name.lower()
-    
+
     # Replace spaces and special characters with underscores
     name = re.sub(r"[^a-z0-9]+", "_", name)
-    
+
     # Remove leading/trailing underscores
     name = name.strip("_")
-    
+
     # Replace multiple underscores with single
     name = re.sub(r"_+", "_", name)
-    
-    return name
+
+    # Ensure we always return a non-empty identifier
+    return name or "unnamed"
 
 
 def parse_time_string(time_str: str) -> tuple[int, int] | None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -64,3 +64,8 @@ def test_validate_dog_name_whitespace_only():
 
 def test_validate_dog_name_rejects_non_string():
     assert not utils.validate_dog_name(None)
+
+
+def test_sanitize_entity_id_provides_fallback_for_empty_names():
+    """Sanitized entity IDs should never be empty."""
+    assert utils.sanitize_entity_id("!!!") == "unnamed"


### PR DESCRIPTION
## Summary
- reuse `sanitize_entity_id` for module identifiers
- ensure `sanitize_entity_id` never returns empty strings
- test fallback behaviour for invalid names

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895f78c4f28833182178e62652767de