### PR TITLE
Handle non-finite coordinates in distance calc

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -23,6 +23,10 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 
     Includes clamping to prevent floating point rounding errors.
     """
+    # Return 0 for any non‑finite coordinate values
+    if not all(isfinite(val) for val in (lat1, lon1, lat2, lon2)):
+        return 0.0
+
     # Early exit to skip trigonometric calculations when coordinates are identical
     if lat1 == lat2 and lon1 == lon2:
         return 0.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -56,6 +56,11 @@ def test_calculate_distance_near_antipodal_stability():
     assert d > 0.9 * math.pi * EARTH_RADIUS_M  # sanity bound
 
 
+def test_calculate_distance_non_finite_values():
+    assert calculate_distance(float("nan"), 0.0, 0.0, 0.0) == 0.0
+    assert calculate_distance(0.0, float("inf"), 0.0, 0.0) == 0.0
+
+
 # --------------------------
 # calculate_speed_kmh tests
 # --------------------------


### PR DESCRIPTION
## Summary
- guard against NaN/Infinity coordinates in `calculate_distance`
- test non-finite inputs for distance calculation

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py tests/test_utils.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a2313dca308331911d1317660cb1b8