### PR TITLE
Validate coordinates before formatting

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -79,8 +79,19 @@ def validate_coordinates(lat: float, lon: float) -> bool:
 
 
 def format_coordinates(lat: float, lon: float) -> str:
-    """Format coordinates for display."""
-    return f"{lat:.6f},{lon:.6f}"
+    """Format coordinates for display.
+
+    Validates the provided latitude and longitude and raises ``ValueError`` if
+    they fall outside the accepted ranges or cannot be converted to floating
+    point numbers.
+    """
+
+    if not validate_coordinates(lat, lon):
+        raise ValueError(f"Invalid coordinates: ({lat}, {lon})")
+
+    # Ensure consistent float formatting even if inputs are ``Decimal`` or
+    # other ``SupportsFloat`` instances.
+    return f"{float(lat):.6f},{float(lon):.6f}"
 
 
 async def safe_service_call(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -114,6 +114,11 @@ def test_format_coordinates():
     assert format_coordinates(1.23456789, 9.87654321) == "1.234568,9.876543"
 
 
+def test_format_coordinates_invalid():
+    with pytest.raises(ValueError):
+        format_coordinates(91.0, 0.0)
+
+
 def test_safe_service_call(caplog):
     class DummyServices:
         def __init__(self):


### PR DESCRIPTION
## Summary
- validate coordinates before formatting them
- test coordinate formatter rejects invalid inputs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a2c93f4d30833187c28edb1b92d51e