### PR TITLE
Avoid deprecated option flow config_entry assignment

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -10,28 +10,59 @@ from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
-from homeassistant.helpers.selector import (BooleanSelector, EntitySelector,
-                                            EntitySelectorConfig,
-                                            NumberSelector,
-                                            NumberSelectorConfig,
-                                            SelectSelector,
-                                            SelectSelectorConfig, TextSelector,
-                                            TimeSelector)
+from homeassistant.helpers.selector import (
+    BooleanSelector,
+    EntitySelector,
+    EntitySelectorConfig,
+    NumberSelector,
+    NumberSelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
+    TextSelector,
+    TimeSelector,
+)
 
-from .const import (CONF_CALENDAR, CONF_DEVICE_TRACKERS, CONF_DOG_AGE,
-                    CONF_DOG_BREED, CONF_DOG_ID, CONF_DOG_MODULES,
-                    CONF_DOG_NAME, CONF_DOG_SIZE, CONF_DOG_WEIGHT, CONF_DOGS,
-                    CONF_DOOR_SENSOR, CONF_EXPORT_FORMAT, CONF_EXPORT_PATH,
-                    CONF_NOTIFICATIONS, CONF_NOTIFY_FALLBACK,
-                    CONF_PERSON_ENTITIES, CONF_QUIET_END, CONF_QUIET_HOURS,
-                    CONF_QUIET_START, CONF_REMINDER_REPEAT, CONF_RESET_TIME,
-                    CONF_SNOOZE_MIN, CONF_SOURCES, CONF_VISITOR_MODE,
-                    CONF_WEATHER, DEFAULT_EXPORT_FORMAT,
-                    DEFAULT_REMINDER_REPEAT, DEFAULT_RESET_TIME,
-                    DEFAULT_SNOOZE_MIN, DOMAIN, MODULE_DASHBOARD,
-                    MODULE_FEEDING, MODULE_GPS, MODULE_GROOMING, MODULE_HEALTH,
-                    MODULE_MEDICATION, MODULE_NOTIFICATIONS, MODULE_TRAINING,
-                    MODULE_WALK)
+from .const import (
+    CONF_CALENDAR,
+    CONF_DEVICE_TRACKERS,
+    CONF_DOG_AGE,
+    CONF_DOG_BREED,
+    CONF_DOG_ID,
+    CONF_DOG_MODULES,
+    CONF_DOG_NAME,
+    CONF_DOG_SIZE,
+    CONF_DOG_WEIGHT,
+    CONF_DOGS,
+    CONF_DOOR_SENSOR,
+    CONF_EXPORT_FORMAT,
+    CONF_EXPORT_PATH,
+    CONF_NOTIFICATIONS,
+    CONF_NOTIFY_FALLBACK,
+    CONF_PERSON_ENTITIES,
+    CONF_QUIET_END,
+    CONF_QUIET_HOURS,
+    CONF_QUIET_START,
+    CONF_REMINDER_REPEAT,
+    CONF_RESET_TIME,
+    CONF_SNOOZE_MIN,
+    CONF_SOURCES,
+    CONF_VISITOR_MODE,
+    CONF_WEATHER,
+    DEFAULT_EXPORT_FORMAT,
+    DEFAULT_REMINDER_REPEAT,
+    DEFAULT_RESET_TIME,
+    DEFAULT_SNOOZE_MIN,
+    DOMAIN,
+    MODULE_DASHBOARD,
+    MODULE_FEEDING,
+    MODULE_GPS,
+    MODULE_GROOMING,
+    MODULE_HEALTH,
+    MODULE_MEDICATION,
+    MODULE_NOTIFICATIONS,
+    MODULE_TRAINING,
+    MODULE_WALK,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -48,9 +79,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._sources: dict = {}
         self._notifications: dict = {}
 
-    async def async_step_user(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_user(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Handle the initial step."""
         if self._async_current_entries():
             return self.async_abort(reason="single_instance_allowed")
@@ -80,9 +109,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_dog_config(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_dog_config(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Configure individual dog."""
         errors = {}
 
@@ -91,9 +118,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             dog_id = user_input.get(CONF_DOG_ID, "").lower().replace(" ", "_")
 
             # Check for duplicate dog IDs
-            existing_ids = [
-                d.get(CONF_DOG_ID) for d in self._dogs[: self._current_dog_index]
-            ]
+            existing_ids = [d.get(CONF_DOG_ID) for d in self._dogs[: self._current_dog_index]]
             if dog_id in existing_ids:
                 errors["base"] = "duplicate_dog_id"
 
@@ -108,26 +133,16 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     CONF_DOG_SIZE: user_input.get(CONF_DOG_SIZE, "medium"),
                     CONF_DOG_MODULES: {
                         MODULE_WALK: user_input.get(f"module_{MODULE_WALK}", True),
-                        MODULE_FEEDING: user_input.get(
-                            f"module_{MODULE_FEEDING}", True
-                        ),
+                        MODULE_FEEDING: user_input.get(f"module_{MODULE_FEEDING}", True),
                         MODULE_HEALTH: user_input.get(f"module_{MODULE_HEALTH}", True),
                         MODULE_GPS: user_input.get(f"module_{MODULE_GPS}", False),
                         MODULE_NOTIFICATIONS: user_input.get(
                             f"module_{MODULE_NOTIFICATIONS}", True
                         ),
-                        MODULE_DASHBOARD: user_input.get(
-                            f"module_{MODULE_DASHBOARD}", True
-                        ),
-                        MODULE_GROOMING: user_input.get(
-                            f"module_{MODULE_GROOMING}", True
-                        ),
-                        MODULE_MEDICATION: user_input.get(
-                            f"module_{MODULE_MEDICATION}", False
-                        ),
-                        MODULE_TRAINING: user_input.get(
-                            f"module_{MODULE_TRAINING}", False
-                        ),
+                        MODULE_DASHBOARD: user_input.get(f"module_{MODULE_DASHBOARD}", True),
+                        MODULE_GROOMING: user_input.get(f"module_{MODULE_GROOMING}", True),
+                        MODULE_MEDICATION: user_input.get(f"module_{MODULE_MEDICATION}", False),
+                        MODULE_TRAINING: user_input.get(f"module_{MODULE_TRAINING}", False),
                     },
                 }
 
@@ -169,33 +184,15 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             translation_key="dog_size",
                         )
                     ),
