### PR TITLE
refactor: centralize earth radius constant

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -6,6 +6,9 @@ from homeassistant.const import Platform
 
 DOMAIN: Final[str] = "pawcontrol"
 
+# Average Earth radius in meters used for distance calculations
+EARTH_RADIUS_M: Final[float] = 6_371_000.0
+
 # Platforms supported by the integration
 PLATFORMS: Final[list[Platform]] = [
     Platform.SENSOR,

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -8,6 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 from homeassistant.exceptions import HomeAssistantError
 
+from .const import EARTH_RADIUS_M
+
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -16,13 +18,12 @@ if TYPE_CHECKING:
 
 def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Return haversine distance in meters between two lat/lon points."""
-    radius = 6_371_000.0
     phi1, phi2 = radians(lat1), radians(lat2)
     dphi = radians(lat2 - lat1)
     dlambda = radians(lon2 - lon1)
     a = sin(dphi / 2) ** 2 + cos(phi1) * cos(phi2) * sin(dlambda / 2) ** 2
     c = 2 * atan2(sqrt(a), sqrt(1 - a))
-    return radius * c
+    return EARTH_RADIUS_M * c
 
 
 def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,13 @@
 
 import math
 
-from custom_components.pawcontrol.utils import validate_coordinates
+from custom_components.pawcontrol.utils import (
+    calculate_distance,
+    calculate_speed_kmh,
+    validate_coordinates,
+)
+
+EARTH_RADIUS_M = 6_371_000.0
 
 
 def test_validate_coordinates_valid():
@@ -26,3 +32,16 @@ def test_validate_coordinates_non_finite():
     """NaN or infinite values are rejected."""
     assert not validate_coordinates(math.nan, 0)
     assert not validate_coordinates(0, math.inf)
+
+
+def test_calculate_distance_equator():
+    """A one-degree shift at the equator has a known distance."""
+    distance = calculate_distance(0.0, 0.0, 0.0, 1.0)
+    expected = EARTH_RADIUS_M * math.pi / 180
+    assert math.isclose(distance, expected, rel_tol=1e-6)
+
+
+def test_calculate_speed_kmh():
+    """Speed calculation converts m/s to km/h."""
+    assert calculate_speed_kmh(1000.0, 3600.0) == 1.0
+    assert calculate_speed_kmh(1000.0, 0.0) == 0.0


### PR DESCRIPTION
## Summary
- centralize Earth radius value in const module
- use shared constant in distance calculation
- add unit tests for distance and speed helpers

## Testing
- `ruff check tests/test_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*
- `pytest tests/test_utils.py` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*

------
https://chatgpt.com/codex/tasks/task_e_689e1bd8b5a08331a1d3f6c6d17dfd89