### PR TITLE
Handle missing integration gracefully

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.exceptions import (
     HomeAssistantError,
     ServiceValidationError,
 )
+from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
@@ -45,6 +46,8 @@ from .types import PawRuntimeData
 assert DOMAIN == CONST_DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
+
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.exceptions import (
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.typing import ConfigType
+from homeassistant.loader import IntegrationNotFound
 
 from . import coordinator as coordinator_mod
 from . import gps_handler as gps
@@ -95,7 +96,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await _register_devices(hass, entry)
 
     # Setup platforms
-    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    try:
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    except IntegrationNotFound:
+        _LOGGER.warning("Integration not found when forwarding entry setups")
 
     # Setup schedulers (daily reset, reports, reminders)
     await scheduler_mod.setup_schedulers(hass, entry)

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.loader import async_get_integration
+from homeassistant.loader import async_get_integration, IntegrationNotFound
 
 from .const import DOMAIN
 
@@ -24,11 +24,15 @@ def async_register(
 
 async def async_system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get system health information."""
-    integration = await async_get_integration(hass, DOMAIN)
+    try:
+        integration = await async_get_integration(hass, DOMAIN)
+        version = integration.version or "unknown"
+    except IntegrationNotFound:
+        version = "unknown"
     entries = hass.config_entries.async_entries(DOMAIN)
 
     health_info = {
-        "version": integration.version or "unknown",
+        "version": version,
         "entries": len(entries),
     }
 

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -7,7 +7,7 @@ from typing import Any
 
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.loader import async_get_integration, IntegrationNotFound
+from homeassistant.loader import IntegrationNotFound, async_get_integration
 
 from .const import DOMAIN
 


### PR DESCRIPTION
## Summary
- prevent system health from failing when integration metadata is unavailable
- avoid crash during setup if integration cannot be resolved

## Testing
- `pytest` *(fails: service_not_found, ImportError, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e133a1ca483319e2468ac774c4887