### PR TITLE
fix: add missing translation strings

### DIFF
--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -611,12 +611,24 @@
     "notify_test": {
       "name": "Notify Test",
       "fields": {
+        "title": {
+          "name": "Title",
+          "description": "Notification title."
+        },
+        "message": {
+          "name": "Message",
+          "description": "Notification message body."
+        },
+        "target": {
+          "name": "Target",
+          "description": "Optional notify target/device."
+        },
         "config_entry_id": {
           "name": "Config Entry Id",
           "description": "Optional config entry ID to target a specific instance."
         }
       },
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback"
+      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback)."
     },
     "purge_all_storage": {
       "name": "Purge All Storage",
@@ -711,7 +723,7 @@
           "name": "Enable"
         }
       },
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der"
+      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der Geozone."
     },
     "prune_stale_devices": {
       "name": "Prune stale devices",

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -451,7 +451,7 @@
     },
     "toggle_geofence_alerts": {
       "name": "Toggle Geofence Alerts",
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der",
+      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der Geozone.",
       "fields": {
         "enabled": {
           "name": "Aktiviert",
@@ -485,7 +485,7 @@
     },
     "notify_test": {
       "name": "Notify Test",
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback",
+      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback).",
       "fields": {
         "title": {
           "name": "Titel",

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -451,7 +451,7 @@
     },
     "toggle_geofence_alerts": {
       "name": "Toggle Geofence Alerts",
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der",
+      "description": "Enable or disable geofence notifications when leaving or entering the area.",
       "fields": {
         "enabled": {
           "name": "Enabled",
@@ -485,7 +485,7 @@
     },
     "notify_test": {
       "name": "Notify Test",
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback",
+      "description": "Send a test message using the configured notify target (fallback).",
       "fields": {
         "title": {
           "name": "Title",


### PR DESCRIPTION
## Summary
- expand notify_test service translations with title, message, and target fields
- complete toggle geofence alert descriptions in strings and translations

## Testing
- `pytest` *(fails: ImportError: cannot import name 'UnitOfLength'; AttributeError: 'MockConfigEntry' object has no attribute 'state'; RuntimeError: Task pending)*

------
https://chatgpt.com/codex/tasks/task_e_689dfc335890833185a83ba9559d76c6