### PR TITLE
fix: add missing service strings

### DIFF
--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -609,14 +609,18 @@
       "description": "Startet einen Spaziergang für einen Hund."
     },
     "notify_test": {
-      "name": "Notify Test",
+      "name": "Test Notification",
+      "description": "Send a test notification",
       "fields": {
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
+        "dog_id": {
+          "name": "Dog ID",
+          "description": "Dog identifier (optional)"
+        },
+        "message": {
+          "name": "Message",
+          "description": "Test message content"
         }
-      },
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback"
+      }
     },
     "purge_all_storage": {
       "name": "Purge All Storage",
@@ -696,22 +700,13 @@
     },
     "toggle_geofence_alerts": {
       "name": "Toggle Geofence Alerts",
+      "description": "Enable or disable geofence notifications",
       "fields": {
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
-        },
-        "dog_id": {
-          "name": "Dog Id"
-        },
-        "selector": {
-          "name": "Selector"
-        },
-        "enable": {
-          "name": "Enable"
+        "enabled": {
+          "name": "Enable Alerts",
+          "description": "Enable geofence alerts"
         }
-      },
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der"
+      }
     },
     "prune_stale_devices": {
       "name": "Prune stale devices",

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -451,25 +451,11 @@
     },
     "toggle_geofence_alerts": {
       "name": "Toggle Geofence Alerts",
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der",
+      "description": "Aktiviert oder deaktiviert Geofence-Benachrichtigungen.",
       "fields": {
         "enabled": {
-          "name": "Aktiviert",
-          "description": "True für aktivieren, false für deaktivieren.",
-          "example": "true"
-        },
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
-        },
-        "dog_id": {
-          "name": "Dog Id"
-        },
-        "selector": {
-          "name": "Selector"
-        },
-        "enable": {
-          "name": "Enable"
+          "name": "Benachrichtigungen aktivieren",
+          "description": "Geofence-Benachrichtigungen einschalten"
         }
       }
     },
@@ -484,27 +470,16 @@
       }
     },
     "notify_test": {
-      "name": "Notify Test",
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback",
+      "name": "Test Notification",
+      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback).",
       "fields": {
-        "title": {
-          "name": "Titel",
-          "description": "Titel der Nachricht.",
-          "example": "Test"
+        "dog_id": {
+          "name": "Hund-ID",
+          "description": "Hund-Kennung (optional)"
         },
         "message": {
           "name": "Nachricht",
-          "description": "Nachrichtentext.",
-          "example": "Hallo von Paw Control"
-        },
-        "target": {
-          "name": "Ziel",
-          "description": "Optionales Notify-Ziel/Gerät.",
-          "example": "mobile_app_pixel"
-        },
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
+          "description": "Inhalt der Testnachricht"
         }
       }
     },

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -451,25 +451,11 @@
     },
     "toggle_geofence_alerts": {
       "name": "Toggle Geofence Alerts",
-      "description": "Aktiviert/Deaktiviert Benachrichtigungen bei Verlassen/Betreten der",
+      "description": "Enable or disable geofence notifications",
       "fields": {
         "enabled": {
-          "name": "Enabled",
-          "description": "True to enable geofence alerts, false to disable.",
-          "example": "true"
-        },
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
-        },
-        "dog_id": {
-          "name": "Dog Id"
-        },
-        "selector": {
-          "name": "Selector"
-        },
-        "enable": {
-          "name": "Enable"
+          "name": "Enable Alerts",
+          "description": "Enable geofence alerts"
         }
       }
     },
@@ -484,27 +470,16 @@
       }
     },
     "notify_test": {
-      "name": "Notify Test",
-      "description": "Sendet eine Test-Nachricht über das konfigurierte Notify-Ziel (Fallback",
+      "name": "Test Notification",
+      "description": "Send a test notification",
       "fields": {
-        "title": {
-          "name": "Title",
-          "description": "Notification title.",
-          "example": "Test"
+        "dog_id": {
+          "name": "Dog ID",
+          "description": "Dog identifier (optional)"
         },
         "message": {
           "name": "Message",
-          "description": "Notification message body.",
-          "example": "Hello from Paw Control"
-        },
-        "target": {
-          "name": "Target",
-          "description": "Optional notify target/device.",
-          "example": "mobile_app_pixel"
-        },
-        "config_entry_id": {
-          "name": "Config Entry Id",
-          "description": "Optional config entry ID to target a specific instance."
+          "description": "Test message content"
         }
       }
     },


### PR DESCRIPTION
## Summary
- add missing Test Notification service strings
- fix Toggle Geofence Alerts service description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries'; 'homeassistant' is not a package)*

------
https://chatgpt.com/codex/tasks/task_e_689dfc335890833185a83ba9559d76c6