### PR TITLE
Expand coverage to full component

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -8,7 +8,7 @@ addopts =
     #--tb=short
     --disable-warnings
     --maxfail=3
-    --cov=custom_components.pawcontrol.const
+    --cov=custom_components.pawcontrol
     --cov-report=term-missing
     --cov-fail-under=95
 markers =


### PR DESCRIPTION
## Summary
- collect coverage for the entire `pawcontrol` custom component

## Testing
- `pytest` *(fails: ImportError: cannot import name 'util' from 'homeassistant')*

------
https://chatgpt.com/codex/tasks/task_e_68a2383771ac8331b592cb02d38b7f59