### PR TITLE
fix: remove manual entry state assignment

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -18,10 +18,7 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.config_entries import (
-    ConfigEntry,
-    ConfigEntryState,
-)
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import (
     ConfigEntryNotReady,
@@ -284,7 +281,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             entry.entry_id,
         )
 
-    entry.state = ConfigEntryState.LOADED
     return True
 
 


### PR DESCRIPTION
## Summary
- avoid directly setting ConfigEntry.state

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2c5fa24f483318c999ca366680848