### PR TITLE
Use constant for sources option in notification router

### DIFF
--- a/custom_components/pawcontrol/helpers/notification_router.py
+++ b/custom_components/pawcontrol/helpers/notification_router.py
@@ -16,6 +16,7 @@ from ..const import (
     CONF_NOTIFICATIONS,
     CONF_NOTIFY_FALLBACK,
     CONF_PERSON_ENTITIES,
+    CONF_SOURCES,
     CONF_QUIET_HOURS,
     CONF_QUIET_START,
     CONF_QUIET_END,
@@ -184,7 +185,7 @@ class NotificationRouter:
         targets = []
         
         # Check for person-based notifications
-        person_entities = self.entry.options.get("sources", {}).get(
+        person_entities = self.entry.options.get(CONF_SOURCES, {}).get(
             CONF_PERSON_ENTITIES, []
         )
         


### PR DESCRIPTION
## Summary
- use constant for sources key when retrieving person entities in notification router

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a5490d8b88331928d41876f6edd30