### PR TITLE
Handle awaitable coordinator refresh

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -1,6 +1,7 @@
 """The Paw Control integration for Home Assistant."""
 from __future__ import annotations
 
+import inspect
 import logging
 from typing import Any
 
@@ -73,7 +74,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = PawControlCoordinator(hass, entry)
 
     try:
-        await coordinator.async_config_entry_first_refresh()
+        refresh = coordinator.async_config_entry_first_refresh()
+        if inspect.isawaitable(refresh):
+            await refresh
     except Exception as err:
         raise ConfigEntryNotReady from err
 


### PR DESCRIPTION
## Summary
- avoid await errors when coordinator refresh isn't awaitable

## Testing
- `pytest tests/test_init.py::test_setup_entry -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a6b8620688331ba2389cd8d6dcd23