### PR TITLE
chore: update ruff configuration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,5 +2,6 @@
 # Contributing to Paw Control
 
 - Code style follows Home Assistant integrations (async, typing).
-- Run GitHub Actions locally where possible (hassfest, HACS validation).
+- Run Ruff (`ruff check`) and GitHub Actions locally where possible (hassfest, HACS validation).
+- Ruff rules are configured in `pyproject.toml` under `[tool.ruff.lint]`.
 - PRs should include a short test plan and screenshots for UI changes.

--- a/README.md
+++ b/README.md
@@ -845,7 +845,7 @@ log_poop:
 
 ## 9) GitHub Actions & HACS
 
-**`.github/workflows/validate.yml`**: hassfest, ruff/flake8, pytest  
+**`.github/workflows/validate.yml`**: hassfest, ruff, pytest
 **`.github/workflows/release.yml`**: Tag → Release (Zip)  
 **`hacs.json`** (Repo-Wurzel):
 ```json

--- a/docs/ERWEITERT_KOMPLETT.md
+++ b/docs/ERWEITERT_KOMPLETT.md
@@ -836,7 +836,7 @@ log_poop:
 
 ## 9) GitHub Actions & HACS
 
-**`.github/workflows/validate.yml`**: hassfest, ruff/flake8, pytest  
+**`.github/workflows/validate.yml`**: hassfest, ruff, pytest
 **`.github/workflows/release.yml`**: Tag → Release (Zip)  
 **`hacs.json`** (Repo-Wurzel):
 ```json

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -836,7 +836,7 @@ log_poop:
 
 ## 9) GitHub Actions & HACS
 
-**`.github/workflows/validate.yml`**: hassfest, ruff/flake8, pytest  
+**`.github/workflows/validate.yml`**: hassfest, ruff, pytest
 **`.github/workflows/release.yml`**: Tag → Release (Zip)  
 **`hacs.json`** (Repo-Wurzel):
 ```json

--- a/docs/README.md
+++ b/docs/README.md
@@ -845,7 +845,7 @@ log_poop:
 
 ## 9) GitHub Actions & HACS
 
-**`.github/workflows/validate.yml`**: hassfest, ruff/flake8, pytest  
+**`.github/workflows/validate.yml`**: hassfest, ruff, pytest
 **`.github/workflows/release.yml`**: Tag → Release (Zip)  
 **`hacs.json`** (Repo-Wurzel):
 ```json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ src_paths = ["custom_components", "tests"]
 [tool.ruff]
 target-version = "py311"
 line-length = 88
+
+[tool.ruff.lint]
 select = [
     "B",    # flake8-bugbear
     "C",    # mccabe
@@ -174,10 +176,10 @@ ignore = [
     "PLR2004", # magic-value-comparison
 ]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 12
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*" = ["S101", "PLR2004", "S106"]
 "custom_components/pawcontrol/__init__.py" = ["F401"]
 


### PR DESCRIPTION
## Summary
- migrate ruff options to new lint sections to eliminate deprecation warnings
- remove outdated flake8 references in docs and note Ruff configuration location

## Testing
- `ruff check` *(fails: Found 1213 errors.)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689ae176d1048331a9a6d6b901265fe0