### PR TITLE
Improve discovery helpers

### DIFF
--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -8,11 +8,11 @@ Key rules:
 
 from __future__ import annotations
 
+import asyncio
 import importlib
 from typing import Any, Final
 
 DOMAIN: Final = "pawcontrol"
-
 
 def _mod(name: str):
     """Best-effort importer that returns None if the module is missing."""
@@ -20,6 +20,19 @@ def _mod(name: str):
         return importlib.import_module(name)
     except Exception:
         return None
+
+
+async def _probe_socket(host: str, port: int, timeout: float = 1.0) -> bool:
+    """Attempt to open a TCP connection to *host:port* with a timeout."""
+    try:
+        conn = asyncio.open_connection(host, port)
+        reader, writer = await asyncio.wait_for(conn, timeout=timeout)
+        writer.close()
+        if hasattr(writer, "wait_closed"):
+            await writer.wait_closed()
+        return True
+    except Exception:
+        return False
 
 
 async def can_connect_pawtracker(hass, data: dict[str, Any]) -> bool:
@@ -37,8 +50,18 @@ async def can_connect_pawtracker(hass, data: dict[str, Any]) -> bool:
     dev = str(
         data.get("device_id") or data.get("serial") or data.get("mac") or ""
     ).lower()
+
     if dev.startswith("usb:"):
-        # We assume it's connectable; real-world: attempt a quick port open with a timeout.
+        # Try to open the device via pyserial if available
+        serial_mod = _mod("serial")
+        if serial_mod is not None:
+            try:
+                ser = serial_mod.Serial(dev[4:], timeout=0.5)
+                ser.close()
+                return True
+            except Exception:
+                return False
+        # If pyserial is not installed we fall back to permissive True
         return True
 
     # Zeroconf props may carry a host/port
@@ -46,8 +69,9 @@ async def can_connect_pawtracker(hass, data: dict[str, Any]) -> bool:
     host = data.get("host") or props.get("host")
     port = data.get("port") or props.get("port")
     if host and str(port or "").isdigit():
-        # Assume reachable; production code would try a socket connect with small timeout.
-        return True
+        if await _probe_socket(host, int(port)):
+            return True
+        return False
 
     # DHCP discovery commonly provides MAC/IP; again, don't hard fail here.
     if data.get("mac") or data.get("ip"):
@@ -62,7 +86,7 @@ async def can_connect_pawtracker(hass, data: dict[str, Any]) -> bool:
 
 def normalize_dhcp_info(info: dict[str, Any]) -> dict[str, Any]:
     """Normalize a DHCP discovery dict into a compact data mapping we can store."""
-    mac = str(info.get("macaddress") or info.get("mac") or "").lower()
+    mac = str(info.get("macaddress") or info.get("mac") or "").replace("-", ":").lower()
     ip = info.get("ip") or info.get("ipv4") or info.get("ipv6")
     hostname = info.get("hostname") or info.get("host")
     return {"mac": mac, "ip": ip, "hostname": hostname}
@@ -70,9 +94,10 @@ def normalize_dhcp_info(info: dict[str, Any]) -> dict[str, Any]:
 
 def normalize_zeroconf_info(info: dict[str, Any]) -> dict[str, Any]:
     """Normalize Zeroconf discovery data."""
-    name = info.get("name")
-    host = info.get("host")
+    name = str(info.get("name") or "").rstrip(".") or None
+    host = info.get("host") or info.get("ip")
     port = info.get("port")
+    port = int(port) if str(port or "").isdigit() else None
     properties = info.get("properties") or {}
     return {"name": name, "host": host, "port": port, "properties": properties}
 
@@ -85,11 +110,12 @@ def normalize_usb_info(info: dict[str, Any]) -> dict[str, Any]:
     serial = info.get("serial_number") or info.get("serial")
     manufacturer = info.get("manufacturer")
     description = info.get("description")
