### PR TITLE
Raise ConfigEntryNotReady on coordinator setup failure

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -81,6 +81,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         _LOGGER.debug("Coordinator initialized successfully")
     except Exception as exc:
         _LOGGER.warning("Coordinator setup failed: %s", exc)
+        # Clean up the partially created data entry and signal Home Assistant
+        # that the setup should be retried. Without raising
+        # ConfigEntryNotReady here, Home Assistant would mark the integration
+        # as loaded even though the coordinator is unavailable.
+        hass.data[DOMAIN].pop(entry.entry_id, None)
+        raise ConfigEntryNotReady from exc
 
     # Ensure per-dog webhooks are generated & registered
     await _ensure_webhooks(hass, entry, data)


### PR DESCRIPTION
## Summary
- raise `ConfigEntryNotReady` and clean up data when the coordinator fails to initialize

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689ae1260fb0833190baada040c94dc0