### PR TITLE
Remove unused imports from config flow

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -3,13 +3,12 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import voluptuous as vol
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.data_entry_flow import FlowResult
-from homeassistant.helpers import selector
 from homeassistant.helpers.selector import (
     BooleanSelector,
     EntitySelector,


### PR DESCRIPTION
## Summary
- remove unused typing and selector imports in config_flow

## Testing
- `python -m py_compile custom_components/pawcontrol/config_flow.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689a7c716fe88331900aa16216b2064b