### PR TITLE
Log failed service calls for easier debugging

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from math import atan2, cos, isfinite, pi, radians, sin, sqrt
 from typing import TYPE_CHECKING, Any, Final
 
 from .const import EARTH_RADIUS_M
+
+
+_LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -94,5 +98,6 @@ async def safe_service_call(
     try:
         await hass.services.async_call(domain, service, data or {}, blocking=blocking)
         return True
-    except Exception:
+    except Exception as err:  # noqa: BLE001 intentionally broad
+        _LOGGER.debug("Service call failed for %s.%s: %s", domain, service, err)
         return False

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import logging
 import pathlib
 import types
 import sys
@@ -113,7 +114,7 @@ def test_format_coordinates():
     assert format_coordinates(1.23456789, 9.87654321) == "1.234568,9.876543"
 
 
-def test_safe_service_call():
+def test_safe_service_call(caplog):
     class DummyServices:
         def __init__(self):
             self.called = False
@@ -128,6 +129,8 @@ def test_safe_service_call():
             self.services = DummyServices()
 
     hass = DummyHass()
-    assert asyncio.run(safe_service_call(hass, "test", "service"))
-    assert hass.services.called
-    assert not asyncio.run(safe_service_call(hass, "fail", "service"))
+    with caplog.at_level(logging.DEBUG):
+        assert asyncio.run(safe_service_call(hass, "test", "service"))
+        assert hass.services.called
+        assert not asyncio.run(safe_service_call(hass, "fail", "service"))
+    assert "Service call failed for fail.service" in caplog.text


### PR DESCRIPTION
## Summary
- log errors when service calls fail
- test logging behavior in safe_service_call

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a2c4833e8c8331a141ea599bdf9ccf