### PR TITLE
Add config schema for Paw Control

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -101,6 +101,9 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# This integration can only be configured via the UI
+CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
 # Ordered platform loading for optimal dependency resolution
 # Legacy: All platforms (kept for reference and fallback)
 ALL_PLATFORMS: Final[list[Platform]] = [


### PR DESCRIPTION
## Summary
- define CONFIG_SCHEMA to mark integration as config-entry only

## Testing
- `pre-commit run --files custom_components/pawcontrol/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b49f95ea2c8331863fd00a699f8fb0