### PR TITLE
Handle invalid geofence repair via options flow

### DIFF
--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -270,20 +270,7 @@
         },
         "invalid_geofence": {
             "title": "Invalid geofence configuration",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Fix geofence settings",
-                        "description": "Choose how to resolve the invalid geofence settings.",
-                        "data": {
-                            "action": "Action"
-                        },
-                        "data_description": {
-                            "action": "Select how to resolve the invalid geofence settings"
-                        }
-                    }
-                }
-            }
+            "description": "The configured geofence appears to be invalid. Use the fix flow to update latitude/longitude and radius."
         }
     },
     "services": {

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -808,21 +808,7 @@
         },
         "invalid_geofence": {
             "title": "Invalid geofence configuration",
-            "description": "The configured geofence appears to be invalid. Use the fix flow to update latitude/longitude and radius.",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Fix geofence settings",
-                        "description": "Choose how to resolve the invalid geofence settings.",
-                        "data": {
-                            "action": "Action"
-                        },
-                        "data_description": {
-                            "action": "Select how to resolve the invalid geofence settings"
-                        }
-                    }
-                }
-            }
+            "description": "The configured geofence appears to be invalid. Use the fix flow to update latitude/longitude and radius."
         }
     },
     "exceptions": {

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -808,21 +808,7 @@
         },
         "invalid_geofence": {
             "title": "Invalid geofence configuration",
-            "description": "The configured geofence appears to be invalid. Use the fix flow to update latitude/longitude and radius.",
-            "fix_flow": {
-                "step": {
-                    "init": {
-                        "title": "Fix geofence settings",
-                        "description": "Choose how to resolve the invalid geofence settings.",
-                        "data": {
-                            "action": "Action"
-                        },
-                        "data_description": {
-                            "action": "Select how to resolve the invalid geofence settings"
-                        }
-                    }
-                }
-            }
+            "description": "The configured geofence appears to be invalid. Use the fix flow to update latitude/longitude and radius."
         }
     },
     "exceptions": {


### PR DESCRIPTION
## Summary
- remove fix flow definitions from invalid geofence translations
- bridge invalid geofence repair flow to the options flow
- simplify repair flow to avoid unused schema

## Testing
- `pre-commit run --files custom_components/pawcontrol/repairs.py custom_components/pawcontrol/translations/en.json custom_components/pawcontrol/translations/de.json custom_components/pawcontrol/strings.json`
- `pytest tests/test_geofence_options.py tests/test_repairs_flow_options_bridge.py`


------
https://chatgpt.com/codex/tasks/task_e_689e3e1abb948331995dd61a6226f359