### PR TITLE
Use Home Assistant unknown state constant

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -18,7 +18,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.const import STATE_UNKNOWN
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
-from homeassistant.const import STATE_UNKNOWN
 
 from .exceptions import (
     WalkAlreadyInProgressError,

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -16,6 +16,7 @@ from typing import Any, Dict, List, Optional
 from homeassistant.components.button import ButtonEntity, ButtonDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
 
 from .exceptions import (
@@ -1313,7 +1314,7 @@ class PawControlHealthCheckButton(PawControlButtonBase):
             health_data = self._get_module_data("health")
             if health_data:
                 # Generate a health summary
-                health_status = health_data.get("health_status", "unknown")
+                health_status = health_data.get("health_status", STATE_UNKNOWN)
                 alerts = health_data.get("health_alerts", [])
 
                 # This would typically trigger a detailed health report

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -24,6 +24,7 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers.storage import Store
+from homeassistant.const import STATE_UNKNOWN
 
 from .const import (
     CONF_DOGS,
@@ -415,14 +416,14 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             return {
                 "current_weight": None,
-                "weight_status": "unknown",
-                "health_status": "unknown",
+                "weight_status": STATE_UNKNOWN,
+                "health_status": STATE_UNKNOWN,
             }
         except Exception:
             return {
                 "current_weight": None,
-                "weight_status": "unknown",
-                "health_status": "unknown",
+                "weight_status": STATE_UNKNOWN,
+                "health_status": STATE_UNKNOWN,
             }
 
     async def _get_basic_walk_data(self, data_manager, dog_id: str) -> dict[str, Any]:

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -25,7 +25,6 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 from homeassistant.helpers.storage import Store
-from homeassistant.const import STATE_UNKNOWN
 
 from .const import (
     CONF_DOGS,

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -323,7 +323,7 @@ class PawControlDogStatusSensor(PawControlSensorBase):
         """Return the current status of the dog."""
         dog_data = self._get_dog_data()
         if not dog_data:
-            return "unknown"
+            return STATE_UNKNOWN
 
         walk_data = dog_data.get("walk", {})
         feeding_data = dog_data.get("feeding", {})
@@ -340,7 +340,7 @@ class PawControlDogStatusSensor(PawControlSensorBase):
             else:
                 return "home"
         elif zone := gps_data.get("zone"):
-            return f"at_{zone}" if zone != "unknown" else "away"
+            return f"at_{zone}" if zone != STATE_UNKNOWN else "away"
 
         return "away"
 
@@ -913,7 +913,7 @@ class PawControlCurrentZoneSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         gps_data = self._get_module_data("gps")
-        return gps_data.get("zone", "unknown") if gps_data else "unknown"
+        return gps_data.get("zone", STATE_UNKNOWN) if gps_data else STATE_UNKNOWN
 
 
 class PawControlGPSBatteryLevelSensor(PawControlSensorBase):
@@ -976,7 +976,9 @@ class PawControlWeightTrendSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("weight_trend", "stable") if health_data else "unknown"
+        return (
+            health_data.get("weight_trend", "stable") if health_data else STATE_UNKNOWN
+        )
 
 
 class PawControlActivityLevelSensor(PawControlSensorBase):
@@ -994,7 +996,11 @@ class PawControlActivityLevelSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("activity_level", "normal") if health_data else "unknown"
+        return (
+            health_data.get("activity_level", "normal")
+            if health_data
+            else STATE_UNKNOWN
+        )
 
 
 class PawControlLastVetVisitSensor(PawControlSensorBase):
@@ -1061,7 +1067,9 @@ class PawControlHealthStatusSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("health_status", "good") if health_data else "unknown"
+        return (
+            health_data.get("health_status", "good") if health_data else STATE_UNKNOWN
+        )
 
 
 class PawControlMedicationDueSensor(PawControlSensorBase):
@@ -1079,4 +1087,4 @@ class PawControlMedicationDueSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("medication_due", "no") if health_data else "unknown"
+        return health_data.get("medication_due", "no") if health_data else STATE_UNKNOWN


### PR DESCRIPTION
## Summary
- use Home Assistant STATE_UNKNOWN for fallback health data
- return STATE_UNKNOWN from dog status and health sensors when data missing
- default health check button to STATE_UNKNOWN status

## Testing
- `pre-commit run --files custom_components/pawcontrol/coordinator.py custom_components/pawcontrol/sensor.py custom_components/pawcontrol/button.py`
- `pytest` *(fails: Required test coverage of 95% not reached. Total coverage: 0.00%)*

------
https://chatgpt.com/codex/tasks/task_e_68b4efed2978833191b0085e52ee32c3