### PR TITLE
feat: add structured exception helpers

### DIFF
--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -54,6 +54,16 @@ class PawControlError(Exception):
             result = f"[{self.error_code}] {result}"
         return result
 
+    def to_dict(self) -> dict[str, Any]:
+        """Return a dictionary representation of the error."""
+        return {
+            "type": self.__class__.__name__,
+            "message": self.args[0] if self.args else "",
+            "error_code": self.error_code,
+            "details": self.details,
+            "recoverable": self.recoverable,
+        }
+
 
 class ConfigurationError(PawControlError):
     """Raised when there are configuration-related errors.
@@ -669,13 +679,14 @@ def wrap_exception(
     details = {"original_exception": str(original_exception)}
     if additional_details:
         details.update(additional_details)
-
-    return PawControlError(
+    error = PawControlError(
         message,
         error_code=error_code or "WRAPPED_EXCEPTION",
         details=details,
         recoverable=recoverable,
     )
+    error.__cause__ = original_exception
+    return error
 
 
 def create_validation_error(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,39 @@
+"""Tests for exception helper utilities."""
+
+from custom_components.pawcontrol.exceptions import (
+    DogNotFoundError,
+    PawControlError,
+    wrap_exception,
+)
+
+
+def test_pawcontrol_error_to_dict() -> None:
+    """PawControlError exposes structured data."""
+    err = PawControlError(
+        "base error",
+        error_code="BASE",
+        details={"foo": "bar"},
+        recoverable=True,
+    )
+    assert err.to_dict() == {
+        "type": "PawControlError",
+        "message": "base error",
+        "error_code": "BASE",
+        "details": {"foo": "bar"},
+        "recoverable": True,
+    }
+
+
+def test_dog_not_found_to_dict() -> None:
+    """Subclass includes specific structured fields."""
+    err = DogNotFoundError("abc123")
+    data = err.to_dict()
+    assert data["error_code"] == "DOG_NOT_FOUND"
+    assert data["details"] == {"dog_id": "abc123"}
+
+
+def test_wrap_exception_preserves_cause() -> None:
+    """wrap_exception links back to original exception."""
+    original = ValueError("boom")
+    wrapped = wrap_exception("do_stuff", original)
+    assert wrapped.__cause__ is original


### PR DESCRIPTION
## Summary
- add `to_dict` helper on `PawControlError`
- preserve original exceptions in `wrap_exception`
- test exception helper utilities

## Testing
- `ruff check custom_components/pawcontrol/exceptions.py tests/test_exceptions.py`
- `pytest tests/test_exceptions.py --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68a23e313ce08331947314db3da44c61