### PR TITLE
Handle import/export step in PawControl options flow

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1084,6 +1084,24 @@ class PawControlOptionsFlow(OptionsFlow):
             ],
         )
 
+    async def async_step_import_export(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Placeholder handler for import/export settings.
+
+        The import/export feature has not yet been implemented. Instead of
+        raising an ``UnknownStep`` error when users navigate to this menu
+        entry, we immediately redirect them back to the main options menu.
+
+        Args:
+            user_input: Not used.
+
+        Returns:
+            Flow result for the initial options step.
+        """
+
+        return await self.async_step_init()
+
     # The remaining methods would follow similar patterns with enhanced
     # validation, modern UI components, and comprehensive error handling
     # ... (Additional methods continue in similar pattern)


### PR DESCRIPTION
## Summary
- prevent UnknownStep errors by adding import/export handler in options flow

## Testing
- `pre-commit run --files custom_components/pawcontrol/config_flow.py`
- `pytest` *(fails: Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68a88a82b928833189a41b6d2a6a1e10