### PR TITLE
Add quick walk logging to PawControl button

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -881,8 +881,18 @@ class PawControlQuickWalkButton(PawControlButtonBase):
                 blocking=True,
             )
 
-            # TODO: In a real implementation, this would set the walk duration
-            # and automatically end it, or log it directly as a completed walk
+            # End the walk with predefined duration and distance
+            await self.hass.services.async_call(
+                DOMAIN,
+                SERVICE_END_WALK,
+                {
+                    ATTR_DOG_ID: self._dog_id,
+                    "duration": 10,  # 10 minutes
+                    "distance": 800,  # 0.8 km
+                    "notes": "Quick walk",
+                },
+                blocking=True,
+            )
 
             _LOGGER.info("Logged quick walk for %s", self._dog_name)
 


### PR DESCRIPTION
## Summary
- Automatically complete quick walk by ending it with preset duration and distance

## Testing
- `pre-commit run --files custom_components/pawcontrol/button.py`
- `pytest` *(fails: Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68b4966c816083319046ee9b28f2976b