### PR TITLE
Fix parameter order for GPS end walk service

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -443,9 +443,15 @@ async def _gps_service_wrapper(
 
     try:
         method = getattr(gps_handler, method_name)
-        if method_name in ["async_start_walk", "async_end_walk"]:
+        if method_name == "async_start_walk":
             await method(
                 call.data.get("walk_type"),
+                call.data.get("dog_id"),
+            )
+        elif method_name == "async_end_walk":
+            await method(
+                call.data.get("rating"),
+                call.data.get("notes"),
                 call.data.get("dog_id"),
             )
         elif method_name == "async_export_last_route":


### PR DESCRIPTION
## Summary
- ensure GPS end walk service receives rating and notes before dog_id

## Testing
- `python -m py_compile custom_components/pawcontrol/__init__.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*
- `ruff check custom_components/pawcontrol/__init__.py` *(fails: found 132 errors)*


------
https://chatgpt.com/codex/tasks/task_e_689af76ffd0083318c8c1508cb64426c