-                    vol.Optional(
-                        f"module_{MODULE_WALK}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_FEEDING}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_HEALTH}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_GPS}", default=False
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_NOTIFICATIONS}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_DASHBOARD}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_GROOMING}", default=True
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_MEDICATION}", default=False
-                    ): BooleanSelector(),
-                    vol.Optional(
-                        f"module_{MODULE_TRAINING}", default=False
-                    ): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_WALK}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_FEEDING}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_HEALTH}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_GPS}", default=False): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_NOTIFICATIONS}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_DASHBOARD}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_GROOMING}", default=True): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_MEDICATION}", default=False): BooleanSelector(),
+                    vol.Optional(f"module_{MODULE_TRAINING}", default=False): BooleanSelector(),
                 }
             ),
             errors=errors,
@@ -205,9 +202,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_sources(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_sources(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Configure data sources."""
         if user_input is not None:
             self._sources = user_input
@@ -217,9 +212,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         needs_door_sensor = any(
             dog.get(CONF_DOG_MODULES, {}).get(MODULE_WALK, False) for dog in self._dogs
         )
-        needs_gps = any(
-            dog.get(CONF_DOG_MODULES, {}).get(MODULE_GPS, False) for dog in self._dogs
-        )
+        needs_gps = any(dog.get(CONF_DOG_MODULES, {}).get(MODULE_GPS, False) for dog in self._dogs)
 
         schema_dict = {}
 
@@ -229,13 +222,11 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             )
 
         if needs_gps:
-            schema_dict[vol.Optional(CONF_PERSON_ENTITIES, default=[])] = (
-                EntitySelector(EntitySelectorConfig(domain="person", multiple=True))
+            schema_dict[vol.Optional(CONF_PERSON_ENTITIES, default=[])] = EntitySelector(
+                EntitySelectorConfig(domain="person", multiple=True)
             )
-            schema_dict[vol.Optional(CONF_DEVICE_TRACKERS, default=[])] = (
-                EntitySelector(
-                    EntitySelectorConfig(domain="device_tracker", multiple=True)
-                )
+            schema_dict[vol.Optional(CONF_DEVICE_TRACKERS, default=[])] = EntitySelector(
+                EntitySelectorConfig(domain="device_tracker", multiple=True)
             )
 
         schema_dict[vol.Optional(CONF_CALENDAR)] = EntitySelector(
@@ -267,8 +258,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         # Check if notifications module is enabled
         needs_notifications = any(
-            dog.get(CONF_DOG_MODULES, {}).get(MODULE_NOTIFICATIONS, False)
-            for dog in self._dogs
+            dog.get(CONF_DOG_MODULES, {}).get(MODULE_NOTIFICATIONS, False) for dog in self._dogs
         )
 
         if not needs_notifications:
@@ -299,9 +289,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                             unit_of_measurement="min",
                         )
                     ),
-                    vol.Optional(
-                        CONF_SNOOZE_MIN, default=DEFAULT_SNOOZE_MIN
-                    ): NumberSelector(
+                    vol.Optional(CONF_SNOOZE_MIN, default=DEFAULT_SNOOZE_MIN): NumberSelector(
                         NumberSelectorConfig(
                             min=5,
                             max=60,
@@ -317,9 +305,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             },
         )
 
-    async def async_step_system(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_system(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Configure system settings."""
         if user_input is not None:
             # Compile all configuration
@@ -339,9 +325,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 },
                 CONF_RESET_TIME: user_input.get(CONF_RESET_TIME, DEFAULT_RESET_TIME),
                 CONF_EXPORT_PATH: user_input.get(CONF_EXPORT_PATH, ""),
-                CONF_EXPORT_FORMAT: user_input.get(
-                    CONF_EXPORT_FORMAT, DEFAULT_EXPORT_FORMAT
-                ),
+                CONF_EXPORT_FORMAT: user_input.get(CONF_EXPORT_FORMAT, DEFAULT_EXPORT_FORMAT),
                 CONF_VISITOR_MODE: user_input.get(CONF_VISITOR_MODE, False),
             }
 
