### PR TITLE
Ensure tests use coverage plugin and fix datetime entity base import

### DIFF
--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -22,7 +22,7 @@ from .const import (
     MODULE_HEALTH,
     MODULE_WALK,
 )
-from .entity import PawControlEntityBase
+from .entity import PawControlEntity
 
 if TYPE_CHECKING:  # pragma: no cover
     from homeassistant.config_entries import ConfigEntry
@@ -107,7 +107,7 @@ async def async_setup_entry(
     async_add_entities(entities, update_before_add=True)
 
 
-class PawControlDateTimeBase(PawControlEntityBase, DateTimeEntity):
+class PawControlDateTimeBase(PawControlEntity, DateTimeEntity):
     """Base class for Paw Control datetime entities."""
 
     _attr_entity_category = EntityCategory.CONFIG

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,5 @@
 homeassistant==2025.8.1
 pytest>=8.3
+pytest-cov>=5.0
 pytest-asyncio>=0.23
 pytest-homeassistant-custom-component  # folgt täglich der HA-Version


### PR DESCRIPTION
## Summary
- include pytest-cov in test requirements
- import correct entity base in datetime platform

## Testing
- `pre-commit run --files requirements_test.txt custom_components/pawcontrol/datetime.py`
- `pytest` *(fails: ImportError: cannot import name 'DOMAIN' from 'custom_components.pawcontrol.const' and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_689ded28dd248331b27e5abea35f2529