### PR TITLE
Improve Home Assistant Code Quality

### DIFF
--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Final
 
 from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.config_entries import ConfigEntry
@@ -10,7 +11,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 
-PARALLEL_UPDATES = 0
+PARALLEL_UPDATES: Final = 0
 
 
 async def async_setup_entry(
@@ -19,7 +20,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up datetime entities from a config entry."""
-    dogs = (entry.options or {}).get("dogs", [])
+    dogs = entry.options.get("dogs", [])
     entities = [
         NextMedicationDateTime(
             hass,

--- a/custom_components/pawcontrol/gps_handler.py
+++ b/custom_components/pawcontrol/gps_handler.py
@@ -23,11 +23,11 @@ def _get_entry(hass: HomeAssistant, call: ServiceCall) -> ConfigEntry:
     raise ServiceValidationError("No loaded Paw Control entries")
 
 
-def _dog_id(entry, call: ServiceCall) -> str:
+def _dog_id(entry: ConfigEntry, call: ServiceCall) -> str:
     dog_id = call.data.get("dog_id")
     if dog_id:
         return dog_id
-    dogs = (entry.options or {}).get("dogs") or []
+    dogs = entry.options.get("dogs", [])
     if dogs and isinstance(dogs, list):
         return dogs[0].get("dog_id") or dogs[0].get("name") or "dog"
     return "dog"
@@ -50,15 +50,9 @@ async def async_update_location(hass: HomeAssistant, call: ServiceCall) -> None:
     coordinator.process_location(dog, lat, lon, acc)
 
     # Mark last action
-    try:
-        coordinator._dog_data[dog]["statistics"]["last_action"] = (
-            dt_util.now().isoformat()
-        )
-        coordinator._dog_data[dog]["statistics"]["last_action_type"] = (
-            "gps_location_posted"
-        )
-    except Exception:
-        pass
+    stats = coordinator._dog_data.setdefault(dog, {}).setdefault("statistics", {})
+    stats["last_action"] = dt_util.now().isoformat()
+    stats["last_action_type"] = "gps_location_posted"
 
 
 async def async_start_walk(hass: HomeAssistant, call: ServiceCall) -> None:


### PR DESCRIPTION
## Summary
- mark parallel updates constant as Final and simplify dog option lookup
- type annotate GPS dog helper and track last GPS action without broad exception handling

## Testing
- `pre-commit run --files custom_components/pawcontrol/datetime.py custom_components/pawcontrol/gps_handler.py`
- `pytest` *(fails: Interrupted: 25 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_689c699bcaf08331a0ae44a29590414f