### PR TITLE
Add dashboard configuration translations

### DIFF
--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -28,7 +28,20 @@
           "enable_gps": "GPS Location Tracking",
           "enable_health": "Health Monitoring",
           "enable_visitor_mode": "Visitor Mode",
+          "enable_dashboard": "Dashboard",
           "enable_advanced_features": "Advanced Features"
+        }
+      },
+      "configure_dashboard": {
+        "title": "Configure Dashboard",
+        "description": "Set up dashboard settings for {dog_count} dogs.\n\n{dashboard_info}",
+        "data": {
+          "auto_create_dashboard": "Automatically create dashboard",
+          "create_per_dog_dashboards": "Create per-dog dashboards",
+          "dashboard_theme": "Dashboard Theme",
+          "dashboard_mode": "Dashboard Mode",
+          "show_statistics": "Show statistics",
+          "show_maps": "Show maps"
         }
       },
       "configure_external_entities": {

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -34,7 +34,20 @@
           "enable_gps": "GPS-Ortungsverfolgung",
           "enable_health": "Gesundheitsüberwachung",
           "enable_visitor_mode": "Besuchermodus",
+          "enable_dashboard": "Dashboard",
           "enable_advanced_features": "Erweiterte Funktionen (Dashboard, Verbesserte Benachrichtigungen)"
+        }
+      },
+      "configure_dashboard": {
+        "title": "Dashboard konfigurieren",
+        "description": "Konfiguriere Dashboard-Einstellungen für {dog_count} Hunde.\n\n{dashboard_info}",
+        "data": {
+          "auto_create_dashboard": "Dashboard automatisch erstellen",
+          "create_per_dog_dashboards": "Dashboard pro Hund erstellen",
+          "dashboard_theme": "Dashboard-Theme",
+          "dashboard_mode": "Dashboard-Modus",
+          "show_statistics": "Statistiken anzeigen",
+          "show_maps": "Karten anzeigen"
         }
       },
       "configure_external_entities": {

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -34,7 +34,20 @@
           "enable_gps": "GPS Location Tracking",
           "enable_health": "Health Monitoring",
           "enable_visitor_mode": "Visitor Mode",
+          "enable_dashboard": "Dashboard",
           "enable_advanced_features": "Advanced Features (Dashboard, Enhanced Notifications)"
+        }
+      },
+      "configure_dashboard": {
+        "title": "Configure Dashboard",
+        "description": "Set up dashboard settings for {dog_count} dogs.\n\n{dashboard_info}",
+        "data": {
+          "auto_create_dashboard": "Automatically create dashboard",
+          "create_per_dog_dashboards": "Create per-dog dashboards",
+          "dashboard_theme": "Dashboard Theme",
+          "dashboard_mode": "Dashboard Mode",
+          "show_statistics": "Show statistics",
+          "show_maps": "Show maps"
         }
       },
       "configure_external_entities": {


### PR DESCRIPTION
## Summary
- add dashboard option to module setup
- provide English and German strings for new dashboard configuration step

## Testing
- `pytest` *(fails: Coverage failure total of 0 is less than fail-under=95)*
- `pytest --no-cov`


------
https://chatgpt.com/codex/tasks/task_e_68b4968c605c83319f36a25ce33a272b