### PR TITLE
Handle missing coordinator in report generator

### DIFF
--- a/custom_components/pawcontrol/report_generator.py
+++ b/custom_components/pawcontrol/report_generator.py
@@ -89,13 +89,22 @@ class ReportGenerator:
             "dogs": {},
         }
 
+        coordinator = self.coordinator
+        if coordinator is None:
+            _LOGGER.warning("No coordinator available when generating report")
+            return report_data
+
         for dog in dogs:
             dog_id = dog.get(CONF_DOG_ID)
             if not dog_id:
                 continue
 
             dog_name = dog.get(CONF_DOG_NAME, dog_id)
-            dog_data = self.coordinator.get_dog_data(dog_id)
+            try:
+                dog_data = coordinator.get_dog_data(dog_id)
+            except AttributeError:
+                _LOGGER.debug("Coordinator missing get_dog_data when generating report")
+                continue
 
             # Compile statistics
             dog_report = {


### PR DESCRIPTION
## Summary
- Guard report generation when coordinator isn't available

## Testing
- `pre-commit run --files custom_components/pawcontrol/report_generator.py`
- `pytest -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_e_68a2bae639a483319686b42307cf12e5