### PR TITLE
Handle options flow initialization without base class call

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -381,7 +381,7 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: config_entries.ConfigEntry) -> None:
         """Initialize options flow."""
-        super().__init__(config_entry)
+        self.config_entry = config_entry
         self._options = dict(config_entry.options)
 
     async def async_step_init(self, user_input: dict[str, Any] | None = None) -> FlowResult:


### PR DESCRIPTION
## Summary
- avoid calling non-existent parent initializer in options flow

## Testing
- `python -m py_compile custom_components/pawcontrol/config_flow.py`
- `pytest` *(fails: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_689a43dedc6883319f2afe2ea47612ad