### PR TITLE
Refactor imports for patching

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -32,11 +32,11 @@ from .const import (
     SERVICE_GENERATE_REPORT,
     SERVICE_EXPORT_DATA,
 )
-from .coordinator import PawControlCoordinator
 from .helpers.scheduler import setup_schedulers, cleanup_schedulers
-from .helpers.setup_sync import SetupSync
-from .helpers.notification_router import NotificationRouter
-from .report_generator import ReportGenerator
+
+# Import modules instead of classes to allow patching in tests
+from . import coordinator, report_generator
+from .helpers import notification_router, setup_sync
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -52,19 +52,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     
     # Initialize coordinator
-    coordinator = PawControlCoordinator(hass, entry)
-    
+    pc_coordinator = coordinator.PawControlCoordinator(hass, entry)
+
     try:
-        await coordinator.async_config_entry_first_refresh()
+        await pc_coordinator.async_config_entry_first_refresh()
     except Exception as err:
         raise ConfigEntryNotReady from err
-    
+
     # Store coordinator and helpers
     hass.data[DOMAIN][entry.entry_id] = {
-        "coordinator": coordinator,
-        "notification_router": NotificationRouter(hass, entry),
-        "setup_sync": SetupSync(hass, entry),
-        "report_generator": ReportGenerator(hass, entry),
+        "coordinator": pc_coordinator,
+        "notification_router": notification_router.NotificationRouter(hass, entry),
+        "setup_sync": setup_sync.SetupSync(hass, entry),
+        "report_generator": report_generator.ReportGenerator(hass, entry),
     }
     
     # Register devices for each dog
@@ -80,8 +80,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await setup_schedulers(hass, entry)
     
     # Initial sync of helpers and entities
-    setup_sync = hass.data[DOMAIN][entry.entry_id]["setup_sync"]
-    await setup_sync.sync_all()
+    setup_sync_helper = hass.data[DOMAIN][entry.entry_id]["setup_sync"]
+    await setup_sync_helper.sync_all()
     
     # Add update listener
     entry.async_on_unload(entry.add_update_listener(async_update_options))
@@ -110,21 +110,21 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Update options."""
-    coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
-    setup_sync = hass.data[DOMAIN][entry.entry_id]["setup_sync"]
-    
+    pc_coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    setup_sync_helper = hass.data[DOMAIN][entry.entry_id]["setup_sync"]
+
     # Update coordinator with new options
-    coordinator.update_options(entry.options)
-    
+    pc_coordinator.update_options(entry.options)
+
     # Resync helpers and entities
-    await setup_sync.sync_all()
-    
+    await setup_sync_helper.sync_all()
+
     # Reschedule tasks with new times
     await cleanup_schedulers(hass, entry)
     await setup_schedulers(hass, entry)
-    
+
     # Refresh data
-    await coordinator.async_request_refresh()
+    await pc_coordinator.async_request_refresh()
 
 
 async def _register_devices(hass: HomeAssistant, entry: ConfigEntry) -> None:


### PR DESCRIPTION
## Summary
- Import coordinator and helper modules instead of classes to allow test patching
- Adjust setup routines to use new module references

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_6899f256e15c8331a4e47da6f7fd7177