### PR TITLE
Fix missing List import in GPSLogic helper

### DIFF
--- a/custom_components/pawcontrol/helpers/gps_logic.py
+++ b/custom_components/pawcontrol/helpers/gps_logic.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import math
 from datetime import timedelta
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from homeassistant.components.device_tracker import DOMAIN as TRACKER_DOMAIN
 from homeassistant.components.person import DOMAIN as PERSON_DOMAIN


### PR DESCRIPTION
## Summary
- add the missing `List` import in `gps_logic.py` to avoid runtime errors when using type hints

## Testing
- `python -m py_compile custom_components/pawcontrol/helpers/gps_logic.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `pip install homeassistant pytest-homeassistant-custom-component` *(fails: Could not find a version that satisfies the requirement homeassistant)*

------
https://chatgpt.com/codex/tasks/task_e_689a43f2cfd08331bf3e60ca9a147e8f