### PR TITLE
Improve datetime setup type hints and error handling

### DIFF
--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -3,15 +3,22 @@ from __future__ import annotations
 from datetime import datetime, timezone
 
 from homeassistant.components.datetime import DateTimeEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 
 PARALLEL_UPDATES = 0
 
 
-async def async_setup_entry(hass: HomeAssistant, entry, async_add_entities):
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up datetime entities from a config entry."""
     dogs = (entry.options or {}).get("dogs", [])
     entities = [
         NextMedicationDateTime(
@@ -42,11 +49,12 @@ class NextMedicationDateTime(DateTimeEntity):
                 if st and st.state and st.state not in ("unknown", "unavailable")
                 else None
             )
-        except Exception:
+        except (AttributeError, TypeError, ValueError):
+            # Invalid or unexpected state format
             self._dt = None
 
     @property
-    def native_value(self):
+    def native_value(self) -> datetime | None:
         return self._dt
 
     async def async_set_value(self, value: datetime) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,25 @@
 import asyncio
+import sys
+import types
 from collections.abc import Generator
 
 import pytest
-from homeassistant.core import HomeAssistant
+
+try:  # pragma: no cover - fallback when Home Assistant isn't installed
+    from homeassistant.core import HomeAssistant
+except ModuleNotFoundError:  # pragma: no cover
+    ha_core = types.ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # minimal stub for tests
+        pass
+
+    class ServiceCall:  # minimal stub for tests
+        pass
+
+    ha_core.HomeAssistant = HomeAssistant
+    ha_core.ServiceCall = ServiceCall
+    sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+    sys.modules["homeassistant.core"] = ha_core
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_datetime_setup.py
+++ b/tests/test_datetime_setup.py
@@ -1,0 +1,145 @@
+import importlib
+import pathlib
+import sys
+import types
+from enum import Enum
+from typing import Callable, Iterable
+from unittest.mock import MagicMock
+
+import pytest
+
+# Home Assistant stubs
+ha_core = types.ModuleType("homeassistant.core")
+
+
+class HomeAssistant:
+    pass
+
+
+class ServiceCall:
+    pass
+
+
+ha_core.HomeAssistant = HomeAssistant
+ha_core.ServiceCall = ServiceCall
+
+ha_config_entries = types.ModuleType("homeassistant.config_entries")
+
+
+class ConfigEntry:
+    def __init__(self, *, options=None):
+        self.options = options or {}
+
+
+class ConfigEntryState(Enum):
+    LOADED = "loaded"
+
+
+ha_config_entries.ConfigEntry = ConfigEntry
+ha_config_entries.ConfigEntryState = ConfigEntryState
+
+ha_const = types.ModuleType("homeassistant.const")
+
+
+class Platform(Enum):
+    SENSOR = "sensor"
+    BINARY_SENSOR = "binary_sensor"
+    BUTTON = "button"
+    NUMBER = "number"
+    SELECT = "select"
+    TEXT = "text"
+    DATETIME = "datetime"
+    SWITCH = "switch"
+    DEVICE_TRACKER = "device_tracker"
+
+
+ha_const.Platform = Platform
+
+ha_helpers_entity = types.ModuleType("homeassistant.helpers.entity")
+
+
+class DeviceInfo:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+ha_helpers_entity.DeviceInfo = DeviceInfo
+
+ha_helpers_entity_platform = types.ModuleType("homeassistant.helpers.entity_platform")
+AddEntitiesCallback = Callable[[Iterable], None]
+ha_helpers_entity_platform.AddEntitiesCallback = AddEntitiesCallback
+
+ha_components_datetime = types.ModuleType("homeassistant.components.datetime")
+
+
+class DateTimeEntity:
+    def async_write_ha_state(self):
+        pass
+
+
+ha_components_datetime.DateTimeEntity = DateTimeEntity
+
+ha_components = types.ModuleType("homeassistant.components")
+ha_components.datetime = ha_components_datetime
+
+# Register stub modules
+sys.modules.setdefault("homeassistant", types.ModuleType("homeassistant"))
+sys.modules["homeassistant.core"] = ha_core
+sys.modules["homeassistant.config_entries"] = ha_config_entries
+sys.modules["homeassistant.const"] = ha_const
+sys.modules.setdefault(
+    "homeassistant.helpers", types.ModuleType("homeassistant.helpers")
+)
+sys.modules["homeassistant.helpers.entity"] = ha_helpers_entity
+sys.modules["homeassistant.helpers.entity_platform"] = ha_helpers_entity_platform
+sys.modules["homeassistant.components"] = ha_components
+sys.modules["homeassistant.components.datetime"] = ha_components_datetime
+
+# Prepare package structure without executing integration __init__
+root_path = pathlib.Path(__file__).resolve().parent.parent / "custom_components"
+custom_pkg = types.ModuleType("custom_components")
+custom_pkg.__path__ = [str(root_path)]
+sys.modules.setdefault("custom_components", custom_pkg)
+
+paw_pkg = types.ModuleType("custom_components.pawcontrol")
+paw_pkg.__path__ = [str(root_path / "pawcontrol")]
+sys.modules["custom_components.pawcontrol"] = paw_pkg
+
+# Import module under test
+paw_datetime = importlib.import_module("custom_components.pawcontrol.datetime")
+NextMedicationDateTime = paw_datetime.NextMedicationDateTime
+async_setup_entry = paw_datetime.async_setup_entry
+DOMAIN = paw_datetime.DOMAIN
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_creates_entities_for_dogs() -> None:
+    hass = MagicMock()
+    hass.states = MagicMock(get=MagicMock(return_value=None))
+    entry = ConfigEntry(
+        options={
+            "dogs": [
+                {"dog_id": "abc", "name": "Rex"},
+                {"name": "Fido"},
+            ]
+        }
+    )
+
+    added: dict[str, list[NextMedicationDateTime]] = {}
+
+    def add_entities(
+        entities: Iterable[NextMedicationDateTime],
+        update_before_add: bool = False,
+    ) -> None:
+        added["entities"] = list(entities)
+        added["update_before_add"] = update_before_add
+
+    await async_setup_entry(hass, entry, add_entities)
+
+    assert added["update_before_add"] is False
+    assert len(added["entities"]) == 2
+    first, second = added["entities"]
+    assert isinstance(first, NextMedicationDateTime)
+    assert isinstance(second, NextMedicationDateTime)
+    assert first._attr_unique_id == f"{DOMAIN}.abc.datetime.next_medication"
+    assert second._attr_unique_id == f"{DOMAIN}.Fido.datetime.next_medication"


### PR DESCRIPTION
## Summary
- add type hints for config entry setup in datetime helper
- narrow exception handling for parsing stored medication timestamps
- add tests verifying datetime setup processes dog entries with typed config

## Testing
- `pre-commit run --files custom_components/pawcontrol/datetime.py tests/conftest.py tests/test_datetime_setup.py`
- `pytest tests/test_datetime_setup.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689c5ee645c4833186dec6693172c8d9