### PR TITLE
Fix indentation in speed calculation and stub HA util for tests

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -53,7 +53,7 @@ def calculate_speed_kmh(distance_m: float, duration_s: float) -> float:
     if not isfinite(distance_m) or distance_m < 0:
         return 0.0
     # Convert m/s to km/h
-   return (distance_m / duration_s) * 3.6
+    return (distance_m / duration_s) * 3.6
 
 
 def validate_coordinates(lat: float, lon: float) -> bool:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,20 @@ homeassistant = types.ModuleType("homeassistant")
 ha_const = types.ModuleType("homeassistant.const")
 
 
+# Minimal homeassistant.util.logging stub for pytest plugin
+ha_util = types.ModuleType("homeassistant.util")
+ha_logging = types.ModuleType("homeassistant.util.logging")
+
+
+def _log_exception(format_err, *args):
+    """Dummy log_exception function for tests."""
+    return None
+
+
+ha_logging.log_exception = _log_exception
+ha_util.logging = ha_logging
+
+
 class Platform:
     BINARY_SENSOR = "binary_sensor"
     BUTTON = "button"
@@ -25,8 +39,11 @@ class Platform:
 
 ha_const.Platform = Platform
 homeassistant.const = ha_const
+homeassistant.util = ha_util
 sys.modules["homeassistant"] = homeassistant
 sys.modules["homeassistant.const"] = ha_const
+sys.modules["homeassistant.util"] = ha_util
+sys.modules["homeassistant.util.logging"] = ha_logging
 
 # Set up package stubs for custom_components.pawcontrol
 ROOT = pathlib.Path(__file__).resolve().parents[1]


### PR DESCRIPTION
## Summary
- fix indentation error in `calculate_speed_kmh`
- add minimal `homeassistant.util.logging` stub in tests to satisfy pytest plugin

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c15e1f748331a2ea320fe55ff8d6