### PR TITLE
Await coordinator startup refresh

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import inspect
 import logging
 from typing import Any
 
@@ -75,9 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator = PawControlCoordinator(hass, entry)
 
     try:
-        refresh = coordinator.async_config_entry_first_refresh()
-        if inspect.isawaitable(refresh):
-            await refresh
+        await coordinator.async_config_entry_first_refresh()
     except Exception as err:
         raise ConfigEntryNotReady from err
 


### PR DESCRIPTION
## Summary
- ensure `async_config_entry_first_refresh` is awaited during setup

## Testing
- `pytest -q` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689a7c716fe88331900aa16216b2064b