### PR TITLE
Use config constants for dog list in GPS logic

### DIFF
--- a/custom_components/pawcontrol/helpers/gps_logic.py
+++ b/custom_components/pawcontrol/helpers/gps_logic.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-import math
 from datetime import timedelta
 from typing import Any, Dict, Optional, Tuple
 
@@ -27,6 +26,7 @@ from ..const import (
     CONF_DEVICE_TRACKERS,
     CONF_PERSON_ENTITIES,
     CONF_DOOR_SENSOR,
+    CONF_DOGS,
     DEFAULT_MIN_WALK_DISTANCE_M,
     DEFAULT_MIN_WALK_DURATION_MIN,
     DEFAULT_IDLE_TIMEOUT_MIN,
@@ -222,7 +222,7 @@ class GPSLogic:
         _LOGGER.debug("Door opened - potential walk start")
         
         # Mark potential walk start for all dogs
-        dogs = self.entry.options.get("dogs", [])
+        dogs = self.entry.options.get(CONF_DOGS, [])
         for dog in dogs:
             dog_id = dog.get("dog_id")
             if dog_id and dog_id not in self._walk_sessions:
@@ -365,11 +365,11 @@ class GPSLogic:
             if dog_data and "walk" in dog_data:
                 dog_data["walk"]["walk_distance_m"] = round(distance_m, 1)
 
-    def _get_dogs_for_entity(self, entity_id: str) -> List[str]:
+    def _get_dogs_for_entity(self, entity_id: str) -> list[str]:
         """Get list of dogs associated with a tracked entity."""
         # For now, return all dogs
         # In a more complex setup, this could map specific trackers to specific dogs
-        dogs = self.entry.options.get("dogs", [])
+        dogs = self.entry.options.get(CONF_DOGS, [])
         return [dog.get("dog_id") for dog in dogs if dog.get("dog_id")]
 
     def check_idle_timeout(self) -> None:


### PR DESCRIPTION
## Summary
- use `CONF_DOGS` instead of a hard-coded key when accessing configured dogs in GPS logic
- remove an unused import and modernize type annotation

## Testing
- `pre-commit run --files custom_components/pawcontrol/helpers/gps_logic.py` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_689a43f2cfd08331bf3e60ca9a147e8f