### PR TITLE
Use async persistent notification API

### DIFF
--- a/custom_components/pawcontrol/helpers/notification_router.py
+++ b/custom_components/pawcontrol/helpers/notification_router.py
@@ -45,8 +45,11 @@ class NotificationRouter:
     async def _send_persistent_notification(self, title: str, message: str) -> None:
         """Send a persistent notification as fallback."""
         try:
-            from homeassistant.components.persistent_notification import create as pn
-            pn(self.hass, message, title=title)
+            from homeassistant.components.persistent_notification import (
+                async_create as pn,
+            )
+
+            await pn(self.hass, message, title=title)
         except Exception as exc:
             _LOGGER.error("Failed to send persistent notification: %s", exc)
     


### PR DESCRIPTION
## Summary
- use async persistent notification creation to avoid blocking when routing notifications

## Testing
- `python validate_integration.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689ae148da8c83319ec3071605e88440