### PR TITLE
fix: allow setting config_entry

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -1994,6 +1994,15 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     def config_entry(self, value: ConfigEntry) -> None:
         """Allow Home Assistant to set the config entry on initialization."""
         self.entry = value
+        self.dogs = self.entry.data.get(CONF_DOGS, [])
+
+        new_interval = self._calculate_optimal_update_interval()
+        self.update_interval = timedelta(seconds=new_interval)
+        _LOGGER.debug(
+            "Configuration updated: %d dogs, new interval: %ds",
+            len(self.dogs),
+            new_interval,
+        )
 
     @property
     def available(self) -> bool:


### PR DESCRIPTION
## Summary
- allow Home Assistant to set coordinator config_entry during initialization

## Testing
- `pre-commit run --files custom_components/pawcontrol/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68a88a751844833197376ce01ae94f95