### PR TITLE
Add auto-generated test requirements script

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ explicit_package_bases = true
 
 [project.optional-dependencies]
 test = [
-  "pytest>=8.2.0",
+  "pytest>=8.3.0",
   "pytest-asyncio>=1.1.0",
-  "pytest-cov>=5.0.0",
+  "pytest-cov>=5.0",
   "coverage[toml]>=7.6.0"
 ]
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,6 +1,7 @@
-# Test dependencies for Paw Control
+# Auto-generated test requirements. Do not edit manually.
+coverage[toml]>=7.6.0
 homeassistant>=2025.8.0
-pytest>=8.3.0
-pytest-cov>=5.0
 pytest-asyncio>=1.1.0
-pytest-homeassistant-custom-component  # folgt täglich der HA-Version
+pytest-cov>=5.0
+pytest-homeassistant-custom-component  # follows daily HA version
+pytest>=8.3.0

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -1,4 +1,5 @@
 """Generate requirements_test.txt from pyproject optional test dependencies."""
+
 from __future__ import annotations
 
 import pathlib

--- a/tools/generate_requirements.py
+++ b/tools/generate_requirements.py
@@ -1,0 +1,26 @@
+"""Generate requirements_test.txt from pyproject optional test dependencies."""
+from __future__ import annotations
+
+import pathlib
+import tomllib
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+OUTPUT = ROOT / "requirements_test.txt"
+
+EXTRA_DEPS = [
+    "homeassistant>=2025.8.0",
+    "pytest-homeassistant-custom-component  # follows daily HA version",
+]
+
+
+def main() -> None:
+    data = tomllib.loads(PYPROJECT.read_text())
+    test_deps = data.get("project", {}).get("optional-dependencies", {}).get("test", [])
+    deps = sorted(set(test_deps + EXTRA_DEPS))
+    lines = ["# Auto-generated test requirements. Do not edit manually.", *deps, ""]
+    OUTPUT.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add script to derive test requirements from `pyproject.toml`
- document generated test dependencies in `requirements_test.txt`
- update test dependency versions in `pyproject.toml`

## Testing
- `ruff check .`
- `pytest` *(fails: ServiceNotFound: service_not_found)*

------
https://chatgpt.com/codex/tasks/task_e_689eff2d875c8331ad27e7be67b02c83