### PR TITLE
refactor gps handler signatures

### DIFF
--- a/custom_components/pawcontrol/gps_handler.py
+++ b/custom_components/pawcontrol/gps_handler.py
@@ -112,30 +112,25 @@ class PawControlGPSHandler:
         self.options = options or {}
         self.entry_id: str | None = None  # Will be set by async_setup_entry
 
-    async def async_update_location(
-        self, hass: HomeAssistant, call: ServiceCall
-    ) -> None:
-        await async_update_location(hass, call)
+    async def async_update_location(self, call: ServiceCall) -> None:
+        """Update GPS location via shared helper."""
+        await async_update_location(self.hass, call)
 
     async def async_setup(self) -> None:
         """Set up GPS handler (placeholder for future enhancements)."""
         return
 
-    async def async_start_walk(self, hass: HomeAssistant, call: ServiceCall) -> None:
-        await async_start_walk(hass, call)
+    async def async_start_walk(self, call: ServiceCall) -> None:
+        await async_start_walk(self.hass, call)
 
-    async def async_end_walk(self, hass: HomeAssistant, call: ServiceCall) -> None:
-        await async_end_walk(hass, call)
+    async def async_end_walk(self, call: ServiceCall) -> None:
+        await async_end_walk(self.hass, call)
 
-    async def async_pause_tracking(
-        self, hass: HomeAssistant, call: ServiceCall
-    ) -> None:
-        await async_pause_tracking(hass, call)
+    async def async_pause_tracking(self, call: ServiceCall) -> None:
+        await async_pause_tracking(self.hass, call)
 
-    async def async_resume_tracking(
-        self, hass: HomeAssistant, call: ServiceCall
-    ) -> None:
-        await async_resume_tracking(hass, call)
+    async def async_resume_tracking(self, call: ServiceCall) -> None:
+        await async_resume_tracking(self.hass, call)
 
     async def async_generate_diagnostics(self) -> dict[str, Any]:
         """Generate GPS diagnostics data."""

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -934,7 +934,7 @@ class ServiceManager:
             if not (-180 <= longitude <= 180):
                 raise ServiceValidationError(f"Invalid longitude: {longitude}")
 
-            await gps_handler.async_update_location(self.hass, call)
+            await gps_handler.async_update_location(call)
             _LOGGER.debug(
                 "Updated GPS for dog %s: %f, %f (accuracy_m: %s)",
                 dog_id,


### PR DESCRIPTION
## Summary
- simplify PawControlGPSHandler methods by using internal hass reference
- update service call to use new GPS handler signature

## Testing
- `pre-commit run --files custom_components/pawcontrol/gps_handler.py custom_components/pawcontrol/services.py`
- `pytest` *(fails: test_setup_entry, test_unload_entry, test_setup_entry_fails_on_exception)*

------
https://chatgpt.com/codex/tasks/task_e_68a243c9abb08331b51c2aacf69f4659