### PR TITLE
Remove duplicate iterator from scheduler

### DIFF
--- a/custom_components/pawcontrol/helpers/notification_router.py
+++ b/custom_components/pawcontrol/helpers/notification_router.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, time, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from homeassistant.components.notify import DOMAIN as NOTIFY_DOMAIN
 from homeassistant.config_entries import ConfigEntry
@@ -40,11 +40,11 @@ class NotificationRouter:
         self,
         title: str,
         message: str,
-        dog_id: Optional[str] = None,
+        dog_id: str | None = None,
         category: str = "general",
-        actions: Optional[List[Dict[str, str]]] = None,
+        actions: List[Dict[str, str]] | None = None,
         priority: str = "normal",
-        tag: Optional[str] = None,
+        tag: str | None = None,
     ) -> bool:
         """Send notification with intelligent routing."""
 
@@ -106,7 +106,7 @@ class NotificationRouter:
         self,
         action: str,
         tag: str,
-        data: Optional[Dict[str, Any]] = None,
+        data: Dict[str, Any] | None = None,
     ) -> None:
         """Handle notification action response."""
         _LOGGER.info(f"Handling notification action: {action} for tag: {tag}")
@@ -244,10 +244,10 @@ class NotificationRouter:
         self,
         title: str,
         message: str,
-        dog_id: Optional[str],
+        dog_id: str | None,
         category: str,
-        actions: Optional[List[Dict[str, str]]],
-        tag: Optional[str],
+        actions: List[Dict[str, str]] | None,
+        tag: str | None,
     ) -> Dict[str, Any]:
         """Build notification data payload."""
         data = {
@@ -320,11 +320,11 @@ class NotificationRouter:
         self,
         title: str,
         message: str,
-        dog_id: Optional[str],
+        dog_id: str | None,
         category: str,
-        actions: Optional[List[Dict[str, str]]],
+        actions: List[Dict[str, str]] | None,
         priority: str,
-        tag: Optional[str],
+        tag: str | None,
     ) -> None:
         """Schedule notification for later delivery."""
         # This would typically use async_track_time_change or similar
@@ -338,7 +338,7 @@ class NotificationRouter:
         reminder_type: str,
         dog_id: str,
         dog_name: str,
-        additional_info: Optional[Dict[str, Any]] = None,
+        additional_info: Dict[str, Any] | None = None,
     ) -> bool:
         """Send a reminder notification for a specific type."""
 

--- a/custom_components/pawcontrol/helpers/scheduler.py
+++ b/custom_components/pawcontrol/helpers/scheduler.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from collections.abc import Callable, Iterable
 from datetime import datetime, time, timedelta
-from typing import Any, Dict, Iterator, Optional
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
@@ -95,19 +94,6 @@ class PawControlScheduler:
                 _LOGGER.debug(f"Cancelled reminder task: {task_id}")
 
         self._reminder_tasks.clear()
-
-    def _iter_dogs_with_module(
-        self, module: str
-    ) -> Iterator[tuple[str, Dict[str, Any]]]:
-        """Yield dogs that have a specific module enabled."""
-        dogs = self.entry.options.get(CONF_DOGS, [])
-        for dog in dogs:
-            dog_id = dog.get(CONF_DOG_ID)
-            if not dog_id:
-                continue
-            modules = dog.get(CONF_DOG_MODULES, {})
-            if modules.get(module, False):
-                yield dog_id, dog
 
     async def _setup_daily_reset(self) -> None:
         """Set up daily reset task."""
@@ -365,7 +351,7 @@ class PawControlScheduler:
         self,
         callback: Callable,
         delay_seconds: int,
-        task_id: Optional[str] = None,
+        task_id: str | None = None,
     ) -> None:
         """Schedule a delayed task."""
 


### PR DESCRIPTION
## Summary
- remove redundant `_iter_dogs_with_module` implementation
- modernize typing for delayed scheduler tasks
- adopt native `| None` unions in notification router, dropping leftover `Optional` import

## Testing
- `pre-commit run --files custom_components/pawcontrol/helpers/scheduler.py custom_components/pawcontrol/helpers/notification_router.py`
- `pytest` *(fails: AttributeError: 'MockConfigEntry' object has no attribute 'runtime_data'; RuntimeError: Task pending)*

------
https://chatgpt.com/codex/tasks/task_e_689c753dde5c83319344324da6070d6a