### PR TITLE
feat: run pre-commit in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,24 +6,18 @@ on:
 
 jobs:
   lint:
-    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-python@v5
         with:
           python-version: "3.13"
-      - name: Install tooling
+      - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install ruff black
-      - name: Ruff lint (fix)
-        run: |
-         pip install ruff
-         ruff check . --select I --fix
-         ruff check . --fix
-      - name: Ruff format
-        run: ruff format .
+          pip install pre-commit
+      - name: Run pre-commit
+        run: pre-commit run --show-diff-on-failure --color always --all-files
       - name: Hassfest
         uses: home-assistant/actions/hassfest@master
 


### PR DESCRIPTION
## Summary
- run pre-commit hooks as lint job
- remove push-only lint guard

## Testing
- `pre-commit run --files .github/workflows/ci.yml`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*


------
https://chatgpt.com/codex/tasks/task_e_689df1f7f1d48331a33ae83809251271