### PR TITLE
fix: improve sensor and text setup

### DIFF
--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -46,7 +46,9 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Paw Control sensor entities."""
-    coordinator: PawControlCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    coordinator: PawControlCoordinator = hass.data[DOMAIN][entry.entry_id][
+        "coordinator"
+    ]
     
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])
@@ -110,8 +112,10 @@ async def async_setup_entry(
             ActivityLevelSensor(coordinator, dog_id, dog_name),
             CaloriesBurnedSensor(coordinator, dog_id, dog_name),
         ])
-    
-    async_add_entities(entities, True)
+
+    # Use keyword argument for clarity instead of a positional boolean,
+    # following best practices for readability.
+    async_add_entities(entities, update_before_add=True)
 
 
 class PawControlSensorBase(CoordinatorEntity, SensorEntity):
@@ -307,7 +311,8 @@ class FeedingCountSensor(PawControlSensorBase):
     @property
     def native_value(self) -> int:
         """Return the feeding count for this meal type."""
-        return self.dog_data.get("feeding", {}).get("feedings_today", {}).get(self._meal_type, 0)
+        feedings = self.dog_data.get("feeding", {}).get("feedings_today", {})
+        return feedings.get(self._meal_type, 0)
 
 
 class WeightSensor(PawControlSensorBase):

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -20,6 +20,7 @@ from .const import (
     MODULE_TRAINING,
 )
 
+# Initialize module logger
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -65,8 +66,9 @@ async def async_setup_entry(
     entities.append(
         ExportPathText(hass, coordinator, entry)
     )
-    
-    async_add_entities(entities, True)
+
+    # Use keyword argument for readability and to avoid ambiguous positional booleans.
+    async_add_entities(entities, update_before_add=True)
 
 
 class PawControlTextBase(TextEntity):
@@ -118,7 +120,9 @@ class PawControlTextBase(TextEntity):
     async def async_set_value(self, value: str) -> None:
         """Set the text value."""
         self._stored_value = value
-        _LOGGER.info(f"{self._attr_name} for {self._dog_name} updated")
+        # Use parameterized logging to defer string formatting until needed,
+        # following logging best practices.
+        _LOGGER.info("%s for %s updated", self._attr_name, self._dog_name)
 
 
 class HealthNotesText(PawControlTextBase):
@@ -178,7 +182,11 @@ class MedicationNotesText(PawControlTextBase):
     @property
     def native_value(self) -> str | None:
         """Return the current value."""
-        return f"{self.dog_data.get('health', {}).get('medication_name', '')} - {self.dog_data.get('health', {}).get('medication_dose', '')}"
+        health = self.dog_data.get("health", {})
+        return (
+            f"{health.get('medication_name', '')} - "
+            f"{health.get('medication_dose', '')}"
+        )
 
 
 class VetNotesText(PawControlTextBase):
@@ -271,5 +279,7 @@ class ExportPathText(TextEntity):
 
     async def async_set_value(self, value: str) -> None:
         """Set the text value."""
-        _LOGGER.info(f"Export path set to {value}")
+        # Use parameterized logging to avoid unnecessary formatting unless
+        # the message is emitted, per logging best practices.
+        _LOGGER.info("Export path set to %s", value)
         # Would update the config entry options


### PR DESCRIPTION
## Summary
- document why parameterized logging is used in text entities
- clarify entity addition with keyword argument for update-before-add
- initialize module logger in text platform

## Testing
- `pip install --upgrade pip` *(fails: Cannot connect to proxy)*
- `pip install -e '.[test]'` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_689a3abe5b3883319e43dc6df90e82b7