### PR TITLE
Fix test interference and GPS location service

### DIFF
--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -656,7 +656,7 @@ class PawControlDateTimeWithStorage(PawControlDateTimeEntity, DateTimeEntity):
                     {
                         "is_future": self._current_value > now,
                         "is_today": self._current_value.date() == now.date(),
-                        "days_until": diff.days if diff.days > 0 else 0,
+                        "days_until": max(0, diff.days),
                         "hours_until": diff.total_seconds() / 3600
                         if diff.total_seconds() > 0
                         else 0,

--- a/custom_components/pawcontrol/helpers/__init__.py
+++ b/custom_components/pawcontrol/helpers/__init__.py
@@ -10,6 +10,6 @@ __all__ = [
     "NotificationRouter",
     "PawControlScheduler",
     "SetupSync",
-    "setup_schedulers",
     "cleanup_schedulers",
+    "setup_schedulers",
 ]

--- a/custom_components/pawcontrol/report_generator.py
+++ b/custom_components/pawcontrol/report_generator.py
@@ -263,7 +263,7 @@ class ReportGenerator:
                 )
 
                 # Write data for each dog
-                for _dog_id, dog_data in report_data["dogs"].items():
+                for dog_data in report_data["dogs"].values():
                     writer.writerow(
                         [
                             dog_data["name"],
@@ -303,7 +303,7 @@ class ReportGenerator:
         lines.append(f"Scope: {report_data['scope'].capitalize()}")
         lines.append("=" * 50)
 
-        for _dog_id, dog_data in report_data["dogs"].items():
+        for dog_data in report_data["dogs"].values():
             lines.append(f"\n🐕 {dog_data['name']}")
             lines.append("-" * 30)
 

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -934,7 +934,7 @@ class ServiceManager:
             if not (-180 <= longitude <= 180):
                 raise ServiceValidationError(f"Invalid longitude: {longitude}")
 
-            await gps_handler.async_update_location(call)
+            await gps_handler.async_update_location(self.hass, call)
             _LOGGER.debug(
                 "Updated GPS for dog %s: %f, %f (accuracy_m: %s)",
                 dog_id,

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,7 +8,7 @@ addopts =
     #--tb=short
     --disable-warnings
     --maxfail=3
-    --cov=custom_components.const
+    --cov=custom_components.pawcontrol.const
     --cov-report=term-missing
     --cov-fail-under=95
 markers =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ except ModuleNotFoundError:  # pragma: no cover - minimal stubs for tests
             self.data = data or {}
             self.options = options or {}
 
-        def add_to_hass(self, hass):  # noqa: D401 - stub method
+        def add_to_hass(self, hass):
             return None
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -38,6 +38,9 @@ format_coordinates = _mod.format_coordinates
 safe_service_call = _mod.safe_service_call
 validate_coordinates = _mod.validate_coordinates
 
+# Remove temporary modules to avoid polluting sys.modules for other tests
+sys.modules.pop("custom_components.pawcontrol", None)
+
 # --------------------------
 # calculate_distance tests
 # --------------------------


### PR DESCRIPTION
## Summary
- repair gps_post_location service to supply Home Assistant instance
- clean up test module injection to avoid polluting sys.modules
- point coverage to pawcontrol const module

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a24b616c0083319ff626bd1da4bc44