### PR TITLE
Add Home Assistant compatibility layer

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -12,10 +12,10 @@ from homeassistant.components.binary_sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .compat import DeviceInfo, EntityCategory
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -9,9 +9,9 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/custom_components/pawcontrol/compat.py
+++ b/custom_components/pawcontrol/compat.py
@@ -17,6 +17,7 @@ except Exception:  # pragma: no cover - used in tests without Home Assistant
 if ha_entity and hasattr(ha_entity, "EntityCategory"):
     EntityCategory = ha_entity.EntityCategory  # type: ignore[assignment]
 else:  # pragma: no cover - fallback for tests
+
     class EntityCategory(StrEnum):
         CONFIG = "config"
         DIAGNOSTIC = "diagnostic"
@@ -31,13 +32,13 @@ try:  # pragma: no cover - exercised in Home Assistant runtime
 except Exception:  # pragma: no cover - used in tests without Home Assistant
     ha_dr = None
 
+
 class DeviceInfo(dict):
     """Device info container with attribute access."""
 
     __getattr__ = dict.__getitem__
     __setattr__ = dict.__setitem__
 
+
 if ha_dr is not None and not hasattr(ha_dr, "DeviceInfo"):
     ha_dr.DeviceInfo = DeviceInfo  # type: ignore[attr-defined]
-
-

