### PR TITLE
chore: extend codespell dictionary

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
     hooks:
       - id: codespell
         args:
-          - --ignore-words-list=hass,hassio,homeassistant,zigbee,zha
+          - --ignore-words-list=hass,hassio,homeassistant,zigbee,zha,ist,ende,alle,adresse,unter,als,startet,sie,oder,manuell,tage,ordner,probleme
           - --skip=./.*,*.csv,*.json,*.min.js,*.map
           - --quiet-level=2
         exclude: |

--- a/docs/BRANDS_PR_TEMPLATE.md
+++ b/docs/BRANDS_PR_TEMPLATE.md
@@ -8,7 +8,7 @@ Repository: https://github.com/home-assistant/brands
 
 ## Checklist
 - [x] Vector SVGs provided (icon, logo)
-- [x] Icon monocrome / adheres to style guide
+- [x] Icon monochrome / adheres to style guide
 - [x] Logo legible on dark/light background
 - [x] Filenames & paths correct
 - [x] Tested locally in HA frontend (cache cleared)


### PR DESCRIPTION
## Summary
- expand codespell ignore list with German words
- fix typo in brands PR template

## Testing
- `pre-commit run --files .pre-commit-config.yaml docs/BRANDS_PR_TEMPLATE.md`
- `pre-commit run codespell --all-files`


------
https://chatgpt.com/codex/tasks/task_e_689c0eda913c8331b0d93ea825decda0