### PR TITLE
chore: remove unused imports

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -16,7 +16,6 @@ import asyncio
 import logging
 from contextlib import asynccontextmanager
 from datetime import time
-from pathlib import Path
 from typing import Any, Final
 
 import voluptuous as vol
@@ -25,7 +24,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant, ServiceCall, callback
 from homeassistant.exceptions import (
-    ConfigEntryAuthFailed,
     ConfigEntryNotReady,
     HomeAssistantError,
     ServiceValidationError,
@@ -83,7 +81,6 @@ from .exceptions import (
     PawControlError,
     ConfigurationError,
     DogNotFoundError,
-    ValidationError,
 )
 
 # Error classes already imported from .exceptions


### PR DESCRIPTION
## Summary
- remove unused imports from `__init__.py`

## Testing
- `pre-commit run --files custom_components/pawcontrol/__init__.py`


------
https://chatgpt.com/codex/tasks/task_e_68b4efd1600c8331af166761d43c0d73