### PR TITLE
Handle unexpected service call errors

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -5,8 +5,6 @@ from __future__ import annotations
 from math import atan2, cos, isfinite, pi, radians, sin, sqrt
 from typing import TYPE_CHECKING, Any, Final
 
-from homeassistant.exceptions import HomeAssistantError
-
 from .const import EARTH_RADIUS_M
 
 if TYPE_CHECKING:
@@ -96,5 +94,5 @@ async def safe_service_call(
     try:
         await hass.services.async_call(domain, service, data or {}, blocking=blocking)
         return True
-    except (HomeAssistantError, ValueError):
+    except Exception:  # noqa: BLE001 - log-free helper should never raise
         return False


### PR DESCRIPTION
## Summary
- return False for any service invocation error

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py tests/test_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*

------
https://chatgpt.com/codex/tasks/task_e_689efe2a2068833187dbc4cbd6315bf3