### PR TITLE
Validate coordinate inputs and test edge cases

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from contextlib import suppress
-from math import atan2, cos, radians, sin, sqrt
+from math import atan2, cos, isfinite, radians, sin, sqrt
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import HomeAssistantError
@@ -43,6 +43,9 @@ def validate_coordinates(lat: float, lon: float) -> bool:
         lat_f = float(lat)
         lon_f = float(lon)
     except (TypeError, ValueError):
+        return False
+
+    if not (isfinite(lat_f) and isfinite(lon_f)):
         return False
 
     return -90.0 <= lat_f <= 90.0 and -180.0 <= lon_f <= 180.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+"""Tests for utility helpers."""
+
+import math
+
+from custom_components.pawcontrol.utils import validate_coordinates
+
+
+def test_validate_coordinates_valid():
+    """Valid latitude and longitude return True."""
+    assert validate_coordinates(10.0, 20.0)
+
+
+def test_validate_coordinates_invalid_bool():
+    """Boolean values should be rejected."""
+    assert not validate_coordinates(True, 0)  # type: ignore[arg-type]
+    assert not validate_coordinates(0, False)  # type: ignore[arg-type]
+
+
+def test_validate_coordinates_out_of_range():
+    """Coordinates outside valid range are rejected."""
+    assert not validate_coordinates(91.0, 0)
+    assert not validate_coordinates(0, 181.0)
+
+
+def test_validate_coordinates_non_finite():
+    """NaN or infinite values are rejected."""
+    assert not validate_coordinates(math.nan, 0)
+    assert not validate_coordinates(0, math.inf)


### PR DESCRIPTION
## Summary
- ensure coordinate validator rejects NaN and infinite inputs
- add tests for valid, bool, out-of-range, and non-finite coordinates

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py tests/test_utils.py`
- `pytest tests/test_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_689ded28dd248331b27e5abea35f2529