### PR TITLE
Add missing dog description for gps_end_walk service

### DIFF
--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -445,7 +445,8 @@
                     "description": "Optional config entry ID to target a specific instance."
                 },
                 "dog_id": {
-                    "name": "Dog Id"
+                    "name": "Dog Id",
+                    "description": "Optional ID of the dog."
                 },
                 "selector": {
                     "name": "Selector"


### PR DESCRIPTION
## Summary
- provide translation description for `dog_id` field in `gps_end_walk` service

## Testing
- `pytest -q` *(fails: Integration 'pawcontrol' not found and other service-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e1b2f269883318015f61517c6c5ca