### PR TITLE
chore: stub home assistant imports

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -12,7 +12,22 @@ from __future__ import annotations
 
 from typing import Final
 
-from homeassistant.const import Platform
+try:  # pragma: no cover - Home Assistant may not be installed
+    from homeassistant.const import Platform
+except Exception:  # pragma: no cover - provide minimal fallback enum
+    from enum import StrEnum
+
+    class Platform(StrEnum):  # type: ignore[missing-class-docstring]
+        BINARY_SENSOR = "binary_sensor"
+        BUTTON = "button"
+        DATETIME = "datetime"
+        DEVICE_TRACKER = "device_tracker"
+        NUMBER = "number"
+        SELECT = "select"
+        SENSOR = "sensor"
+        SWITCH = "switch"
+        TEXT = "text"
+
 
 # Integration domain identifier
 DOMAIN: Final[str] = "pawcontrol"


### PR DESCRIPTION
## Summary
- allow importing without Home Assistant by stubbing types
- provide fallback Platform enum for tests

## Testing
- `pre-commit run --files custom_components/pawcontrol/const.py custom_components/pawcontrol/__init__.py`
- `pytest tests/test_init_smoke.py::test_import -q` *(fails: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_689f7c295b20833180dc990e3223bc8d