### PR TITLE
Refactor compatibility helpers and annotate sensor utilities

### DIFF
--- a/custom_components/pawcontrol/compat.py
+++ b/custom_components/pawcontrol/compat.py
@@ -19,10 +19,11 @@ if ha_entity and hasattr(ha_entity, "EntityCategory"):
     EntityCategory = ha_entity.EntityCategory  # type: ignore[assignment]
 else:  # pragma: no cover - fallback for tests
 
-    class EntityCategory(StrEnum):
+    class _EntityCategory(StrEnum):
         CONFIG = "config"
         DIAGNOSTIC = "diagnostic"
 
+    EntityCategory = _EntityCategory
     if ha_entity is not None:
         ha_entity.EntityCategory = EntityCategory  # type: ignore[attr-defined]
 
@@ -92,9 +93,10 @@ try:  # pragma: no cover - Home Assistant provides the enum
     UnitOfLength = ha_const.UnitOfLength  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - tests without Home Assistant
 
-    class UnitOfLength(StrEnum):
+    class _UnitOfLength(StrEnum):
         METERS = "m"
 
+    UnitOfLength = _UnitOfLength
     if ha_const is not None:  # type: ignore[truthy-bool]
         ha_const.UnitOfLength = UnitOfLength  # type: ignore[attr-defined]
 
@@ -103,10 +105,11 @@ try:  # pragma: no cover - Home Assistant provides the enum
     UnitOfMass = ha_const.UnitOfMass  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - tests without Home Assistant
 
-    class UnitOfMass(StrEnum):
+    class _UnitOfMass(StrEnum):
         GRAMS = "g"
         KILOGRAMS = "kg"
 
+    UnitOfMass = _UnitOfMass
     if ha_const is not None:  # type: ignore[truthy-bool]
         ha_const.UnitOfMass = UnitOfMass  # type: ignore[attr-defined]
 
@@ -115,10 +118,11 @@ try:  # pragma: no cover - Home Assistant provides the enum
     UnitOfTime = ha_const.UnitOfTime  # type: ignore[attr-defined]
 except Exception:  # pragma: no cover - tests without Home Assistant
 
-    class UnitOfTime(StrEnum):
+    class _UnitOfTime(StrEnum):
         SECONDS = "s"
         MINUTES = "min"
         HOURS = "h"
 
+    UnitOfTime = _UnitOfTime
     if ha_const is not None:  # type: ignore[truthy-bool]
         ha_const.UnitOfTime = UnitOfTime  # type: ignore[attr-defined]

--- a/custom_components/pawcontrol/sensor_factory.py
+++ b/custom_components/pawcontrol/sensor_factory.py
@@ -297,7 +297,7 @@ def create_dog_sensors(
     ]
 
 
-CLASS_MAP = {
+CLASS_MAP: dict[str, dict[str, str | None]] = {
     "battery_level": {
         "device_class": "battery",
         "state_class": "measurement",
@@ -331,7 +331,7 @@ CLASS_MAP = {
 }
 
 
-def _apply_class_map(self, key: str):
+def _apply_class_map(self, key: str) -> None:
     meta = CLASS_MAP.get(key)
     if not meta:
         return
@@ -342,7 +342,7 @@ def _apply_class_map(self, key: str):
         self._attr_native_unit_of_measurement = unit
 
 
-def _apply_classes_from_key(self, key: str):
+def _apply_classes_from_key(self, key: str) -> None:
     if "battery" in key:
         self._attr_device_class = "battery"
         self._attr_state_class = "measurement"


### PR DESCRIPTION
## Summary
- avoid redefinition warnings by isolating compatibility fallbacks
- type and annotate sensor utility helpers

## Testing
- `ruff check custom_components/pawcontrol/compat.py custom_components/pawcontrol/sensor_factory.py`
- `mypy custom_components/pawcontrol/compat.py custom_components/pawcontrol/sensor_factory.py` *(fails: Function is missing a type annotation for one or more arguments, ...)*
- `pytest` *(fails: fixture 'mock_config_entry' not found; AttributeError: 'ServiceRegistry' object attribute 'async_call' is read-only)*

------
https://chatgpt.com/codex/tasks/task_e_689e6ee79dc883319cadcb515e76d707