### PR TITLE
refactor scheduler dog module filter

### DIFF
--- a/custom_components/pawcontrol/helpers/scheduler.py
+++ b/custom_components/pawcontrol/helpers/scheduler.py
@@ -201,7 +201,6 @@ class PawControlScheduler:
     async def _setup_feeding_reminders(self) -> None:
         """Set up feeding reminder schedules."""
         for dog_id, dog_name in self._iter_dogs_with_module(MODULE_FEEDING):
-
             # Default feeding times
             feeding_schedule = {
                 "breakfast": "07:00:00",

--- a/custom_components/pawcontrol/helpers/scheduler.py
+++ b/custom_components/pawcontrol/helpers/scheduler.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime, time, timedelta
-from typing import Any, Callable, Dict, Iterator, Optional
+from typing import Any, Dict, Iterator, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback


### PR DESCRIPTION
## Summary
- reduce reminder setup duplication by filtering dogs via a shared helper

## Testing
- `pre-commit run --files custom_components/pawcontrol/helpers/scheduler.py`
- `pytest` *(fails: MockConfigEntry object has no attribute runtime_data)*

------
https://chatgpt.com/codex/tasks/task_e_689c6cd6e16c83318b03c0cf9b904818