### PR TITLE
Refactor discovery handlers

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -191,24 +191,28 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         title = discovery_info.get("name") or DEFAULT_TITLE
         return self.async_create_entry(title=str(title), data=data)
 
+    async def _async_validate_and_handle_discovery(
+        self, source: str, discovery_info: Any
+    ) -> FlowResult:
+        """Validate discovery info type and delegate to handler."""
+        if not isinstance(discovery_info, dict):
+            return self.async_abort(reason="not_supported")
+        return await self._handle_discovery(source, discovery_info)
+
     async def async_step_dhcp(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle DHCP discovery."""
         # We don't import homeassistant.components.dhcp at module time – tests stay clean.
-        if not isinstance(discovery_info, dict):
-            return self.async_abort(reason="not_supported")
-        return await self._handle_discovery("dhcp", discovery_info)
+        return await self._async_validate_and_handle_discovery("dhcp", discovery_info)
 
     async def async_step_zeroconf(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle Zeroconf discovery."""
-        if not isinstance(discovery_info, dict):
-            return self.async_abort(reason="not_supported")
-        return await self._handle_discovery("zeroconf", discovery_info)
+        return await self._async_validate_and_handle_discovery(
+            "zeroconf", discovery_info
+        )
 
     async def async_step_usb(self, discovery_info: dict[str, Any]) -> FlowResult:
         """Handle USB discovery."""
-        if not isinstance(discovery_info, dict):
-            return self.async_abort(reason="not_supported")
-        return await self._handle_discovery("usb", discovery_info)
+        return await self._async_validate_and_handle_discovery("usb", discovery_info)
 
     # --- REAUTH FLOW ---
 

--- a/tests/test_config_flow_discovery.py
+++ b/tests/test_config_flow_discovery.py
@@ -1,0 +1,32 @@
+from unittest.mock import AsyncMock
+
+import pytest
+from custom_components.pawcontrol import config_flow
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.parametrize("step", ["dhcp", "zeroconf", "usb"])
+async def test_discovery_invalid_info_aborts(hass, step):
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+    method = getattr(flow, f"async_step_{step}")
+    result = await method(None)  # type: ignore[arg-type]
+    assert result["type"] == "abort"
+    assert result["reason"] == "not_supported"
+
+
+@pytest.mark.parametrize(
+    "step, source",
+    [("dhcp", "dhcp"), ("zeroconf", "zeroconf"), ("usb", "usb")],
+)
+async def test_discovery_creates_entry(hass, monkeypatch, step, source):
+    flow = config_flow.ConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+    monkeypatch.setattr(config_flow, "_can_connect", AsyncMock(return_value=True))
+    discovery_info = {"mac": "aa:bb:cc:dd:ee:ff", "name": "Device"}
+    result = await getattr(flow, f"async_step_{step}")(discovery_info)
+    assert result["type"] == "create_entry"
+    assert result["data"][config_flow.CONF_SOURCE] == source


### PR DESCRIPTION
## Summary
- centralize discovery validation and handling in config flow
- test discovery flows for invalid input and successful entries

## Testing
- `ruff check custom_components/pawcontrol/config_flow.py tests/test_config_flow_discovery.py`
- `pytest` *(fails: Required test coverage of 95% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68a23d6c4c6c8331a207e665d9f4c503