### PR TITLE
refactor: clean utils and text modules

### DIFF
--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -1,26 +1,35 @@
-
 """Text entities for Paw Control medication names/notes."""
 from __future__ import annotations
-from typing import Any
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from typing import TYPE_CHECKING
+
 from homeassistant.components.text import TextEntity
-from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.restore_state import RestoreEntity
+
 from .const import DOMAIN
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     dogs = (entry.options or {}).get("dogs", [])
     entities: list[TextEntity] = []
-    for d in dogs:
-        dog_id = d.get("dog_id") or d.get("name")
-        title = d.get("name") or dog_id or "Dog"
+    for dog in dogs:
+        dog_id = dog.get("dog_id") or dog.get("name")
+        title = dog.get("name") or dog_id or "Dog"
         if not dog_id:
             continue
         entities.append(MedicationNameText(hass, dog_id, title))
         entities.append(MedicationNotesText(hass, dog_id, title))
-        for i in (1,2,3):
+        for i in (1, 2, 3):
             entities.append(MedicationNameTextSlot(hass, dog_id, title, i))
             entities.append(MedicationNotesTextSlot(hass, dog_id, title, i))
     if entities:
@@ -28,19 +37,25 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
 class _BaseDogText(TextEntity, RestoreEntity):
     _attr_has_entity_name = True
-    def __init__(self, hass: HomeAssistant, dog_id: str, title: str, key: str):
+
+    def __init__(self, hass: HomeAssistant, dog_id: str, title: str, key: str) -> None:
         self.hass = hass
         self._dog = dog_id
         self._name = title
         self._key = key
         self._attr_unique_id = f"{DOMAIN}.{dog_id}.text.{key}"
-        self._attr_device_info = DeviceInfo(identifiers={(DOMAIN, dog_id)}, name=f"Hund {title}", manufacturer="Paw Control", model="Text" )
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, dog_id)},
+            name=f"Dog {title}",
+            manufacturer="Paw Control",
+            model="Text",
+        )
         self._attr_entity_category = "config"
         self._attr_native_value: str | None = None
 
     async def async_added_to_hass(self) -> None:
         last = await self.async_get_last_state()
-        if last and last.state not in ("unknown","unavailable", None):
+        if last and last.state not in ("unknown", "unavailable", None):
             self._attr_native_value = last.state
 
     @property
@@ -51,14 +66,26 @@ class _BaseDogText(TextEntity, RestoreEntity):
         self._attr_native_value = value or ""
         self.async_write_ha_state()
 
+
 class MedicationNameText(_BaseDogText):
-    def __init__(self, hass, dog_id, title): super().__init__(hass, dog_id, title, "medication_name")
+    def __init__(self, hass: HomeAssistant, dog_id: str, title: str) -> None:
+        super().__init__(hass, dog_id, title, "medication_name")
+
 
 class MedicationNotesText(_BaseDogText):
-    def __init__(self, hass, dog_id, title): super().__init__(hass, dog_id, title, "medication_notes")
+    def __init__(self, hass: HomeAssistant, dog_id: str, title: str) -> None:
+        super().__init__(hass, dog_id, title, "medication_notes")
+
 
 class MedicationNameTextSlot(_BaseDogText):
-    def __init__(self, hass, dog_id, title, index: int): super().__init__(hass, dog_id, title, f"medication_name_{index}")
+    def __init__(
+        self, hass: HomeAssistant, dog_id: str, title: str, index: int
+    ) -> None:
+        super().__init__(hass, dog_id, title, f"medication_name_{index}")
+
 
 class MedicationNotesTextSlot(_BaseDogText):
-    def __init__(self, hass, dog_id, title, index: int): super().__init__(hass, dog_id, title, f"medication_notes_{index}")
+    def __init__(
+        self, hass: HomeAssistant, dog_id: str, title: str, index: int
+    ) -> None:
+        super().__init__(hass, dog_id, title, f"medication_notes_{index}")

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1,10 +1,11 @@
-
 """Utility helpers for Paw Control (clean minimal set)."""
 from __future__ import annotations
 
-from math import radians, sin, cos, sqrt, atan2
-from typing import Any, Mapping, Callable
-from homeassistant.core import HomeAssistant
+from math import atan2, cos, radians, sin, sqrt
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from homeassistant.core import HomeAssistant
 
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Return haversine distance in meters between two lat/lon points."""
@@ -19,17 +20,27 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:
     if duration_s <= 0:
         return 0.0
-    return (distance_m/1000.0) / (duration_s/3600.0)
+    return (distance_m / 1000.0) / (duration_s / 3600.0)
 
 def validate_coordinates(lat: float, lon: float) -> bool:
-    return isinstance(lat, (int,float)) and isinstance(lon, (int,float)) and -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0
+    return (
+        isinstance(lat, int | float)
+        and isinstance(lon, int | float)
+        and -90.0 <= lat <= 90.0
+        and -180.0 <= lon <= 180.0
+    )
 
 def format_coordinates(lat: float, lon: float) -> str:
     return f"{lat:.6f},{lon:.6f}"
 
-async def safe_service_call(hass: HomeAssistant, domain: str, service: str, data: Mapping[str, Any] | None = None) -> None:
+async def safe_service_call(
+    hass: HomeAssistant,
+    domain: str,
+    service: str,
+    data: dict[str, Any] | None = None,
+) -> None:
     try:
         await hass.services.async_call(domain, service, data or {}, blocking=False)
-    except Exception:
+    except Exception:  # noqa: BLE001
         # Swallow errors to avoid cascading failures from optional notifications etc.
         return


### PR DESCRIPTION
## Summary
- refactor utils helper with better imports and validation
- clean up text entities and improve readability

## Testing
- `ruff check custom_components/pawcontrol/utils.py`
- `ruff check custom_components/pawcontrol/text.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689ae148da8c83319ec3071605e88440