### PR TITLE
Raise PlatformNotReady when coordinator is unavailable

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -11,6 +11,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -40,6 +41,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Paw Control binary sensor entities."""
     coordinator: PawControlCoordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -36,6 +37,13 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Paw Control button entities."""
+    coordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
+
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])
 

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -9,6 +9,7 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfMass, UnitOfTime
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -38,6 +39,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Paw Control number entities."""
     coordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])

--- a/custom_components/pawcontrol/quality_scale.yaml
+++ b/custom_components/pawcontrol/quality_scale.yaml
@@ -72,8 +72,8 @@ rules:
 
   # Raise PlatformNotReady if unable to connect
   platform_not_ready:
-    status: partial
-    comment: ConfigEntryNotReady used, but needs improvement
+    status: done
+    comment: Platform setup raises PlatformNotReady when coordinator is unavailable
 
   # Handles expiration of auth credentials
   reauthentication:

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -8,6 +8,7 @@ from typing import Any
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -48,6 +49,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Paw Control select entities."""
     coordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -16,6 +16,7 @@ from homeassistant.const import (
     UnitOfTime,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -33,6 +34,11 @@ async def async_setup_entry(
     """Set up Paw Control sensors."""
     runtime_data = entry.runtime_data
     coordinator = runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     dogs = entry.options.get(CONF_DOGS, [])
     entities: list[PawControlSensor] = []

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -8,6 +8,7 @@ from typing import Any
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -38,6 +39,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Paw Control switch entities."""
     coordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -6,6 +6,7 @@ import logging
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity
+from homeassistant.exceptions import PlatformNotReady
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
 from .const import (
@@ -37,6 +38,11 @@ async def async_setup_entry(
 ) -> None:
     """Set up Paw Control text entities."""
     coordinator = entry.runtime_data.coordinator
+
+    if not coordinator.last_update_success:
+        await coordinator.async_refresh()
+        if not coordinator.last_update_success:
+            raise PlatformNotReady
 
     entities = []
     dogs = entry.options.get(CONF_DOGS, [])


### PR DESCRIPTION
## Summary
- Ensure platform setup raises `PlatformNotReady` if the coordinator refresh fails
- Update quality scale documentation to reflect new readiness checks

## Testing
- `pre-commit run --files custom_components/pawcontrol/sensor.py custom_components/pawcontrol/binary_sensor.py custom_components/pawcontrol/number.py custom_components/pawcontrol/select.py custom_components/pawcontrol/switch.py custom_components/pawcontrol/text.py custom_components/pawcontrol/button.py custom_components/pawcontrol/quality_scale.yaml`
- `pytest` *(fails: ImportError: cannot import name 'util' from 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_689c63a832b8833183576486b38e5943