### PR TITLE
Implement placeholder logic for trend analysis and summary notifications

### DIFF
--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -815,10 +815,10 @@ class PawControlNotificationManager:
                     title = "\ud83d\udcca Daily Summary"
 
                 history = [
-                    n for n in self._notification_history if n["timestamp"] >= start
-                ]
-                if dogs:
-                    history = [n for n in history if n["dog_id"] in dogs]
+                          n
+                          for n in self._notification_history
+                          if n["timestamp"] >= start and (not dogs or n["dog_id"] in dogs)
+                         ]
 
                 if not history:
                     return False

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -18,7 +18,7 @@ from datetime import datetime, timedelta
 from typing import Any, Optional, TYPE_CHECKING
 
 from homeassistant.components import persistent_notification
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -804,11 +804,58 @@ class PawControlNotificationManager:
         dogs: Optional[list[str]] = None,
     ) -> bool:
         """Send a summary notification with activity overview."""
-        # Placeholder implementation
-        return False
+        try:
+            async with self._lock:
+                now = dt_util.utcnow()
+                if timeframe == "weekly":
+                    start = now - timedelta(days=7)
+                    title = "\ud83d\udcc8 Weekly Summary"
+                else:
+                    start = now - timedelta(days=1)
+                    title = "\ud83d\udcca Daily Summary"
+
+                history = [
+                    n for n in self._notification_history if n["timestamp"] >= start
+                ]
+                if dogs:
+                    history = [n for n in history if n["dog_id"] in dogs]
+
+                if not history:
+                    return False
+
+                counts: dict[str, int] = {}
+                for item in history:
+                    name = item.get("dog_name", item["dog_id"])
+                    counts[name] = counts.get(name, 0) + 1
+
+                message = ", ".join(
+                    f"{name}: {count}" for name, count in counts.items()
+                )
+
+            return await self.async_send_notification(
+                "summary",
+                NOTIFICATION_SYSTEM,
+                message,
+                title=title,
+                priority=PRIORITY_LOW,
+                force=True,
+                data={"timeframe": timeframe, "counts": counts},
+            )
+
+        except Exception as err:
+            _LOGGER.error("Failed to send summary notification: %s", err)
+            return False
 
     async def _register_services(self) -> None:
         """Register notification-related services."""
         # Note: SERVICE_NOTIFY_TEST is now registered in init.py to avoid conflicts
-        # This method reserved for future notification-specific services
-        pass
+        # Register summary notification service
+        if self.hass.services.has_service(DOMAIN, "send_summary"):
+            return
+
+        async def _handle_send_summary(call: ServiceCall) -> None:
+            timeframe = call.data.get("timeframe", "daily")
+            dogs = call.data.get("dogs")
+            await self.async_send_summary_notification(timeframe, dogs)
+
+        self.hass.services.async_register(DOMAIN, "send_summary", _handle_send_summary)

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -815,10 +815,10 @@ class PawControlNotificationManager:
                     title = "\ud83d\udcca Daily Summary"
 
                 history = [
-                          n
-                          for n in self._notification_history
-                          if n["timestamp"] >= start and (not dogs or n["dog_id"] in dogs)
-                         ]
+                    n
+                    for n in self._notification_history
+                    if n["timestamp"] >= start and (not dogs or n["dog_id"] in dogs)
+                ]
 
                 if not history:
                     return False

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -772,7 +772,13 @@ def calculate_trend_advanced(
     else:
         # Simplified calculation for other algorithms
         slope = (y[-1] - y[0]) / (n - 1) if n > 1 else 0
-        r_squared = 0.5  # Placeholder
+
+        # Estimate r-squared using a basic linear fit between first and last point
+        y_mean = sum(y) / n
+        y_pred = [y[0] + slope * i for i in range(n)]
+        ss_tot = sum((yi - y_mean) ** 2 for yi in y)
+        ss_res = sum((yi - yp) ** 2 for yi, yp in zip(y, y_pred))
+        r_squared = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0
 
     # Determine trend characteristics
     abs_slope = abs(slope)

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -771,7 +771,7 @@ def calculate_trend_advanced(
 
     else:
         # Simplified calculation for other algorithms
-        slope = (y[-1] - y[0]) / (n - 1) if n > 1 else 0
+        slope = (y[-1] - y[0]) / (n - 1)
 
         # Estimate r-squared using a basic linear fit between first and last point
         y_mean = sum(y) / n


### PR DESCRIPTION
## Summary
- Compute r-squared for non-linear trend analysis instead of placeholder value
- Implement summary notification dispatch aggregating recent notifications
- Register Home Assistant service to trigger summary notification delivery

## Testing
- `pytest` *(fails: Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68b49a6f78c48331a2cb15ae75205e84