### PR TITLE
Ensure select entities update dog state

### DIFF
--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -151,11 +151,13 @@ class DefaultFoodTypeSelect(PawControlSelectBase):
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        return FOOD_DRY
+        return self.dog_data.get("feeding", {}).get("last_food_type", FOOD_DRY)
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Default food type for {self._dog_name} set to {option}")
+        _LOGGER.info("Default food type for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("feeding", {})["last_food_type"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class PreferredMealTimeSelect(PawControlSelectBase):
@@ -177,11 +179,13 @@ class PreferredMealTimeSelect(PawControlSelectBase):
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        return "3 meals"
+        return self.dog_data.get("feeding", {}).get("meal_schedule", "3 meals")
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Meal schedule for {self._dog_name} set to {option}")
+        _LOGGER.info("Meal schedule for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("feeding", {})["meal_schedule"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class DefaultGroomingTypeSelect(PawControlSelectBase):
@@ -237,7 +241,9 @@ class TrainingTopicSelect(PawControlSelectBase):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Training topic for {self._dog_name} set to {option}")
+        _LOGGER.info("Training topic for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("training", {})["last_topic"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class TrainingIntensitySelect(PawControlSelectBase):
@@ -259,11 +265,13 @@ class TrainingIntensitySelect(PawControlSelectBase):
     @property
     def current_option(self) -> str | None:
         """Return the current selected option."""
-        return INTENSITY_MEDIUM
+        return self.dog_data.get("training", {}).get("intensity", INTENSITY_MEDIUM)
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Training intensity for {self._dog_name} set to {option}")
+        _LOGGER.info("Training intensity for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("training", {})["intensity"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class ActivityLevelSelect(PawControlSelectBase):


### PR DESCRIPTION
## Summary
- keep select entity changes in coordinator state and refresh after user selection
- read current select options from stored dog data so UI reflects persisted choices

## Testing
- `python validate_integration.py`
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a6b8620688331ba2389cd8d6dcd23