### PR TITLE
Fix incorrect type annotation for GPS route point limit

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -7,6 +7,7 @@ and various thresholds and limits.
 Constants are organized by category and follow Home Assistant's Platinum
 standards with complete type annotations and comprehensive documentation.
 """
+
 from typing import Final
 from homeassistant.const import Platform
 
@@ -45,7 +46,7 @@ EARTH_RADIUS_M: Final[float] = 6_371_000.0
 
 # GPS accuracy and movement thresholds
 GPS_MIN_ACCURACY = 100  # meters - minimum acceptable GPS accuracy
-GPS_MAX_POINTS_PER_ROUTE: [int] = 10_000  # maximum GPS points stored per route
+GPS_MAX_POINTS_PER_ROUTE: Final[int] = 10_000  # maximum GPS points stored per route
 GPS_POINT_FILTER_DISTANCE: Final[int] = (
     5  # meters - minimum distance between stored points
 )


### PR DESCRIPTION
## Summary
- Correct constant definition for GPS_MAX_POINTS_PER_ROUTE to use `Final[int]` instead of a list annotation

## Testing
- `pre-commit run --files custom_components/pawcontrol/const.py`
- `pytest -q` *(fails: Module custom_components.pawcontrol was never imported, Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68a2b61b50cc8331a79fe91959e3e283