### PR TITLE
Fix missing datetime import in Poop log button

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any
 
 from homeassistant.components.button import ButtonEntity


### PR DESCRIPTION
## Summary
- add missing `datetime` import to button module

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68994d283b1c83318296b48d292f75bf