### PR TITLE
Clean up sensor imports to resolve integration errors

### DIFF
--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime
-from typing import Any, Optional
+
+# The typing imports were previously unused, causing lint failures during
+# integration tests. They have been removed to keep the module clean and to
+# ensure style checks pass.
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,


### PR DESCRIPTION
## Summary
- remove unused typing imports in sensor module
- document the change to keep lint checks passing

## Testing
- `python -m py_compile custom_components/pawcontrol/sensor.py`
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*
- `pre-commit run --files custom_components/pawcontrol/sensor.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a5cfaf6ec83319fd335c6441640d7