### PR TITLE
Configure mypy to avoid duplicate module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,9 @@ lint: ## Run all linters
 	@echo "Running linters..."
 	@. $(VENV)/bin/activate && black --check $(CUSTOM_COMPONENTS)
 	@. $(VENV)/bin/activate && isort --check-only $(CUSTOM_COMPONENTS)
-	@. $(VENV)/bin/activate && flake8 $(CUSTOM_COMPONENTS)
-	@. $(VENV)/bin/activate && mypy $(CUSTOM_COMPONENTS)
-	@. $(VENV)/bin/activate && yamllint -c .yamllint $(CUSTOM_COMPONENTS)
+@. $(VENV)/bin/activate && flake8 $(CUSTOM_COMPONENTS)
+@. $(VENV)/bin/activate && mypy
+@. $(VENV)/bin/activate && yamllint -c .yamllint $(CUSTOM_COMPONENTS)
 
 format: ## Format code with black and isort
 	@echo "Formatting code..."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -246,6 +246,7 @@ directory = "htmlcov"
 
 [tool.mypy]
 python_version = "3.11"
+files = ["custom_components/pawcontrol"]
 show_error_codes = true
 follow_imports = "silent"
 ignore_missing_imports = true


### PR DESCRIPTION
## Summary
- scope mypy to the integration package to prevent duplicate module detection
- run mypy from the Makefile without passing the package path explicitly

## Testing
- `mypy`

------
https://chatgpt.com/codex/tasks/task_e_689a6b71235083319f353af265d68024