### PR TITLE
Refactor distance clamping and add edge case tests

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -38,14 +38,14 @@ def calculate_distance(lat1: float, lon1: float, lat2: float, lon2: float) -> fl
 
     a = s_dphi * s_dphi + cos(phi1) * cos(phi2) * s_dlam * s_dlam
 
-    # Clamp against numerical out-of-range values
-    if a <= 0.0:
+    # Clamp against numerical out-of-range values before processing
+    a = max(0.0, min(1.0, a))
+    if a == 0.0:
         return 0.0
-    if a >= 1.0:
+    if a == 1.0:
         # Antipodal case → half of Earth's circumference
         return pi * EARTH_RADIUS_M
 
-    a = min(1.0, max(0.0, a))
     c = 2.0 * atan2(sqrt(a), sqrt(1.0 - a))
     return EARTH_RADIUS_M * c
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib.util
 import logging
+import math
 import pathlib
 import types
 import sys
@@ -95,6 +96,10 @@ def test_calculate_speed_kmh_zero_duration():
 def test_calculate_distance_variants():
     assert calculate_distance(0.0, 0.0, 0.0, 0.0) == 0.0
     assert calculate_distance(50.0, 10.0, 50.0, 10.1) > 0.0
+    assert calculate_distance(0.0, 0.0, 0.0, 180.0) == pytest.approx(
+        math.pi * const_mod.EARTH_RADIUS_M
+    )
+    assert calculate_distance(80.0, 0.0, 100.0, 180.0) == 0.0
 
 
 @pytest.mark.parametrize(
@@ -104,6 +109,7 @@ def test_calculate_distance_variants():
         ("bad", 20.0, False),
         (True, 20.0, False),
         (100.0, 20.0, False),
+        (float("nan"), 20.0, False),
     ],
 )
 def test_validate_coordinates(lat, lon, expected):


### PR DESCRIPTION
## Summary
- Refactor distance calculation to clamp values before processing and handle antipodal/zero cases cleanly
- Test additional distance and coordinate edge cases for full coverage

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a2c93f4d30833187c28edb1b92d51e