### PR TITLE
fix: robust notify fallback parsing

### DIFF
--- a/custom_components/pawcontrol/helpers/notification_router.py
+++ b/custom_components/pawcontrol/helpers/notification_router.py
@@ -207,18 +207,15 @@ class NotificationRouter:
             )
             
             if fallback:
-                # Extract service name from entity
-                # ``notify`` services may contain additional dots after the
-                # domain portion (e.g. ``notify.mobile_app.pixel_7``). Using a
-                # plain ``split('.')`` followed by index ``[1]`` would yield
-                # ``"mobile_app"`` and drop ``"pixel_7"``, producing an invalid
-                # service name.  By limiting the split to one occurrence,
-                # ``split('.', 1)[1]`` preserves everything after the first dot
-                # and leaves the full service identifier intact.
-                if "." in fallback:
-                    service = fallback.split(".", 1)[1]
-                else:
-                    service = fallback
+                # Extract the service name from the entity ID. ``notify``
+                # services may contain additional dots after the domain portion
+                # (e.g. ``notify.mobile_app.pixel_7``). A simple
+                # ``split('.')`` call would drop everything after the first dot
+                # and produce an invalid service name. Using ``split('.', 1)``
+                # and taking the last element preserves the entire service
+                # identifier while also handling values without a domain
+                # prefix.
+                service = fallback.split(".", 1)[-1]
 
                 if self.hass.services.has_service(NOTIFY_DOMAIN, service):
                     targets.append(service)


### PR DESCRIPTION
## Summary
- handle notify fallback entities with extra dots more gracefully

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a4fa1380883319ce8029fc44a9a06