### PR TITLE
fix gps accuracy field and improve logging

### DIFF
--- a/custom_components/pawcontrol/gps_handler.py
+++ b/custom_components/pawcontrol/gps_handler.py
@@ -67,7 +67,7 @@ async def async_update_location(hass: HomeAssistant, call: ServiceCall) -> None:
     dog = _get_dog_id(entry, call)
     lat = float(call.data.get("latitude"))
     lon = float(call.data.get("longitude"))
-    acc = call.data.get("accuracy_m")  # Konsistent mit schema
+    acc = call.data.get("accuracy_m")  # Consistent with schema
     acc = float(acc) if acc is not None else None
 
     # Update safe-zone and live distance via coordinator

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -201,7 +201,7 @@ SERVICE_SCHEMA_GPS_POST_LOCATION = vol.Schema(
         vol.Required("longitude"): vol.All(
             vol.Coerce(float), vol.Range(min=-180.0, max=180.0)
         ),
-        vol.Optional("accuracy"): vol.All(
+        vol.Optional("accuracy_m"): vol.All(
             vol.Coerce(float), vol.Range(min=0.0, max=10000.0)
         ),
         vol.Optional("source", default="manual"): cv.string,
@@ -828,7 +828,7 @@ class ServiceManager:
         dog_id = call.data[CONF_DOG_ID]
         latitude = call.data["latitude"]
         longitude = call.data["longitude"]
-        accuracy = call.data.get("accuracy")
+        accuracy = call.data.get("accuracy_m")
 
         try:
             self._validate_dog_exists(dog_id)
@@ -841,7 +841,7 @@ class ServiceManager:
 
             self.coordinator.update_gps(dog_id, latitude, longitude, accuracy)
             _LOGGER.debug(
-                "Updated GPS for dog %s: %f, %f (accuracy: %s)",
+                "Updated GPS for dog %s: %f, %f (accuracy_m: %s)",
                 dog_id,
                 latitude,
                 longitude,

--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -610,8 +610,8 @@
         "gps_post_location": {
             "name": "Gps Post Location",
             "fields": {
-                "accuracy": {
-                    "name": "Accuracy",
+                "accuracy_m": {
+                    "name": "Accuracy (m)",
                     "description": "No description provided"
                 },
                 "selector": {

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from math import atan2, cos, isfinite, pi, radians, sin, sqrt
 from typing import TYPE_CHECKING, Any, Final
 
+import logging
+
 from .const import EARTH_RADIUS_M
 
 if TYPE_CHECKING:
@@ -94,5 +96,8 @@ async def safe_service_call(
     try:
         await hass.services.async_call(domain, service, data or {}, blocking=blocking)
         return True
-    except Exception:
+    except Exception as err:  # pragma: no cover - broad for safety
+        logging.getLogger(__name__).debug(
+            "Service call %s.%s failed: %s", domain, service, err
+        )
         return False


### PR DESCRIPTION
## Summary
- align `gps_post_location` service schema with `accuracy_m` field
- log failed service calls for easier debugging
- tidy comment wording

## Testing
- `python -m py_compile custom_components/pawcontrol/services.py custom_components/pawcontrol/gps_handler.py custom_components/pawcontrol/utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68a1e8d724fc8331895dd750f11640e6