### PR TITLE
Use asyncio marker for async tests

### DIFF
--- a/tests/test_config_flow_user.py
+++ b/tests/test_config_flow_user.py
@@ -3,7 +3,7 @@ from custom_components.pawcontrol import config_flow as cf
 from homeassistant.core import HomeAssistant
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_config_flow_user_starts(hass: HomeAssistant):
     flow = cf.PawControlConfigFlow()
     flow.hass = hass

--- a/tests/test_device_registry.py
+++ b/tests/test_device_registry.py
@@ -5,7 +5,7 @@ from homeassistant.setup import async_setup_component
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_device_registry_identifiers(hass: HomeAssistant):
     await async_setup_component(hass, DOMAIN, {})
     # Real device registration requires loaded config_entry; smoke-check only here.

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -20,7 +20,7 @@ class DummyCoordinator:
         return self._dog_data[dog_id]
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_diagnostics_redacts_sensitive(hass: HomeAssistant):
     entry = SimpleNamespace(
         entry_id="abc123", version=1, domain=DOMAIN, title="Paw Control"

--- a/tests/test_diagnostics_redaction.py
+++ b/tests/test_diagnostics_redaction.py
@@ -5,7 +5,7 @@ from homeassistant.setup import async_setup_component
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_diagnostics_redacts_sensitive(hass: HomeAssistant):
     await async_setup_component(hass, DOMAIN, {})
     # Fake a config entry and attach some sensitive data in runtime storage

--- a/tests/test_gps_pause_resume.py
+++ b/tests/test_gps_pause_resume.py
@@ -7,7 +7,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 DOMAIN = comp.DOMAIN
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 @pytest.mark.parametrize("expected_lingering_timers", [True])
 async def test_gps_pause_and_resume(hass: HomeAssistant, expected_lingering_timers):
     assert await comp.async_setup(hass, {}) or True

--- a/tests/test_init_smoke.py
+++ b/tests/test_init_smoke.py
@@ -5,7 +5,7 @@ from homeassistant.core import HomeAssistant
 DOMAIN = comp.DOMAIN
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_domain_setup_registers_services(hass: HomeAssistant):
     # Setting up the domain should register services
     assert await comp.async_setup(hass, {}) or True

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -11,7 +11,7 @@ class DummyEntry:
     title = "Dummy"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_create_repair_issue_registers(hass: HomeAssistant):
     issue_reg = ir.async_get(hass)
     create_repair_issue(hass, "missing_door_sensor", DummyEntry())

--- a/tests/test_service_validation.py
+++ b/tests/test_service_validation.py
@@ -6,7 +6,7 @@ from homeassistant.setup import async_setup_component
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_service_validation_no_entries(hass: HomeAssistant):
     # Setup domain (registers services) but no config entry loaded
     await async_setup_component(hass, DOMAIN, {})

--- a/tests/test_services_more.py
+++ b/tests/test_services_more.py
@@ -8,7 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_toggle_geofence_and_purge_storage(hass: HomeAssistant):
     assert await async_setup_component(hass, DOMAIN, {}) or True
 

--- a/tests/test_services_registration.py
+++ b/tests/test_services_registration.py
@@ -5,7 +5,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_services_registered(hass: HomeAssistant):
     entry = MockConfigEntry(domain=DOMAIN, data={}, options={})
     entry.add_to_hass(hass)

--- a/tests/test_services_runtime.py
+++ b/tests/test_services_runtime.py
@@ -8,7 +8,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 DOMAIN = "pawcontrol"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_route_history_list_emits_event(hass: HomeAssistant):
     assert await async_setup_component(hass, DOMAIN, {}) or True
 
@@ -39,7 +39,7 @@ async def test_route_history_list_emits_event(hass: HomeAssistant):
         assert events[0].data["result"][0]["id"] == "r1"
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_gps_post_location_calls_handler(hass: HomeAssistant):
     assert await async_setup_component(hass, DOMAIN, {}) or True
 
@@ -63,7 +63,7 @@ async def test_gps_post_location_calls_handler(hass: HomeAssistant):
         assert called["data"]["latitude"] == 52.5
 
 
-@pytest.mark.anyio
+@pytest.mark.asyncio
 async def test_route_history_list_requires_loaded_entry(hass: HomeAssistant):
     assert await async_setup_component(hass, DOMAIN, {}) or True
     with pytest.raises(Exception):


### PR DESCRIPTION
## Summary
- replace `anyio` markers with `asyncio` in tests to comply with strict markers

## Testing
- `pre-commit run --files tests/test_config_flow_user.py tests/test_device_registry.py tests/test_diagnostics.py tests/test_diagnostics_redaction.py tests/test_gps_pause_resume.py tests/test_init_smoke.py tests/test_repairs.py tests/test_service_validation.py tests/test_services_more.py tests/test_services_registration.py tests/test_services_runtime.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant.config_entries')*

------
https://chatgpt.com/codex/tasks/task_e_689f7c4f41748331af1bb035edb7445f