### PR TITLE
Fix export select immutability and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ Paw Control provides extensive services for automation:
 ### System
 - `pawcontrol.daily_reset` - Reset daily counters
 - `pawcontrol.generate_report` - Generate activity report
-- `pawcontrol.export_health_data` - Export health data
+- `pawcontrol.export_health_data` - Export health data in a chosen format (immutable options: csv, json, pdf)
 
 ## 📊 Entities
 

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -295,19 +295,23 @@ class ActivityLevelSelect(PawControlSelectBase):
 
 
 class ExportFormatSelect(SelectEntity):
-    """Select entity for export format."""
+    """Select entity for export format.
+
+    The available formats are defined as an immutable tuple to prevent
+    accidental modification.
+    """
 
     _attr_has_entity_name = True
     _attr_name = "Export Format"
     _attr_icon = "mdi:file-export"
-    _attr_options = ["csv", "json", "pdf"]
+    _attr_options = ("csv", "json", "pdf")
 
     def __init__(self, hass: HomeAssistant, coordinator: Any, entry: ConfigEntry):
         """Initialize the select entity."""
         self.hass = hass
         self.coordinator = coordinator
         self.entry = entry
-        
+
         self._attr_unique_id = f"{DOMAIN}.global.select.export_format"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, "global")},
@@ -324,4 +328,4 @@ class ExportFormatSelect(SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Export format set to {option}")
+        _LOGGER.info("Export format set to %s", option)


### PR DESCRIPTION
## Summary
- make export format select options immutable
- use parameterized logging for export format select
- document export format tuple in code and README

## Testing
- `pip install -r requirements_dev.txt` *(fails: Could not find a version that satisfies the requirement homeassistant>=2024.1.0)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a5490d8b88331928d41876f6edd30