### PR TITLE
Avoid deprecated option flow config_entry assignment

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1049,9 +1049,9 @@ class PawControlOptionsFlow(OptionsFlow):
         Args:
             config_entry: Configuration entry to modify
         """
-        self.config_entry = config_entry
+        self._config_entry = config_entry
         self._current_dog: DogConfigData | None = None
-        self._dogs: list[DogConfigData] = config_entry.data.get(CONF_DOGS, [])
+        self._dogs: list[DogConfigData] = self._config_entry.data.get(CONF_DOGS, [])
         self._navigation_stack: list[str] = []
         self._unsaved_changes: dict[str, Any] = {}
 


### PR DESCRIPTION
## Summary
- store config entry in private attribute within options flow to avoid deprecated direct assignment

## Testing
- `pre-commit run --files custom_components/pawcontrol/config_flow.py`
- `pytest` *(fails: Required test coverage of 95% not reached, Total coverage: 0%)*

------
https://chatgpt.com/codex/tasks/task_e_68a88a8d80f88331a6ff56eda7a99af1