### PR TITLE
Improve setup helpers and repair issue reporting

### DIFF
--- a/custom_components/pawcontrol/gps_handler.py
+++ b/custom_components/pawcontrol/gps_handler.py
@@ -109,10 +109,19 @@ async def async_resume_tracking(hass: HomeAssistant, call: ServiceCall) -> None:
 class PawControlGPSHandler:
     """Helper class to expose GPS service methods."""
 
+    def __init__(self, hass: HomeAssistant, options: dict | None) -> None:
+        """Store reference to Home Assistant and configuration options."""
+        self.hass = hass
+        self.options = options or {}
+
     async def async_update_location(
         self, hass: HomeAssistant, call: ServiceCall
     ) -> None:
         await async_update_location(hass, call)
+
+    async def async_setup(self) -> None:
+        """Set up GPS handler (placeholder for future enhancements)."""
+        return
 
     async def async_start_walk(self, hass: HomeAssistant, call: ServiceCall) -> None:
         await async_start_walk(hass, call)

--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -71,8 +71,9 @@ def create_repair_issue(hass: HomeAssistant, issue_id: str, entry: Any) -> None:
     ir.async_create_issue(
         hass,
         DOMAIN,
-        issue_id,
+        issue_id=issue_id,
         is_fixable=True,
+        severity=ir.IssueSeverity.WARNING,
         translation_key=issue_id,
         data={"entry_id": getattr(entry, "entry_id", None)},
     )

--- a/tests/test_config_flow_reauth.py
+++ b/tests/test_config_flow_reauth.py
@@ -1,20 +1,17 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 
 async def test_reauth_updates_entry(hass):
     import custom_components.pawcontrol.config_flow as cf
-    from homeassistant.config_entries import ConfigEntry
 
-    entry = ConfigEntry(
-        version=1,
+    entry = MockConfigEntry(
         domain="pawcontrol",
-        title="Paw",
         data={"api_key": "oldkey"},
-        source="user",
-        entry_id="test123",
         options={},
+        entry_id="test123",
     )
-    hass.config_entries._entries.append(entry)
+    entry.add_to_hass(hass)
     flow = cf.ConfigFlow()
     flow.hass = hass
     flow.context = {"entry_id": entry.entry_id}

--- a/tests/test_device_remove.py
+++ b/tests/test_device_remove.py
@@ -1,22 +1,15 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_async_remove_config_entry_device_allows_removal(hass):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers import device_registry as dr
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="e1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e1")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     dev_reg = dr.async_get(hass)

--- a/tests/test_on_unload_registered.py
+++ b/tests/test_on_unload_registered.py
@@ -1,21 +1,14 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_entry_has_on_unload_callbacks(hass):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="e1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e1")
+    entry.add_to_hass(hass)
     # Before setup, no callbacks
     assert not getattr(entry, "_on_unload", [])
     await comp.async_setup_entry(hass, entry)

--- a/tests/test_options_flow_geofence.py
+++ b/tests/test_options_flow_geofence.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
@@ -6,17 +7,9 @@ pytestmark = pytest.mark.asyncio
 async def test_options_flow_geofence_triggers_reload(hass, monkeypatch):
     import custom_components.pawcontrol as comp
     from custom_components.pawcontrol import config_flow as cf
-    from homeassistant.config_entries import ConfigEntry
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="opt1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="opt1")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     reloaded = {"count": 0}

--- a/tests/test_repairs_autoprune.py
+++ b/tests/test_repairs_autoprune.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
@@ -15,18 +16,15 @@ async def _make_device(hass, entry, dog_id):
 
 async def test_stale_devices_issue_when_auto_false(hass, monkeypatch):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers import issue_registry as ir
 
