### PR TITLE
chore: add missing type hints

### DIFF
--- a/custom_components/pawcontrol/device_action.py
+++ b/custom_components/pawcontrol/device_action.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 
 import voluptuous as vol
 
@@ -40,7 +39,7 @@ ACTION_SCHEMA = DEVICE_ACTION_BASE_SCHEMA.extend(
 
 async def async_get_actions(
     hass: HomeAssistant, device_id: str
-) -> list[dict[str, Any]]:
+) -> list[dict[str, str]]:
     """List device actions for Paw Control devices."""
     registry = dr.async_get(hass)
     device = registry.async_get(device_id)
@@ -56,10 +55,10 @@ async def async_get_actions(
     if not domain_in_identifiers:
         return []
 
-    actions = []
+    actions: list[dict[str, str]] = []
 
     # Get dog_id from device identifiers
-    dog_id = None
+    dog_id: str | None = None
     for identifier in device.identifiers:
         if identifier[0] == DOMAIN:
             dog_id = identifier[1]

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -1,15 +1,24 @@
 
 from __future__ import annotations
+
+from typing import Mapping
+
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant
+
 from .const import DOMAIN
 
-async def async_register(hass: HomeAssistant, register: system_health.SystemHealthRegistration) -> None:
+async def async_register(
+    hass: HomeAssistant,
+    register: system_health.SystemHealthRegistration,
+) -> None:
     register.async_register_info(DOMAIN, async_system_health_info)
 
-async def async_system_health_info(hass: HomeAssistant):
-    data = hass.data.get(DOMAIN) or {}
-    version = data.get("version") if isinstance(data, dict) else None
+async def async_system_health_info(
+    hass: HomeAssistant,
+) -> dict[str, str | int]:
+    data: Mapping[str, object] | None = hass.data.get(DOMAIN)  # type: ignore[assignment]
+    version = data.get("version") if isinstance(data, Mapping) else None
     return {
         "version": version or "unknown",
         "entries": len((data or {}).keys()) if isinstance(data, dict) else 0,


### PR DESCRIPTION
## Summary
- refine system health registration types
- tighten typing for device triggers and actions

## Testing
- `python validate_integration.py`
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_689ae141d6a483319abc271c6f4a1151