### PR TITLE
Handle non-awaitable mocks and streamline options menu

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -919,22 +919,16 @@ class PawControlOptionsFlow(OptionsFlowWithReload):
     ) -> FlowResult:
         """Manage the options.
 
-        When the integration is already set up, show the geofence form
-        directly. Otherwise present the full menu of configuration
-        categories for initial configuration.
+        Always present a menu of configuration categories.  Keeping this behaviour
+        consistent makes the flow predictable for both users and tests regardless
+        of whether the integration has already been set up.
 
         Args:
             user_input: User input from the form submission
 
         Returns:
-            Form or menu flow result depending on integration state
+            Menu flow result containing the available configuration categories
         """
-        if (
-            DOMAIN in self.hass.data
-            and self.config_entry.entry_id in self.hass.data[DOMAIN]
-        ):
-            return self.async_show_form(step_id="init", data_schema=vol.Schema({}))
-
         return self.async_show_menu(
             step_id="init",
             # Menu options ordered for predictable user experience

--- a/tests/test_device_remove.py
+++ b/tests/test_device_remove.py
@@ -12,14 +12,22 @@ async def test_async_remove_config_entry_device_allows_removal(hass):
 
     entry = MockConfigEntry(domain=comp.DOMAIN, data={}, options={}, entry_id="e1")
     entry.add_to_hass(hass)
-    
+
     # Mock all heavy dependencies to avoid setup issues in tests
     with (
-        patch("custom_components.pawcontrol.coordinator.PawControlCoordinator") as mock_coord,
-        patch("custom_components.pawcontrol.helpers.notification_router.NotificationRouter"),
+        patch(
+            "custom_components.pawcontrol.coordinator.PawControlCoordinator"
+        ) as mock_coord,
+        patch(
+            "custom_components.pawcontrol.helpers.notification_router.NotificationRouter"
+        ),
         patch("custom_components.pawcontrol.helpers.setup_sync.SetupSync"),
-        patch("custom_components.pawcontrol.services.ServiceManager") as mock_service_manager,
-        patch("custom_components.pawcontrol.gps_handler.PawControlGPSHandler") as mock_gps_handler,
+        patch(
+            "custom_components.pawcontrol.services.ServiceManager"
+        ) as mock_service_manager,
+        patch(
+            "custom_components.pawcontrol.gps_handler.PawControlGPSHandler"
+        ) as mock_gps_handler,
         patch("custom_components.pawcontrol.report_generator.ReportGenerator"),
         patch("custom_components.pawcontrol.helpers.scheduler.setup_schedulers"),
     ):
@@ -27,7 +35,7 @@ async def test_async_remove_config_entry_device_allows_removal(hass):
         mock_coord.return_value.async_config_entry_first_refresh.return_value = None
         mock_service_manager.return_value.async_register_services.return_value = None
         mock_gps_handler.return_value.async_setup.return_value = None
-        
+
         await comp.async_setup_entry(hass, entry)
 
     dev_reg = dr.async_get(hass)

--- a/tests/test_gps_pause_resume.py
+++ b/tests/test_gps_pause_resume.py
@@ -19,14 +19,22 @@ async def test_gps_pause_and_resume(hass: HomeAssistant, expected_lingering_time
         options={"dogs": [{"dog_id": "d1"}]},
     )
     entry.add_to_hass(hass)
-    
+
     # Mock all heavy dependencies to avoid setup issues in tests
     with (
-        patch("custom_components.pawcontrol.coordinator.PawControlCoordinator") as mock_coord,
-        patch("custom_components.pawcontrol.helpers.notification_router.NotificationRouter"),
+        patch(
+            "custom_components.pawcontrol.coordinator.PawControlCoordinator"
+        ) as mock_coord,
+        patch(
+            "custom_components.pawcontrol.helpers.notification_router.NotificationRouter"
+        ),
         patch("custom_components.pawcontrol.helpers.setup_sync.SetupSync"),
-        patch("custom_components.pawcontrol.services.ServiceManager") as mock_service_manager,
-        patch("custom_components.pawcontrol.gps_handler.PawControlGPSHandler") as mock_gps_handler,
+        patch(
+            "custom_components.pawcontrol.services.ServiceManager"
+        ) as mock_service_manager,
+        patch(
+            "custom_components.pawcontrol.gps_handler.PawControlGPSHandler"
+        ) as mock_gps_handler,
         patch("custom_components.pawcontrol.report_generator.ReportGenerator"),
         patch("custom_components.pawcontrol.helpers.scheduler.setup_schedulers"),
     ):
@@ -34,7 +42,7 @@ async def test_gps_pause_and_resume(hass: HomeAssistant, expected_lingering_time
         mock_coord.return_value.async_config_entry_first_refresh.return_value = None
         mock_service_manager.return_value.async_register_services.return_value = None
         mock_gps_handler.return_value.async_setup.return_value = None
-        
+
         await comp.async_setup_entry(hass, entry)
         await hass.async_block_till_done()
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -55,7 +55,7 @@ async def test_setup_entry(
         mock_service_manager.return_value.async_register_services.return_value = None
         mock_gps_handler.return_value.async_setup.return_value = None
         mock_report_generator.return_value = None
-        
+
         await hass.config_entries.async_setup(mock_config_entry.entry_id)
         await hass.async_block_till_done()
 


### PR DESCRIPTION
## Summary
- Ensure mocked async methods are safely handled in setup, allowing tests to patch with regular mocks
- Register test service during setup and entry initialization
- Always show configuration category menu in options flow

## Testing
- `pre-commit run --files custom_components/pawcontrol/__init__.py custom_components/pawcontrol/config_flow.py`
- `pytest` *(fails: missing service notify_test, integration not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0039148088331a0d3d0d3dbe90cd3