### PR TITLE
Avoid config entity category for binary sensors

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -963,7 +963,7 @@ class GeofenceAlertsActiveBinarySensor(
             entity_key="geofence_alerts_active",
             translation_key="geofence_alerts_active",
             device_class=BinarySensorDeviceClass.RUNNING,
-            entity_category=EntityCategory.CONFIG,
+            entity_category=EntityCategory.DIAGNOSTIC,
             icon=ICONS.get("notifications", "mdi:shield-alert"),
         )
 
@@ -1057,7 +1057,7 @@ class VisitorModeBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     _attr_has_entity_name = True
     _attr_device_class = BinarySensorDeviceClass.RUNNING
-    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coordinator: PawControlCoordinator, entry: ConfigEntry) -> None:
         """Initialize the visitor mode binary sensor."""


### PR DESCRIPTION
## Summary
- Avoid using `EntityCategory.CONFIG` for binary sensors

## Testing
- `pre-commit run --files custom_components/pawcontrol/binary_sensor.py`
- `pytest tests`

------
https://chatgpt.com/codex/tasks/task_e_68a2cb6a7d988331969dc1a3f95eaf44