### PR TITLE
Fix pyproject duplicate requires-python entry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Environment :: Plugins",
 ]
-requires-python = ">=3.11"
 dependencies = [
     "homeassistant>=2024.1.0",
     "voluptuous>=0.13.1",


### PR DESCRIPTION
## Summary
- remove duplicate `requires-python` key in `pyproject.toml` to fix configuration error

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689a131908d48331bfc1400af3eccdd8