### PR TITLE
chore: remove unused datetime import

### DIFF
--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import timedelta
 from typing import Any, Optional, TYPE_CHECKING
 
 from homeassistant.components import persistent_notification
@@ -28,7 +28,7 @@ from .exceptions import NotificationError
 from .utils import is_within_quiet_hours
 
 if TYPE_CHECKING:
-    pass
+    from datetime import datetime
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- remove unused `datetime` import and move to type-checking block

## Testing
- `pre-commit run --files custom_components/pawcontrol/notifications.py`
- `pytest` *(fails: Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68b4efd1600c8331af166761d43c0d73