### PR TITLE
Refactor test fixture and clean imports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,22 @@
 """Fixtures for Paw Control tests."""
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from unittest.mock import patch
+
 import pytest
-from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
-from homeassistant.config_entries import ConfigEntry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.pawcontrol.const import DOMAIN
 
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
+
 
 @pytest.fixture(autouse=True)
-def auto_enable_custom_integrations(enable_custom_integrations):
+def auto_enable_custom_integrations(_enable_custom_integrations):
     """Enable custom integrations for all tests."""
-    yield
+    return
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary
- avoid unused fixture argument and replace yield with return in tests
- organize imports with TYPE_CHECKING guard

## Testing
- `ruff check tests/conftest.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*
- `pip install '.[test]'` *(fails: Could not find a version that satisfies the requirement setuptools>=61.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a43dedc6883319f2afe2ea47612ad