### PR TITLE
Import missing modules

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -48,6 +48,7 @@ from .const import (
     CONF_DOGS,
     CONF_DOG_ID,
     CONF_DOG_NAME,
+    CONF_NAME,
     CONF_RESET_TIME,
     DEFAULT_DASHBOARD_AUTO_CREATE,
     DEFAULT_DASHBOARD_ENABLED,
@@ -643,7 +644,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         dashboard_url = await dashboard_generator.async_create_dashboard(
                             dogs_config,
                             options={
-                                "title": f"🐕 {entry.data.get(CONF_NAME, 'Paw Control')}",  # noqa: F821
+                                "title": f"🐕 {entry.data.get(CONF_NAME, 'Paw Control')}",
                                 "theme": entry.options.get(
                                     "dashboard_theme", "default"
                                 ),

--- a/custom_components/pawcontrol/dog_manager.py
+++ b/custom_components/pawcontrol/dog_manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 from typing import Any, Dict
 
 
@@ -29,4 +30,4 @@ class DogDataManager:
     async def async_all_dogs(self) -> Dict[str, Dict[str, Any]]:
         """Return a copy of all stored dog data."""
         async with self._lock:
-            return copy.deepcopy(self._dogs)  # noqa: F821
+            return copy.deepcopy(self._dogs)

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict, List, Optional
+import copy
 import uuid
 
 
@@ -58,4 +59,4 @@ class WalkManager:
 
     async def async_get_walks(self, dog_id: str) -> List[WalkSession]:
         """Return a copy of the walk history for ``dog_id``."""
-        return [copy.copy(session) for session in self._history.get(dog_id, [])]  # noqa: F821
+        return [copy.copy(session) for session in self._history.get(dog_id, [])]


### PR DESCRIPTION
## Summary
- Add missing imports for copy module in dog_manager and walk_manager
- Import CONF_NAME constant and remove noqa in __init__

## Testing
- `pytest` *(fails: Required test coverage of 95% not reached. Total coverage: 0.00%)*

------
https://chatgpt.com/codex/tasks/task_e_68b49a6f78c48331a2cb15ae75205e84