--- a/custom_components/pawcontrol/compat.py
+++ b/custom_components/pawcontrol/compat.py
@@ -1,0 +1,43 @@
+"""Compatibility helpers for optional Home Assistant features.
+
+This module provides local fallbacks for enums and data classes that are
+available in Home Assistant but may be absent in the minimal test environment.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+# EntityCategory -------------------------------------------------------------------------
+try:  # pragma: no cover - exercised in Home Assistant runtime
+    from homeassistant.helpers import entity as ha_entity
+except Exception:  # pragma: no cover - used in tests without Home Assistant
+    ha_entity = None
+
+if ha_entity and hasattr(ha_entity, "EntityCategory"):
+    EntityCategory = ha_entity.EntityCategory  # type: ignore[assignment]
+else:  # pragma: no cover - fallback for tests
+    class EntityCategory(StrEnum):
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
+
+    if ha_entity is not None:
+        ha_entity.EntityCategory = EntityCategory  # type: ignore[attr-defined]
+
+
+# DeviceInfo ----------------------------------------------------------------------------
+try:  # pragma: no cover - exercised in Home Assistant runtime
+    from homeassistant.helpers import device_registry as ha_dr
+except Exception:  # pragma: no cover - used in tests without Home Assistant
+    ha_dr = None
+
+class DeviceInfo(dict):
+    """Device info container with attribute access."""
+
+    __getattr__ = dict.__getitem__
+    __setattr__ = dict.__setitem__
+
+if ha_dr is not None and not hasattr(ha_dr, "DeviceInfo"):
+    ha_dr.DeviceInfo = DeviceInfo  # type: ignore[attr-defined]
+
+

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -5,9 +5,9 @@ from datetime import datetime, timezone
 from homeassistant.components.datetime import DateTimeEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo
 from .const import DOMAIN
 
 PARALLEL_UPDATES = 0

--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -5,9 +5,9 @@ from homeassistant.components.device_tracker.const import SourceType
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo
 from .const import DOMAIN
 
 PARALLEL_UPDATES = 0

--- a/custom_components/pawcontrol/diagnostics.py
+++ b/custom_components/pawcontrol/diagnostics.py
@@ -6,8 +6,13 @@ from typing import Any
 
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import HomeAssistant
+
+try:  # pragma: no cover - Home Assistant provides these in runtime
+    from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+except Exception:  # pragma: no cover - tests without full Home Assistant
+    CONF_PASSWORD = "password"
+    CONF_USERNAME = "username"
 
 from .const import DOMAIN
 
@@ -29,7 +34,11 @@ async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
 ) -> dict[str, Any]:
     """Return diagnostics for a config entry."""
-    coordinator = entry.runtime_data.coordinator
+    coordinator = getattr(
+        getattr(entry, "runtime_data", None),
+        "coordinator",
+        hass.data.get(DOMAIN, {}).get(entry.entry_id, {}).get("coordinator"),
+    )
 
     # Get all dog data but redact sensitive information
     dogs_data = {}

--- a/custom_components/pawcontrol/entity.py
+++ b/custom_components/pawcontrol/entity.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .compat import DeviceInfo, EntityCategory
 from .const import CONF_DOG_ID, CONF_DOG_NAME, DOMAIN
 
 if TYPE_CHECKING:

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -10,9 +10,9 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfMass, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo, EntityCategory
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -9,9 +9,9 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo, EntityCategory
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -17,10 +17,10 @@ from homeassistant.const import (
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
+from .compat import DeviceInfo, EntityCategory
 from .const import CONF_DOG_ID, CONF_DOG_NAME, CONF_DOGS, DOMAIN
 from .coordinator import PawControlCoordinator
 

--- a/custom_components/pawcontrol/sensor_factory.py
+++ b/custom_components/pawcontrol/sensor_factory.py
@@ -12,8 +12,8 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
+from .compat import DeviceInfo, EntityCategory
 from .const import DOMAIN
 
 

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -9,9 +9,9 @@ from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .compat import DeviceInfo, EntityCategory
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.text import TextEntity
 from homeassistant.exceptions import PlatformNotReady
-from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 
+from .compat import DeviceInfo, EntityCategory
 from .const import (
     CONF_DOG_ID,
     CONF_DOG_MODULES,

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,39 @@
+"""Test environment compatibility helpers.
+
+This module is loaded automatically by Python before any other imports. It
+ensures that optional Home Assistant helpers exist when the test environment
+provides a minimal stub of the framework.
+"""
+
+from __future__ import annotations
+
+import sys
+from enum import StrEnum
+from types import ModuleType
+
+try:  # pragma: no cover - Home Assistant available
+    from homeassistant.helpers import device_registry, entity
+except Exception:  # pragma: no cover - create minimal stubs
+    ha = sys.modules.setdefault("homeassistant", ModuleType("homeassistant"))
+    helpers = ModuleType("homeassistant.helpers")
+    ha.helpers = helpers  # type: ignore[attr-defined]
+    sys.modules["homeassistant.helpers"] = helpers
+    entity = ModuleType("homeassistant.helpers.entity")
+    device_registry = ModuleType("homeassistant.helpers.device_registry")
+    sys.modules["homeassistant.helpers.entity"] = entity
+    sys.modules["homeassistant.helpers.device_registry"] = device_registry
+
+if not hasattr(entity, "EntityCategory"):
+    class EntityCategory(StrEnum):
+        CONFIG = "config"
+        DIAGNOSTIC = "diagnostic"
+
+    entity.EntityCategory = EntityCategory  # type: ignore[attr-defined]
+
+if not hasattr(device_registry, "DeviceInfo"):
+    class DeviceInfo(dict):
+        __getattr__ = dict.__getitem__
+        __setattr__ = dict.__setitem__
+
+    device_registry.DeviceInfo = DeviceInfo  # type: ignore[attr-defined]
+

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -24,6 +24,7 @@ except Exception:  # pragma: no cover - create minimal stubs
     sys.modules["homeassistant.helpers.device_registry"] = device_registry
 
 if not hasattr(entity, "EntityCategory"):
+
     class EntityCategory(StrEnum):
         CONFIG = "config"
         DIAGNOSTIC = "diagnostic"
@@ -31,9 +32,9 @@ if not hasattr(entity, "EntityCategory"):
     entity.EntityCategory = EntityCategory  # type: ignore[attr-defined]
 
 if not hasattr(device_registry, "DeviceInfo"):
+
     class DeviceInfo(dict):
         __getattr__ = dict.__getitem__
         __setattr__ = dict.__setitem__
 
     device_registry.DeviceInfo = DeviceInfo  # type: ignore[attr-defined]
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import types
 from collections.abc import Generator
 
 import pytest
+import sitecustomize  # noqa: F401  # Ensure HA compatibility shims
 
 try:  # pragma: no cover - fallback when Home Assistant isn't installed
     from homeassistant.core import HomeAssistant

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 from unittest.mock import MagicMock, patch
 
 import pytest
+from custom_components.pawcontrol.compat import EntityCategory
 from custom_components.pawcontrol.const import CONF_DOG_ID, CONF_DOG_NAME, DOMAIN
 from custom_components.pawcontrol.entity import (
     PawControlBinarySensorEntity,
@@ -13,7 +14,6 @@ from custom_components.pawcontrol.entity import (
     PawControlSensorEntity,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import EntityCategory
 
 if TYPE_CHECKING:
     from pytest_homeassistant_custom_component.common import MockConfigEntry


### PR DESCRIPTION
## Summary
- provide compatibility helpers for `EntityCategory` and `DeviceInfo`
- fall back to string constants in diagnostics
- wire tests to load compatibility shims

## Testing
- `ruff check .`
- `pytest` *(fails: AttributeError: 'types.SimpleNamespace' object has no attribute 'options', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689c699bcaf08331a0ae44a29590414f