### PR TITLE
Handle invalid grooming timestamp in Paw Control coordinator

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -203,7 +203,7 @@ class PawControlCoordinator(DataUpdateCoordinator):
             days_since = (dt_util.now() - last_grooming).days
             return days_since >= data["grooming_interval_days"]
         except (ValueError, TypeError):
-            return False
+            return True
 
     def _calculate_activity_level(self, dog_id: str) -> str:
         """Calculate activity level based on today's activities."""

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -203,6 +203,8 @@ class PawControlCoordinator(DataUpdateCoordinator):
             days_since = (dt_util.now() - last_grooming).days
             return days_since >= data["grooming_interval_days"]
         except (ValueError, TypeError):
+            # Fall back to needing grooming when the timestamp can't be parsed
+            # to avoid falsely assuming grooming occurred
             return True
 
     def _calculate_activity_level(self, dog_id: str) -> str:


### PR DESCRIPTION
## Summary
- treat parsing failures for `last_grooming` as needing grooming

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_689a3fb42fb883318ea18e545ace3eef