### PR TITLE
fix: use valid integration config URL

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -37,6 +37,7 @@ from .const import (
     CONF_DOGS,
     DOMAIN,
     ICONS,
+    INTEGRATION_URL,
     INTEGRATION_VERSION,
     MODULE_FEEDING,
     MODULE_GPS,
@@ -1071,7 +1072,7 @@ class VisitorModeBinarySensor(CoordinatorEntity, BinarySensorEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version=INTEGRATION_VERSION,
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1109,7 +1110,7 @@ class EmergencyModeBinarySensor(CoordinatorEntity, BinarySensorEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version=INTEGRATION_VERSION,
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1160,7 +1161,7 @@ class SystemHealthyBinarySensor(CoordinatorEntity, BinarySensorEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version=INTEGRATION_VERSION,
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -33,6 +33,7 @@ from .const import (
     CONF_DOGS,
     DOMAIN,
     ICONS,
+    INTEGRATION_URL,
     MODULE_FEEDING,
     MODULE_GROOMING,
     MODULE_HEALTH,
@@ -1342,7 +1343,7 @@ class DailyResetButton(ButtonEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1391,7 +1392,7 @@ class GenerateReportButton(ButtonEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1444,7 +1445,7 @@ class SyncSetupButton(ButtonEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1492,7 +1493,7 @@ class ToggleVisitorModeButton(ButtonEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property

--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -17,6 +17,11 @@ DOMAIN: Final[str] = "pawcontrol"
 # Integration version for internal tracking
 INTEGRATION_VERSION = "1.0.0"
 
+# Link to this integration's configuration page in Home Assistant
+INTEGRATION_URL: Final[str] = (
+    f"https://my.home-assistant.io/redirect/integration/?domain={DOMAIN}"
+)
+
 # ==============================================================================
 # PLATFORMS
 # ==============================================================================

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -36,6 +36,7 @@ from .const import (
     CONF_DOGS,
     DOMAIN,
     ICONS,
+    INTEGRATION_URL,
     MODULE_FEEDING,
     MODULE_GROOMING,
     MODULE_HEALTH,
@@ -1255,7 +1256,7 @@ class DailyResetDateTime(DateTimeEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1363,7 +1364,7 @@ class WeeklyReportDateTime(DateTimeEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property

--- a/custom_components/pawcontrol/entity.py
+++ b/custom_components/pawcontrol/entity.py
@@ -50,6 +50,7 @@ from .const import (
     DOMAIN,
     ENTITY_UPDATE_DEBOUNCE_SECONDS,
     ICONS,
+    INTEGRATION_URL,
     INTEGRATION_VERSION,
     STATUS_READY,
 )
@@ -162,7 +163,7 @@ class PawControlEntity(CoordinatorEntity["PawControlCoordinator"]):
                 manufacturer="Paw Control",
                 model="Smart Dog Manager",
                 sw_version=INTEGRATION_VERSION,
-                configuration_url=f"/config/integrations/integration/{DOMAIN}",
+                configuration_url=INTEGRATION_URL,
                 suggested_area="Pet Care",  # Platinum: suggested area
             )
         except Exception as err:

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -47,6 +47,7 @@ from .const import (
     GROOMING_TRIM,
     GROOMING_TYPES,
     ICONS,
+    INTEGRATION_URL,
     INTENSITY_HIGH,
     INTENSITY_LOW,
     INTENSITY_MEDIUM,
@@ -1166,7 +1167,7 @@ class ExportFormatSelect(SelectEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property
@@ -1240,7 +1241,7 @@ class NotificationPrioritySelect(SelectEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -34,6 +34,7 @@ from .const import (
     CONF_DOGS,
     DOMAIN,
     ICONS,
+    INTEGRATION_URL,
     MODULE_FEEDING,
     MODULE_GPS,
     MODULE_GROOMING,
@@ -62,7 +63,7 @@ def _get_system_device_info() -> DeviceInfo:
         manufacturer="Paw Control",
         model="Smart Dog Manager",
         sw_version="1.1.0",
-        configuration_url=f"/config/integrations/integration/{DOMAIN}",
+        configuration_url=INTEGRATION_URL,
     )
 
 

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_DOGS,
     DOMAIN,
     ICONS,
+    INTEGRATION_URL,
     MAX_NOTE_LENGTH,
     MAX_STRING_LENGTH,
     MODULE_GROOMING,
@@ -1046,7 +1047,7 @@ class ExportPathText(TextEntity):
             manufacturer="Paw Control",
             model="Smart Dog Manager",
             sw_version="1.1.0",
-            configuration_url=f"/config/integrations/integration/{DOMAIN}",
+            configuration_url=INTEGRATION_URL,
         )
 
     @property


### PR DESCRIPTION
## Summary
- fix ValueError by replacing invalid configuration_url with my.home-assistant redirect
- centralize configuration URL constant

## Testing
- `pre-commit run --files custom_components/pawcontrol/const.py custom_components/pawcontrol/binary_sensor.py custom_components/pawcontrol/datetime.py custom_components/pawcontrol/switch.py custom_components/pawcontrol/text.py custom_components/pawcontrol/select.py custom_components/pawcontrol/button.py custom_components/pawcontrol/entity.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c5e200a88331927fd06ff163bc00