### PR TITLE
fix english translations

### DIFF
--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -67,12 +67,12 @@
       "duplicate_dog_id": "This Dog ID already exists. Please choose a unique identifier.",
       "invalid_path": "Invalid export path",
       "invalid_time": "Invalid time format",
-      "invalid_auth": "Ungültige Anmeldedaten",
+      "invalid_auth": "Invalid credentials",
       "invalid_geofence": "Invalid geofence settings"
     },
     "abort": {
       "single_instance_allowed": "Only one instance of Paw Control is allowed.",
-      "reauth_successful": "Anmeldedaten aktualisiert"
+      "reauth_successful": "Credentials updated"
     }
   },
   "options": {


### PR DESCRIPTION
## Summary
- correct German phrases to English in invalid_auth and reauth_successful messages

## Testing
- `pre-commit run --files custom_components/pawcontrol/translations/en.json`

------
https://chatgpt.com/codex/tasks/task_e_689df7d31730833192b481ea4fc7f9c3