### PR TITLE
Refactor helpers and sensor setup for cleaner integration

### DIFF
--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -1,26 +1,35 @@
 """Sensors for Paw Control."""
 from __future__ import annotations
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from typing import TYPE_CHECKING
+
 from .sensor_factory import create_dog_sensors
 
+if TYPE_CHECKING:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
     """Set up sensors for each configured dog."""
     dogs = (entry.options or {}).get("dogs", [])
-    entities = []
-    
+    entities: list = []
+
     for dog_config in dogs:
         dog_id = dog_config.get("dog_id") or dog_config.get("name")
         title = dog_config.get("name") or dog_id or "Dog"
-        
+
         if not dog_id:
             continue
-            
+
         # Use factory pattern to create all sensors
         dog_sensors = create_dog_sensors(hass, dog_id, title)
         entities.extend(dog_sensors)
-        
+
     if entities:
         async_add_entities(entities)

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1,35 +1,60 @@
-
 """Utility helpers for Paw Control (clean minimal set)."""
 from __future__ import annotations
 
-from math import radians, sin, cos, sqrt, atan2
-from typing import Any, Mapping, Callable
-from homeassistant.core import HomeAssistant
+from math import atan2, cos, radians, sin, sqrt
+from typing import TYPE_CHECKING, Any
+
+from homeassistant.exceptions import HomeAssistantError
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from homeassistant.core import HomeAssistant
+
 
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Return haversine distance in meters between two lat/lon points."""
-    R = 6371000.0
+    radius = 6_371_000.0
     phi1, phi2 = radians(lat1), radians(lat2)
     dphi = radians(lat2 - lat1)
     dlambda = radians(lon2 - lon1)
-    a = sin(dphi/2)**2 + cos(phi1)*cos(phi2)*sin(dlambda/2)**2
-    c = 2*atan2(sqrt(a), sqrt(1-a))
-    return R * c
+    a = sin(dphi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(dlambda / 2) ** 2
+    c = 2 * atan2(sqrt(a), sqrt(1 - a))
+    return radius * c
+
 
 def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:
+    """Return speed in km/h given distance in meters and duration in seconds."""
     if duration_s <= 0:
         return 0.0
-    return (distance_m/1000.0) / (duration_s/3600.0)
+    return (distance_m / 1000.0) / (duration_s / 3600.0)
+
 
 def validate_coordinates(lat: float, lon: float) -> bool:
-    return isinstance(lat, (int,float)) and isinstance(lon, (int,float)) and -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0
+    """Validate latitude and longitude values."""
+    return (
+        isinstance(lat, int | float)
+        and isinstance(lon, int | float)
+        and -90.0 <= lat <= 90.0
+        and -180.0 <= lon <= 180.0
+    )
+
 
 def format_coordinates(lat: float, lon: float) -> str:
+    """Format coordinates for display."""
     return f"{lat:.6f},{lon:.6f}"
 
-async def safe_service_call(hass: HomeAssistant, domain: str, service: str, data: Mapping[str, Any] | None = None) -> None:
+
+async def safe_service_call(
+    hass: HomeAssistant,
+    domain: str,
+    service: str,
+    data: Mapping[str, Any] | None = None,
+) -> None:
+    """Call a Home Assistant service safely."""
     try:
         await hass.services.async_call(domain, service, data or {}, blocking=False)
-    except Exception:
-        # Swallow errors to avoid cascading failures from optional notifications etc.
+    except (HomeAssistantError, ValueError):
+        # Swallow errors to avoid cascading failures from optional notifications.
         return
+


### PR DESCRIPTION
## Summary
- streamline integration utilities with type-only imports and targeted error handling
- clean up sensor setup by moving Home Assistant imports behind `TYPE_CHECKING`

## Testing
- `ruff check custom_components/pawcontrol/utils.py custom_components/pawcontrol/sensor.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689ae148da8c83319ec3071605e88440