### PR TITLE
fix missing timedelta import in notification_router

### DIFF
--- a/custom_components/pawcontrol/helpers/notification_router.py
+++ b/custom_components/pawcontrol/helpers/notification_router.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from typing import Any, Dict, List, Optional
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN


### PR DESCRIPTION
## Summary
- fix missing timedelta import in notification_router helper

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*
- `flake8` *(fails: command not found)*
- `mypy custom_components/pawcontrol` *(fails: Type statement is only supported in Python 3.12 and greater)*

------
https://chatgpt.com/codex/tasks/task_e_689a07a8c1188331b770b32d328a0e4b