### PR TITLE
Add missing manifest metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,8 +81,12 @@ und dieses Projekt folgt [Semantic Versioning](https://semver.org/spec/v2.0.0.ht
 
 ---
 
-## [Unreleased] - Geplante Features
+## [Unreleased]
 
+### Fixed
+- Added missing `issue_tracker` and Home Assistant version requirement to manifest to satisfy installation validation.
+
+### Geplante Features
 Siehe [ROADMAP.md](ROADMAP.md) für alle geplanten Features und Entwicklungsschritte.
 
 ---

--- a/custom_components/pawcontrol/manifest.json
+++ b/custom_components/pawcontrol/manifest.json
@@ -3,6 +3,7 @@
   "name": "PawControl",
   "version": "1.0.0",
   "documentation": "https://github.com/your-github/pawcontrol",
+  "issue_tracker": "https://github.com/your-github/pawcontrol/issues",
   "dependencies": [],
   "codeowners": [
     "@your-github"
@@ -10,5 +11,6 @@
   "requirements": [],
   "after_dependencies": [],
   "iot_class": "local_push",
+  "homeassistant": "2024.6.0",
   "config_flow": true
 }


### PR DESCRIPTION
## Summary
- provide issue tracker URL and Home Assistant version requirement in manifest to pass validation
- document manifest fixes in changelog

## Testing
- `python validate_installation.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6895fe8d4d5c8331a89a4fe68f636ffd