### PR TITLE
Handle negative distances in speed calculation

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -50,7 +50,7 @@ def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:
     """Return speed in km/h given distance in meters and duration in seconds."""
     if not isfinite(duration_s) or duration_s <= _EPS_TIME_S:
         return 0.0
-    if not isfinite(distance_m):
+    if not isfinite(distance_m) or distance_m < 0.0:
         return 0.0
     # Convert m/s to km/h
     return (distance_m / duration_s) * 3.6

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -84,6 +84,10 @@ def test_calculate_speed_kmh_non_finite_distance():
     assert calculate_speed_kmh(float("nan"), 10.0) == 0.0
 
 
+def test_calculate_speed_kmh_negative_distance():
+    assert calculate_speed_kmh(-100.0, 10.0) == 0.0
+
+
 # --------------------------
 # validate_coordinates tests
 # --------------------------


### PR DESCRIPTION
## Summary
- Guard against negative distances in `calculate_speed_kmh`
- Add regression test for negative distance handling

## Testing
- `python -m py_compile custom_components/pawcontrol/utils.py tests/test_utils.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a1e8d724fc8331895dd750f11640e6