### PR TITLE
Fix async markers in discovery tests

### DIFF
--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -8,9 +8,8 @@ from custom_components.pawcontrol.discovery import (
     normalize_zeroconf_info,
 )
 
-pytestmark = pytest.mark.asyncio
 
-
+@pytest.mark.asyncio
 @pytest.mark.enable_socket
 async def test_can_connect_pawtracker_tcp_success(hass, socket_enabled):
     async def handle(reader, writer):
@@ -26,6 +25,7 @@ async def test_can_connect_pawtracker_tcp_success(hass, socket_enabled):
         await server.wait_closed()
 
 
+@pytest.mark.asyncio
 @pytest.mark.enable_socket
 async def test_can_connect_pawtracker_tcp_fail(hass, socket_enabled):
     async def handle(reader, writer):


### PR DESCRIPTION
## Summary
- remove module-level asyncio marker in discovery tests
- mark individual async discovery tests with `@pytest.mark.asyncio`

## Testing
- `pytest tests/test_discovery.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2509490f88331930de94756ddba44