-    entry = ConfigEntry(
-        version=1,
+    entry = MockConfigEntry(
         domain=comp.DOMAIN,
-        title="Paw",
         data={},
-        source="user",
-        entry_id="e1",
         options={"auto_prune_devices": False},
+        entry_id="e1",
     )
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     # Create a stale device (dog-x not in coordinator data)
@@ -47,18 +45,15 @@ async def test_stale_devices_issue_when_auto_false(hass, monkeypatch):
 
 async def test_stale_devices_auto_prunes(hass, monkeypatch):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers import device_registry as dr
 
-    entry = ConfigEntry(
-        version=1,
+    entry = MockConfigEntry(
         domain=comp.DOMAIN,
-        title="Paw",
         data={},
-        source="user",
-        entry_id="e2",
         options={"auto_prune_devices": True},
+        entry_id="e2",
     )
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     dev = await _make_device(hass, entry, "dog-y")
@@ -75,18 +70,10 @@ async def test_stale_devices_auto_prunes(hass, monkeypatch):
 
 async def test_prune_service_removes(hass):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers import device_registry as dr
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="e3",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e3")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     dev_reg = dr.async_get(hass)

--- a/tests/test_repairs_flow_options_bridge.py
+++ b/tests/test_repairs_flow_options_bridge.py
@@ -1,4 +1,5 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
@@ -6,17 +7,9 @@ pytestmark = pytest.mark.asyncio
 async def test_invalid_geofence_fix_starts_options_flow(hass, monkeypatch):
     import custom_components.pawcontrol as comp
     from custom_components.pawcontrol import repairs as rep
-    from homeassistant.config_entries import ConfigEntry
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="r1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="r1")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     started = {"count": 0}

--- a/tests/test_repairs_geofence.py
+++ b/tests/test_repairs_geofence.py
@@ -1,22 +1,20 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_invalid_geofence_creates_issue(hass):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.helpers import issue_registry as ir
 
-    entry = ConfigEntry(
-        version=1,
+    entry = MockConfigEntry(
         domain=comp.DOMAIN,
-        title="Paw",
         data={},
-        source="user",
-        entry_id="g1",
         options={"geofence_radius_m": 0, "home_lat": 50.0},
+        entry_id="g1",
     )
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     reg = ir.async_get(hass)

--- a/tests/test_services_registration.py
+++ b/tests/test_services_registration.py
@@ -1,13 +1,16 @@
 import pytest
 from homeassistant.core import HomeAssistant
-from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 DOMAIN = "pawcontrol"
 
 
 @pytest.mark.anyio
 async def test_services_registered(hass: HomeAssistant):
-    assert await async_setup_component(hass, DOMAIN, {DOMAIN: {}}) or True
+    entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
     for svc in [
         "notify_test",
         "gps_start_walk",

--- a/tests/test_services_target_mapping.py
+++ b/tests/test_services_target_mapping.py
@@ -1,5 +1,6 @@
 import pytest
 from homeassistant.exceptions import HomeAssistantError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
@@ -8,18 +9,10 @@ async def test_service_wrapper_requires_target(hass):
     import custom_components.pawcontrol as comp
 
     # Register services via setup so wrappers exist
-    from homeassistant.config_entries import ConfigEntry
     from homeassistant.core import ServiceCall
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="e1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e1")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     # Wrapper resolve path should raise if no device/dog_id

--- a/tests/test_setup_retry.py
+++ b/tests/test_setup_retry.py
@@ -1,5 +1,6 @@
 import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
@@ -8,17 +9,9 @@ async def test_setup_retry_on_initial_refresh(hass, monkeypatch):
     """If the coordinator initial refresh fails, integration should raise ConfigEntryNotReady."""
     # Arrange: minimal environment
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
 
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="test123",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="test123")
+    entry.add_to_hass(hass)
 
     # Spy to capture created coordinator and make its first refresh fail
 

--- a/tests/test_unload_services.py
+++ b/tests/test_unload_services.py
@@ -1,22 +1,15 @@
 import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_unload_removes_services_when_last_entry(hass):
     import custom_components.pawcontrol as comp
-    from homeassistant.config_entries import ConfigEntry
 
     # Setup one entry → services registered
-    entry = ConfigEntry(
-        version=1,
-        domain=comp.DOMAIN,
-        title="Paw",
-        data={},
-        source="user",
-        entry_id="e1",
-        options={},
-    )
+    entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e1")
+    entry.add_to_hass(hass)
     await comp.async_setup_entry(hass, entry)
 
     for svc in (


### PR DESCRIPTION
## Summary
- Add initialization to `PawControlGPSHandler` and stub `async_setup`
- Pass issue id and severity when creating repair issues
- Update tests to use `MockConfigEntry`

## Testing
- `python -m pre_commit run --all-files`
- `pytest`
- `pytest tests` *(fails: KeyError 'e1' and service registration errors)*

------
https://chatgpt.com/codex/tasks/task_e_689c5893e8648331ae382b114a22174a