### PR TITLE
Fix empty service fields in services.yaml

### DIFF
--- a/custom_components/pawcontrol/services.yaml
+++ b/custom_components/pawcontrol/services.yaml
@@ -338,7 +338,7 @@ activate_emergency_mode:
 daily_reset:
   name: Daily Reset
   description: Reset all daily counters
-  fields:
+  fields: {}
 
 generate_report:
   name: Generate Report
@@ -419,7 +419,7 @@ export_health_data:
 sync_setup:
   name: Sync Setup
   description: Synchronize helpers and entities with current configuration
-  fields:
+  fields: {}
 
 notify_test:
   name: Test Notification


### PR DESCRIPTION
## Summary
- define empty fields for `daily_reset` and `sync_setup` services to prevent parsing errors

## Testing
- `python quick_check.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `pip install -r requirements_dev.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6899f4e107c8833195f0d52a0cc6d54b