### PR TITLE
Refactor speed calculation for clarity

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -29,7 +29,8 @@ def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:
     """Return speed in km/h given distance in meters and duration in seconds."""
     if duration_s <= 0:
         return 0.0
-    return (distance_m / 1000.0) / (duration_s / 3600.0)
+    # Use direct conversion from m/s to km/h for clarity
+    return (distance_m / duration_s) * 3.6
 
 
 def validate_coordinates(lat: float, lon: float) -> bool:


### PR DESCRIPTION
## Summary
- simplify speed calculation by converting meters per second directly to km/h

## Testing
- `ruff check .`
- `pytest tests/test_config_flow.py::test_options_flow_instantiation_and_options_copy -q`
- `pytest` *(fails: service_not_found, integration not found)*

------
https://chatgpt.com/codex/tasks/task_e_689c753dde5c83319344324da6070d6a