-    device_id = (
-        f"usb:VID_{str(vid).upper()}&PID_{str(pid).upper()}"
-        if vid and pid
-        else "usb:unknown"
-    )
+    try:
+        vid_hex = f"{int(str(vid), 16):04X}"
+        pid_hex = f"{int(str(pid), 16):04X}"
+        device_id = f"usb:VID_{vid_hex}&PID_{pid_hex}"
+    except Exception:
+        device_id = "usb:unknown"
     return {
         "vid": vid,
         "pid": pid,

--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -14,6 +14,7 @@ from typing import Any, Final
 
 DOMAIN: Final = "pawcontrol"
 
+
 def _mod(name: str):
     """Best-effort importer that returns None if the module is missing."""
     try:
@@ -69,9 +70,7 @@ async def can_connect_pawtracker(hass, data: dict[str, Any]) -> bool:
     host = data.get("host") or props.get("host")
     port = data.get("port") or props.get("port")
     if host and str(port or "").isdigit():
-        if await _probe_socket(host, int(port)):
-            return True
-        return False
+        return bool(await _probe_socket(host, int(port)))
 
     # DHCP discovery commonly provides MAC/IP; again, don't hard fail here.
     if data.get("mac") or data.get("ip"):

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,13 +1,12 @@
 import asyncio
-import pytest
 
+import pytest
 from custom_components.pawcontrol.discovery import (
     can_connect_pawtracker,
     normalize_dhcp_info,
-    normalize_zeroconf_info,
     normalize_usb_info,
+    normalize_zeroconf_info,
 )
-
 
 pytestmark = pytest.mark.asyncio
 
@@ -51,7 +50,12 @@ def test_normalize_dhcp_info():
 
 
 def test_normalize_zeroconf_info():
-    info = {"name": "Test._tcp.local.", "host": "test.local", "port": "80", "properties": {}}
+    info = {
+        "name": "Test._tcp.local.",
+        "host": "test.local",
+        "port": "80",
+        "properties": {},
+    }
     assert normalize_zeroconf_info(info) == {
         "name": "Test._tcp.local",
         "host": "test.local",
@@ -61,7 +65,13 @@ def test_normalize_zeroconf_info():
 
 
 def test_normalize_usb_info():
-    info = {"vid": "10c4", "pid": "ea60", "serial_number": "123", "manufacturer": "ACME", "description": "USB"}
+    info = {
+        "vid": "10c4",
+        "pid": "ea60",
+        "serial_number": "123",
+        "manufacturer": "ACME",
+        "description": "USB",
+    }
     norm = normalize_usb_info(info)
     assert norm["device_id"] == "usb:VID_10C4&PID_EA60"
     assert norm["vid"] == "10c4"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,68 @@
+import asyncio
+import pytest
+
+from custom_components.pawcontrol.discovery import (
+    can_connect_pawtracker,
+    normalize_dhcp_info,
+    normalize_zeroconf_info,
+    normalize_usb_info,
+)
+
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.mark.enable_socket
+async def test_can_connect_pawtracker_tcp_success(hass, socket_enabled):
+    async def handle(reader, writer):
+        writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    data = {"host": host, "port": port}
+    try:
+        assert await can_connect_pawtracker(hass, data) is True
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.enable_socket
+async def test_can_connect_pawtracker_tcp_fail(hass, socket_enabled):
+    async def handle(reader, writer):
+        writer.close()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    host, port = server.sockets[0].getsockname()[:2]
+    server.close()
+    await server.wait_closed()
+
+    data = {"host": host, "port": port}
+    assert await can_connect_pawtracker(hass, data) is False
+
+
+def test_normalize_dhcp_info():
+    info = {"macaddress": "AA-BB-CC-DD-EE-FF", "ip": "1.2.3.4", "hostname": "dog"}
+    assert normalize_dhcp_info(info) == {
+        "mac": "aa:bb:cc:dd:ee:ff",
+        "ip": "1.2.3.4",
+        "hostname": "dog",
+    }
+
+
+def test_normalize_zeroconf_info():
+    info = {"name": "Test._tcp.local.", "host": "test.local", "port": "80", "properties": {}}
+    assert normalize_zeroconf_info(info) == {
+        "name": "Test._tcp.local",
+        "host": "test.local",
+        "port": 80,
+        "properties": {},
+    }
+
+
+def test_normalize_usb_info():
+    info = {"vid": "10c4", "pid": "ea60", "serial_number": "123", "manufacturer": "ACME", "description": "USB"}
+    norm = normalize_usb_info(info)
+    assert norm["device_id"] == "usb:VID_10C4&PID_EA60"
+    assert norm["vid"] == "10c4"
+    assert norm["pid"] == "ea60"


### PR DESCRIPTION
## Summary
- improve pawtracker discovery by probing sockets and USB serial lazily
- normalize DHCP, Zeroconf and USB discovery data
- add unit tests for discovery utilities

## Testing
- `pytest --cov-fail-under=0 tests/test_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a23e1cb84483319b31c064954f90c1