### PR TITLE
Add entity categories for Gold quality compliance

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -11,7 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -268,7 +268,7 @@ class VisitorModeBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}.global.binary_sensor.visitor_mode"
-        self._attr_entity_category = "config"
+        self._attr_entity_category = EntityCategory.CONFIG
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, "global")},
             name="Paw Control System",
@@ -295,7 +295,7 @@ class EmergencyModeBinarySensor(CoordinatorEntity, BinarySensorEntity):
         """Initialize the sensor."""
         super().__init__(coordinator)
         self._attr_unique_id = f"{DOMAIN}.global.binary_sensor.emergency_mode"
-        self._attr_entity_category = "diagnostic"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, "global")},
             name="Paw Control System",

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -9,7 +9,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfMass, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -90,6 +90,7 @@ class PawControlNumberBase(NumberEntity):
 
     _attr_has_entity_name = True
     _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/pawcontrol/quality_scale.yaml
+++ b/custom_components/pawcontrol/quality_scale.yaml
@@ -123,8 +123,8 @@ rules:
 
   # Entities have entity category set
   entity_category:
-    status: partial
-    comment: Diagnostic entities need category set
+    status: done
+    comment: Config and diagnostic entities specify entity_category
 
   # Has a repair flow
   repair_flow:

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -97,6 +97,7 @@ class PawControlSelectBase(SelectEntity):
     """Base class for Paw Control select entities."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,
@@ -329,6 +330,7 @@ class ExportFormatSelect(SelectEntity):
     _attr_name = "Export Format"
     _attr_icon = "mdi:file-export"
     _attr_options = ("csv", "json", "pdf")
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, hass: HomeAssistant, coordinator: Any, entry: ConfigEntry):
         """Initialize the select entity."""

--- a/custom_components/pawcontrol/sensor_factory.py
+++ b/custom_components/pawcontrol/sensor_factory.py
@@ -12,7 +12,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .const import DOMAIN
 
@@ -28,7 +28,7 @@ class SensorConfig:
     state_class: Optional[SensorStateClass] = None
     unit: Optional[str] = None
     options: Optional[list[str]] = None
-    entity_category: Optional[str] = None
+    entity_category: Optional[EntityCategory] = None
     default_value: Any = None
     transform_func: Optional[callable] = None
 
@@ -195,7 +195,7 @@ def create_sensor_configs() -> Dict[str, SensorConfig]:
             key="gps_points_total",
             name="GPS Points Total",
             data_path="gps.points_total",
-            entity_category="diagnostic",
+            entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.TOTAL,
             default_value=0,
             transform_func=lambda x: int(float(x)),
@@ -204,7 +204,7 @@ def create_sensor_configs() -> Dict[str, SensorConfig]:
             key="gps_accuracy_avg",
             name="GPS Accuracy Average",
             data_path="gps.accuracy_avg",
-            entity_category="diagnostic",
+            entity_category=EntityCategory.DIAGNOSTIC,
             device_class=SensorDeviceClass.DISTANCE,
             state_class=SensorStateClass.MEASUREMENT,
             unit="m",

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -8,7 +8,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import (
@@ -159,6 +159,7 @@ class PawControlSwitchBase(SwitchEntity):
     """Base class for Paw Control switches."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(
         self,

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -6,7 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .const import (
     CONF_DOG_ID,
@@ -77,6 +77,7 @@ class PawControlTextBase(TextEntity):
     """Base class for Paw Control text entities."""
 
     _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,
@@ -260,6 +261,7 @@ class ExportPathText(TextEntity):
     _attr_name = "Export Path"
     _attr_icon = "mdi:folder-export"
     _attr_native_max = 255
+    _attr_entity_category = EntityCategory.CONFIG
 
     def __init__(self, hass: HomeAssistant, coordinator: Any, entry: ConfigEntry):
         """Initialize the text entity."""


### PR DESCRIPTION
## Summary
- classify numbers, selects, switches, texts, and global binary sensors with appropriate `entity_category`
- mark entity categories requirement as complete in quality scale

## Testing
- `pre-commit run --files custom_components/pawcontrol/binary_sensor.py custom_components/pawcontrol/number.py custom_components/pawcontrol/quality_scale.yaml custom_components/pawcontrol/select.py custom_components/pawcontrol/sensor_factory.py custom_components/pawcontrol/switch.py custom_components/pawcontrol/text.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5893e8648331ae382b114a22174a