### PR TITLE
refactor: clean up tests imports

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,15 +1,17 @@
 """Test Paw Control config flow."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pytest
 from homeassistant import config_entries
-from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pawcontrol.const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 
 async def test_form_single_dog(hass: HomeAssistant) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,14 +1,16 @@
 """Test Paw Control setup."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
 
-import pytest
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.core import HomeAssistant
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pawcontrol.const import DOMAIN
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_setup_entry(


### PR DESCRIPTION
## Summary
- avoid runtime imports in tests by moving Home Assistant type hints behind TYPE_CHECKING
- drop unused pytest imports

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_689a3fb42fb883318ea18e545ace3eef