### PR TITLE
Use Platform enum for platform list

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -1,5 +1,7 @@
 """Constants for the Paw Control integration."""
 
+from typing import Final
+
 from homeassistant.const import Platform
 
 DOMAIN = "pawcontrol"
@@ -8,7 +10,7 @@ DOMAIN = "pawcontrol"
 # values are instances of the ``Platform`` enum; using raw strings would cause
 # setup and unload to fail.  Typing the list helps static checkers catch any
 # accidental regression back to string values.
-PLATFORMS: list[Platform] = [
+PLATFORMS: Final[list[Platform]] = [
     Platform.SENSOR,
     Platform.BINARY_SENSOR,
     Platform.BUTTON,


### PR DESCRIPTION
## Summary
- use Platform enum to type the integration platform list

## Testing
- `pytest -q` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a6b8620688331ba2389cd8d6dcd23