### PR TITLE
Ensure select entities update dog state

### DIFF
--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -155,7 +155,9 @@ class DefaultFoodTypeSelect(PawControlSelectBase):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Default food type for {self._dog_name} set to {option}")
+        _LOGGER.info("Default food type for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("feeding", {})["last_food_type"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class PreferredMealTimeSelect(PawControlSelectBase):
@@ -181,7 +183,9 @@ class PreferredMealTimeSelect(PawControlSelectBase):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Meal schedule for {self._dog_name} set to {option}")
+        _LOGGER.info("Meal schedule for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("feeding", {})["meal_schedule"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class DefaultGroomingTypeSelect(PawControlSelectBase):
@@ -237,7 +241,9 @@ class TrainingTopicSelect(PawControlSelectBase):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Training topic for {self._dog_name} set to {option}")
+        _LOGGER.info("Training topic for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("training", {})["last_topic"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class TrainingIntensitySelect(PawControlSelectBase):
@@ -263,7 +269,9 @@ class TrainingIntensitySelect(PawControlSelectBase):
 
     async def async_select_option(self, option: str) -> None:
         """Update the selected option."""
-        _LOGGER.info(f"Training intensity for {self._dog_name} set to {option}")
+        _LOGGER.info("Training intensity for %s set to %s", self._dog_name, option)
+        self.dog_data.setdefault("training", {})["intensity"] = option
+        await self.coordinator.async_request_refresh()
 
 
 class ActivityLevelSelect(PawControlSelectBase):


### PR DESCRIPTION
## Summary
- keep select entity changes in coordinator state and refresh after user selection

## Testing
- `python validate_integration.py`
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a6b8620688331ba2389cd8d6dcd23