### PR TITLE
refactor: reduce hass.data usage

### DIFF
--- a/custom_components/pawcontrol/device_condition.py
+++ b/custom_components/pawcontrol/device_condition.py
@@ -44,11 +44,18 @@ def _dog_id_from_device_id(hass: HomeAssistant, device_id: str | None) -> str | 
 
 
 def _get_coordinator(hass: HomeAssistant, dog_id: str | None):
-    data = hass.data.get(DOMAIN) or {}
-    for entry_id, st in data.items():
-        coord = st.get("coordinator")
-        if coord and getattr(coord, "_dog_data", {}).get(dog_id) is not None:
-            return coord
+    if not dog_id:
+        return None
+
+    for entry in hass.config_entries.async_entries(DOMAIN):
+        runtime = getattr(entry, "runtime_data", None)
+        coordinator = getattr(runtime, "coordinator", None)
+        if (
+            coordinator
+            and getattr(coordinator, "_dog_data", {}).get(dog_id) is not None
+        ):
+            return coordinator
+
     return None
 
 

--- a/custom_components/pawcontrol/quality_scale.yaml
+++ b/custom_components/pawcontrol/quality_scale.yaml
@@ -200,7 +200,7 @@ rules:
   # Use ConfigEntry.runtime_data
   runtime_data:
     status: partial
-    comment: Most platforms use ConfigEntry.runtime_data; some helpers still rely on hass.data
+    comment: Most helpers now use ConfigEntry.runtime_data; scheduler and legacy helpers still rely on hass.data
 
   # Entities have suggested_device_class
   entity_suggested_device_class:

--- a/custom_components/pawcontrol/sensor_factory.py
+++ b/custom_components/pawcontrol/sensor_factory.py
@@ -66,22 +66,22 @@ class ConfigurableDogSensor(SensorEntity, RestoreSensor):
 
     def _get_coordinator_data(self, path: str, default: Any = None) -> Any:
         """Get data from coordinator safely."""
-        domain_data = self.hass.data.get(DOMAIN, {})
-        for entry_data in domain_data.values():
-            if isinstance(entry_data, dict) and "coordinator" in entry_data:
-                coordinator = entry_data["coordinator"]
-                if coordinator and hasattr(coordinator, "get_dog_data"):
-                    dog_data = coordinator.get_dog_data(self._dog)
-                    if dog_data:
-                        keys = path.split(".")
-                        data = dog_data
-                        try:
-                            for key in keys:
-                                data = data.get(key, {})
-                                if not isinstance(data, dict):
-                                    return data if data is not None else default
-                        except (AttributeError, TypeError):
-                            return default
+        for entry in self.hass.config_entries.async_entries(DOMAIN):
+            coordinator = getattr(
+                getattr(entry, "runtime_data", None), "coordinator", None
+            )
+            if coordinator and hasattr(coordinator, "get_dog_data"):
+                dog_data = coordinator.get_dog_data(self._dog)
+                if dog_data:
+                    keys = path.split(".")
+                    data = dog_data
+                    try:
+                        for key in keys:
+                            data = data.get(key, {})
+                            if not isinstance(data, dict):
+                                return data if data is not None else default
+                    except (AttributeError, TypeError):
+                        return default
         return default
 
     @property

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant
+from homeassistant.loader import async_get_integration
 
 from .const import DOMAIN
 
@@ -13,9 +14,10 @@ async def async_register(
 
 
 async def async_system_health_info(hass: HomeAssistant):
-    data = hass.data.get(DOMAIN) or {}
-    version = data.get("version") if isinstance(data, dict) else None
+    integration = await async_get_integration(hass, DOMAIN)
+    entries = hass.config_entries.async_entries(DOMAIN)
+
     return {
-        "version": version or "unknown",
-        "entries": len((data or {}).keys()) if isinstance(data, dict) else 0,
+        "version": integration.version or "unknown",
+        "entries": len(entries),
     }


### PR DESCRIPTION
## Summary
- refactor helpers to read data from `ConfigEntry.runtime_data`
- streamline system health reporting
- document runtime data progress in quality scale tracking

## Testing
- `pre-commit run --files custom_components/pawcontrol/device_condition.py custom_components/pawcontrol/gps_handler.py custom_components/pawcontrol/system_health.py custom_components/pawcontrol/sensor_factory.py custom_components/pawcontrol/quality_scale.yaml`
- `pytest` *(fails: unrecognized arguments --cov=custom_components.pawcontrol.const --cov-report=term-missing --cov-fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_689c63a832b8833183576486b38e5943