### PR TITLE
Fix daily report schedule timezone handling

### DIFF
--- a/custom_components/pawcontrol/helpers/scheduler.py
+++ b/custom_components/pawcontrol/helpers/scheduler.py
@@ -133,12 +133,12 @@ class PawControlScheduler:
         
         # Schedule report 5 minutes before daily reset
         reset_time_str = self.entry.options.get(CONF_RESET_TIME, DEFAULT_RESET_TIME)
-        
+
         try:
             reset_time = time.fromisoformat(reset_time_str)
-            report_time = (
-                datetime.combine(datetime.today(), reset_time) - timedelta(minutes=5)
-            ).time()
+            # Use Home Assistant's timezone-aware time for scheduling
+            now = dt_util.now()
+            report_time = (datetime.combine(now.date(), reset_time) - timedelta(minutes=5)).time()
             
             @callback
             def daily_report_callback(now):


### PR DESCRIPTION
## Summary
- use timezone-aware `dt_util.now()` when scheduling daily reports

## Testing
- `pip install homeassistant` *(fails: Could not find a version that satisfies the requirement homeassistant)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_689a43f2cfd08331bf3e60ca9a147e8f