@@ -356,13 +340,9 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             step_id="system",
             data_schema=vol.Schema(
                 {
-                    vol.Optional(
-                        CONF_RESET_TIME, default=DEFAULT_RESET_TIME
-                    ): TimeSelector(),
+                    vol.Optional(CONF_RESET_TIME, default=DEFAULT_RESET_TIME): TimeSelector(),
                     vol.Optional(CONF_EXPORT_PATH, default=""): TextSelector(),
-                    vol.Optional(
-                        CONF_EXPORT_FORMAT, default=DEFAULT_EXPORT_FORMAT
-                    ): SelectSelector(
+                    vol.Optional(CONF_EXPORT_FORMAT, default=DEFAULT_EXPORT_FORMAT): SelectSelector(
                         SelectSelectorConfig(
                             options=["csv", "json", "pdf"],
                             translation_key="export_format",
@@ -390,12 +370,10 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        self.config_entry = config_entry
+        super().__init__(config_entry)
         self._options = dict(config_entry.options)
 
-    async def async_step_init(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage the options."""
         return self.async_show_menu(
             step_id="init",
@@ -407,15 +385,11 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
             ],
         )
 
-    async def async_step_dogs(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_dogs(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage dogs configuration."""
         if user_input is not None:
             # Update dogs configuration
-            self._options[CONF_DOGS] = user_input.get(
-                CONF_DOGS, self._options.get(CONF_DOGS, [])
-            )
+            self._options[CONF_DOGS] = user_input.get(CONF_DOGS, self._options.get(CONF_DOGS, []))
             return self.async_create_entry(title="", data=self._options)
 
         # For simplicity, we'll just show a message here
@@ -428,9 +402,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
             },
         )
 
-    async def async_step_sources(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_sources(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage data sources."""
         if user_input is not None:
             self._options[CONF_SOURCES] = user_input
@@ -448,21 +420,17 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                     vol.Optional(
                         CONF_PERSON_ENTITIES,
                         default=sources.get(CONF_PERSON_ENTITIES, []),
-                    ): EntitySelector(
-                        EntitySelectorConfig(domain="person", multiple=True)
-                    ),
+                    ): EntitySelector(EntitySelectorConfig(domain="person", multiple=True)),
                     vol.Optional(
                         CONF_DEVICE_TRACKERS,
                         default=sources.get(CONF_DEVICE_TRACKERS, []),
-                    ): EntitySelector(
-                        EntitySelectorConfig(domain="device_tracker", multiple=True)
+                    ): EntitySelector(EntitySelectorConfig(domain="device_tracker", multiple=True)),
+                    vol.Optional(CONF_CALENDAR, default=sources.get(CONF_CALENDAR)): EntitySelector(
+                        EntitySelectorConfig(domain="calendar")
                     ),
-                    vol.Optional(
-                        CONF_CALENDAR, default=sources.get(CONF_CALENDAR)
-                    ): EntitySelector(EntitySelectorConfig(domain="calendar")),
-                    vol.Optional(
-                        CONF_WEATHER, default=sources.get(CONF_WEATHER)
-                    ): EntitySelector(EntitySelectorConfig(domain="weather")),
+                    vol.Optional(CONF_WEATHER, default=sources.get(CONF_WEATHER)): EntitySelector(
+                        EntitySelectorConfig(domain="weather")
+                    ),
                 }
             ),
         )
@@ -472,9 +440,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
     ) -> FlowResult:
         """Manage notification settings."""
         if user_input is not None:
-            quiet_hours = self._options.get(CONF_NOTIFICATIONS, {}).get(
-                CONF_QUIET_HOURS, {}
-            )
+            quiet_hours = self._options.get(CONF_NOTIFICATIONS, {}).get(CONF_QUIET_HOURS, {})
 
             self._options[CONF_NOTIFICATIONS] = {
                 CONF_NOTIFY_FALLBACK: user_input.get(CONF_NOTIFY_FALLBACK),
@@ -488,9 +454,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                         quiet_hours.get(CONF_QUIET_END, "07:00:00"),
                     ),
                 },
-                CONF_REMINDER_REPEAT: user_input.get(
-                    CONF_REMINDER_REPEAT, DEFAULT_REMINDER_REPEAT
-                ),
+                CONF_REMINDER_REPEAT: user_input.get(CONF_REMINDER_REPEAT, DEFAULT_REMINDER_REPEAT),
                 CONF_SNOOZE_MIN: user_input.get(CONF_SNOOZE_MIN, DEFAULT_SNOOZE_MIN),
             }
             return self.async_create_entry(title="", data=self._options)
@@ -516,9 +480,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                     ): TimeSelector(),
                     vol.Optional(
                         CONF_REMINDER_REPEAT,
-                        default=notifications.get(
-                            CONF_REMINDER_REPEAT, DEFAULT_REMINDER_REPEAT
-                        ),
+                        default=notifications.get(CONF_REMINDER_REPEAT, DEFAULT_REMINDER_REPEAT),
                     ): NumberSelector(
                         NumberSelectorConfig(
                             min=5,
@@ -544,14 +506,10 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
             ),
         )
 
-    async def async_step_system(
-        self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    async def async_step_system(self, user_input: dict[str, Any] | None = None) -> FlowResult:
         """Manage system settings."""
         if user_input is not None:
-            self._options[CONF_RESET_TIME] = user_input.get(
-                CONF_RESET_TIME, DEFAULT_RESET_TIME
-            )
+            self._options[CONF_RESET_TIME] = user_input.get(CONF_RESET_TIME, DEFAULT_RESET_TIME)
             self._options[CONF_EXPORT_PATH] = user_input.get(CONF_EXPORT_PATH, "")
             self._options[CONF_EXPORT_FORMAT] = user_input.get(
                 CONF_EXPORT_FORMAT, DEFAULT_EXPORT_FORMAT
@@ -573,9 +531,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                     ): TextSelector(),
                     vol.Optional(
                         CONF_EXPORT_FORMAT,
-                        default=self._options.get(
-                            CONF_EXPORT_FORMAT, DEFAULT_EXPORT_FORMAT
-                        ),
+                        default=self._options.get(CONF_EXPORT_FORMAT, DEFAULT_EXPORT_FORMAT),
                     ): SelectSelector(
                         SelectSelectorConfig(
                             options=["csv", "json", "pdf"],


### PR DESCRIPTION
## Summary
- call `super().__init__` in options flow and stop assigning `config_entry`

## Testing
- `black custom_components/pawcontrol/config_flow.py`
- `isort custom_components/pawcontrol/config_flow.py`
- `flake8 custom_components/pawcontrol/config_flow.py` *(fails: command not found)*
- `pip install flake8 mypy` *(fails: Could not find a version that satisfies the requirement flake8)*
- `mypy custom_components/pawcontrol/config_flow.py` *(fails: multiple errors in existing code)*
- `pytest tests/` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_6899f4d14fe08331b3dbc02d4ac8c55c