### PR TITLE
Fix validation warnings and add service metadata

### DIFF
--- a/custom_components/pawcontrol/services.yaml
+++ b/custom_components/pawcontrol/services.yaml
@@ -94,6 +94,7 @@ toggle_geofence_alerts:
 export_options:
   name: Optionen exportieren
   description: Schreibt die aktuellen Options (Config-Entry) als JSON nach /config/pawcontrol_options_export.json
+  fields: {}
 
 import_options:
   name: Optionen importieren
@@ -136,17 +137,17 @@ route_history_export_range:
 purge_all_storage:
   name: Alle gespeicherten Daten löschen
   description: Löscht gespeicherte GPS-Einstellungen und den Routenverlauf (Storage).
-
+  fields: {}
 
 gps_list_webhooks:
   name: Webhooks auflisten
   description: Schreibt eine Datei mit allen Webhook-URLs in /config/pawcontrol_diagnostics/webhooks.json
-
+  fields: {}
 
 gps_regenerate_webhooks:
   name: Webhooks erneuern
   description: Erzeugt neue Webhook-IDs pro Hund und registriert sie.
-
+  fields: {}
 
 gps_post_location:
   name: GPS-Position posten (manuell)
@@ -161,3 +162,4 @@ gps_post_location:
 notify_test:
   name: Test-Benachrichtigung senden
   description: Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback persistent_notification).
+  fields: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-homeassistant-custom-component>=0.13.0",
     "pytest-cov>=4.0.0",
     "pytest-asyncio>=0.21.0",
+    "PyYAML>=6.0.0",
     "types-requests",
     "types-PyYAML",
     "ruff>=0.1.0",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,6 +9,7 @@ pytest>=7.0.0
 pytest-homeassistant-custom-component>=0.13.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
+PyYAML>=6.0.0
 types-requests
 types-PyYAML
 ruff>=0.1.0

--- a/validate_integration.py
+++ b/validate_integration.py
@@ -265,17 +265,14 @@ class IntegrationValidator:
             return False
 
     def _check_type_hints(self, tree: ast.AST) -> bool:
-        """Check if AST has type hints."""
+        """Return True if functions have type hints or none exist."""
+        has_function = False
         for node in ast.walk(tree):
-            if isinstance(node, ast.FunctionDef):
-                # Check return type
-                if node.returns:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                has_function = True
+                if node.returns or any(arg.annotation for arg in node.args.args):
                     return True
-                # Check parameter types
-                for arg in node.args.args:
-                    if arg.annotation:
-                        return True
-        return False
+        return not has_function
 
     def print_results(self) -> None:
         """Print validation results."""


### PR DESCRIPTION
## Summary
- improve type-hint detection in integration validator
- declare PyYAML dev dependency and service field placeholders

## Testing
- `python validate_integration.py`
- `pre-commit run --files validate_integration.py requirements_dev.txt pyproject.toml custom_components/pawcontrol/services.yaml` *(fails: command not found)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689ae141d6a483319abc271c6f4a1151