### PR TITLE
chore: add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,30 @@
+name: Coverage
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -U pytest pytest-asyncio pytest-cov
+          pip install -U homeassistant==2025.8.1
+          pip install -U pytest-homeassistant-custom-component
+      - name: Run tests with coverage
+        env:
+          PYTHONPATH: .
+        run: |
+          pytest --cov-report=xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          fail_ci_if_error: true


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests with coverage and upload to Codecov

## Testing
- `pre-commit run --files .github/workflows/coverage.yml`
- `pytest` *(fails: AttributeError: 'MockConfigEntry' object has no attribute 'options')*


------
https://chatgpt.com/codex/tasks/task_e_689dfc7a3bac8331bc187bbf7815665b