### PR TITLE
Ensure text entities update state after value changes

### DIFF
--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -3,23 +3,25 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
-    DOMAIN,
-    CONF_DOGS,
     CONF_DOG_ID,
-    CONF_DOG_NAME,
     CONF_DOG_MODULES,
+    CONF_DOG_NAME,
+    CONF_DOGS,
+    DOMAIN,
     MODULE_HEALTH,
     MODULE_TRAINING,
 )
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 # Initialize module logger
 _LOGGER = logging.getLogger(__name__)
@@ -120,6 +122,9 @@ class PawControlTextBase(TextEntity):
         # Use parameterized logging to defer string formatting until needed,
         # following logging best practices.
         _LOGGER.info("%s for %s updated", self._attr_name, self._dog_name)
+        # Ensure Home Assistant is notified about the updated value so the
+        # UI and automations receive the change immediately.
+        self.async_write_ha_state()
 
 
 class HealthNotesText(PawControlTextBase):


### PR DESCRIPTION
## Summary
- Ensure text entity state updates after setting new value
- Clean up text platform imports and add type-checking guard

## Testing
- `python -m py_compile custom_components/pawcontrol/text.py`
- `ruff check custom_components/pawcontrol/text.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689a7c716fe88331900aa16216b2064b