### PR TITLE
Fix report generator initialization

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -67,8 +67,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "coordinator": coordinator,
         "notification_router": NotificationRouter(hass, entry),
         "setup_sync": SetupSync(hass, entry),
-        "report_generator": ReportGenerator(hass, entry),
     }
+
+    # Report generator depends on the coordinator being stored above, so
+    # instantiate it only after the shared data structure has been created.
+    hass.data[DOMAIN][entry.entry_id]["report_generator"] = ReportGenerator(hass, entry)
     
     # Register devices for each dog
     await _register_devices(hass, entry)


### PR DESCRIPTION
## Summary
- Ensure ReportGenerator is instantiated only after coordinator is stored

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a5cfaf6ec83319fd335c6441640d7