### PR TITLE
Fix coordinator locking and config flow errors

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -108,6 +108,7 @@ class PawControlConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "intro": "Welcome to Paw Control! Let's set up your smart dog management system."
             },
+            errors={},
         )
 
     async def async_step_dog_config(
@@ -531,11 +532,11 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                 CONF_NOTIFY_FALLBACK: user_input.get(CONF_NOTIFY_FALLBACK),
                 CONF_QUIET_HOURS: {
                     CONF_QUIET_START: user_input.get(
-                        f"{CONF_QUIET_HOURS}_{CONF_QUIET_START}",
+                        CONF_QUIET_START,
                         quiet_hours.get(CONF_QUIET_START, "22:00:00"),
                     ),
                     CONF_QUIET_END: user_input.get(
-                        f"{CONF_QUIET_HOURS}_{CONF_QUIET_END}",
+                        CONF_QUIET_END,
                         quiet_hours.get(CONF_QUIET_END, "07:00:00"),
                     ),
                 },
@@ -558,13 +559,13 @@ class PawControlOptionsFlow(config_entries.OptionsFlow):
                         default=notifications.get(CONF_NOTIFY_FALLBACK),
                     ): TextSelector(),
                     vol.Optional(
-                        f"{CONF_QUIET_HOURS}_{CONF_QUIET_START}",
+                        CONF_QUIET_START,
                         default=quiet_hours.get(CONF_QUIET_START, "22:00:00"),
-                    ): TimeSelector(),
+                    ): TextSelector(),
                     vol.Optional(
-                        f"{CONF_QUIET_HOURS}_{CONF_QUIET_END}",
+                        CONF_QUIET_END,
                         default=quiet_hours.get(CONF_QUIET_END, "07:00:00"),
-                    ): TimeSelector(),
+                    ): TextSelector(),
                     vol.Optional(
                         CONF_REMINDER_REPEAT,
                         default=notifications.get(

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Mapping, Union
+import asyncio
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -43,7 +44,7 @@ class PawControlCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
         self._visitor_mode: bool = False
         self._emergency_mode: bool = False
         self._emergency_level: str = "info"
-        self._lock = hass.helpers.asyncio.async_get_lock(f"{DOMAIN}_{entry.entry_id}")
+        self._lock = asyncio.Lock()
         self._initialize_dog_data()
 
     def _initialize_dog_data(self) -> None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode=auto

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ from unittest.mock import patch
 
 import pytest
 
+pytest_plugins = "pytest_homeassistant_custom_component"
+
 try:
     from homeassistant.core import HomeAssistant
 except ModuleNotFoundError:  # pragma: no cover - skip if dependency missing
@@ -26,10 +28,10 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 
 
-@pytest.fixture(autouse=True)
-def auto_enable_custom_integrations(_enable_custom_integrations):
-    """Enable custom integrations for all tests."""
-    return
+# Note: enable_custom_integrations fixture is provided by the HA test plugin.
+#       It enables loading custom components in Home Assistant tests. We don't
+#       need additional handling beyond requesting the fixture when needed.
+
 
 
 @pytest.fixture

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -23,6 +23,8 @@ except ModuleNotFoundError:  # pragma: no cover - skip if dependency missing
 
 from custom_components.pawcontrol.const import DOMAIN
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -14,6 +14,8 @@ except ModuleNotFoundError:  # pragma: no cover - skip if dependency missing
 
 from custom_components.pawcontrol.const import DOMAIN
 
+pytestmark = [pytest.mark.asyncio, pytest.mark.usefixtures("enable_custom_integrations")]
+
 if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from pytest_homeassistant_custom_component.common import MockConfigEntry


### PR DESCRIPTION
## Summary
- use `asyncio.Lock` in coordinator initialization
- ensure initial config flow step returns errors dict
- configure pytest for asyncio tests

## Testing
- `pytest` *(fails: Schema validation failed @ data['quiet_hours_start'])*

------
https://chatgpt.com/codex/tasks/task_e_689af440b590833192e2583bdfc84ce8