### PR TITLE
Use Home Assistant STATE_UNKNOWN for missing data

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -19,6 +19,7 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -462,7 +463,7 @@ class PawControlOnlineBinarySensor(PawControlBinarySensorBase):
             attrs.update(
                 {
                     "last_update": dog_data.get("last_update"),
-                    "status": dog_data.get("status", "unknown"),
+                    "status": dog_data.get("status", STATE_UNKNOWN),
                     "enabled_modules": dog_data.get("enabled_modules", []),
                     "system_health": "healthy" if self.is_on else "disconnected",
                 }
@@ -712,7 +713,7 @@ class PawControlIsHungryBinarySensor(PawControlBinarySensorBase):
         last_feeding_hours = feeding_data.get("last_feeding_hours")
 
         if not last_feeding_hours:
-            return "unknown"
+            return STATE_UNKNOWN
 
         if last_feeding_hours > 12:
             return "very_hungry"
@@ -929,7 +930,7 @@ class PawControlNeedsWalkBinarySensor(PawControlBinarySensorBase):
         last_walk_hours = walk_data.get("last_walk_hours")
 
         if not last_walk_hours:
-            return "unknown"
+            return STATE_UNKNOWN
 
         if last_walk_hours > 12:
             return "urgent"
@@ -1039,7 +1040,7 @@ class PawControlIsHomeBinarySensor(PawControlBinarySensorBase):
         if gps_data:
             attrs.update(
                 {
-                    "current_zone": gps_data.get("zone", "unknown"),
+                    "current_zone": gps_data.get("zone", STATE_UNKNOWN),
                     "distance_from_home": gps_data.get("distance_from_home"),
                     "last_seen": gps_data.get("last_seen"),
                     "accuracy": gps_data.get("accuracy"),

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -17,6 +17,7 @@ from homeassistant.components.button import ButtonEntity, ButtonDeviceClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.const import STATE_UNKNOWN
 
 from .exceptions import (
     WalkAlreadyInProgressError,
@@ -740,7 +741,7 @@ class PawControlStartWalkButton(PawControlButtonBase):
             if walk_data and walk_data.get("walk_in_progress", False):
                 raise WalkAlreadyInProgressError(
                     dog_id=self._dog_id,
-                    walk_id=walk_data.get("current_walk_id", "unknown"),
+                    walk_id=walk_data.get("current_walk_id", STATE_UNKNOWN),
                     start_time=walk_data.get("current_walk_start"),
                 )
 
@@ -1313,7 +1314,7 @@ class PawControlHealthCheckButton(PawControlButtonBase):
             health_data = self._get_module_data("health")
             if health_data:
                 # Generate a health summary
-                health_status = health_data.get("health_status", "unknown")
+                health_status = health_data.get("health_status", STATE_UNKNOWN)
                 alerts = health_data.get("health_alerts", [])
 
                 # This would typically trigger a detailed health report

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -16,6 +16,7 @@ import logging
 from datetime import datetime, timedelta, date
 from typing import Any, Callable, Optional, TYPE_CHECKING
 
+from homeassistant.const import STATE_UNKNOWN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import (
@@ -415,14 +416,14 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             return {
                 "current_weight": None,
-                "weight_status": "unknown",
-                "health_status": "unknown",
+                "weight_status": STATE_UNKNOWN,
+                "health_status": STATE_UNKNOWN,
             }
         except Exception:
             return {
                 "current_weight": None,
-                "weight_status": "unknown",
-                "health_status": "unknown",
+                "weight_status": STATE_UNKNOWN,
+                "health_status": STATE_UNKNOWN,
             }
 
     async def _get_basic_walk_data(self, data_manager, dog_id: str) -> dict[str, Any]:

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -17,7 +17,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -323,7 +323,7 @@ class PawControlDogStatusSensor(PawControlSensorBase):
         """Return the current status of the dog."""
         dog_data = self._get_dog_data()
         if not dog_data:
-            return "unknown"
+            return STATE_UNKNOWN
 
         walk_data = dog_data.get("walk", {})
         feeding_data = dog_data.get("feeding", {})
@@ -340,7 +340,7 @@ class PawControlDogStatusSensor(PawControlSensorBase):
             else:
                 return "home"
         elif zone := gps_data.get("zone"):
-            return f"at_{zone}" if zone != "unknown" else "away"
+            return f"at_{zone}" if zone != STATE_UNKNOWN else "away"
 
         return "away"
 
@@ -913,7 +913,7 @@ class PawControlCurrentZoneSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         gps_data = self._get_module_data("gps")
-        return gps_data.get("zone", "unknown") if gps_data else "unknown"
+        return gps_data.get("zone", STATE_UNKNOWN) if gps_data else STATE_UNKNOWN
 
 
 class PawControlGPSBatteryLevelSensor(PawControlSensorBase):
@@ -976,7 +976,9 @@ class PawControlWeightTrendSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("weight_trend", "stable") if health_data else "unknown"
+        return (
+            health_data.get("weight_trend", "stable") if health_data else STATE_UNKNOWN
+        )
 
 
 class PawControlActivityLevelSensor(PawControlSensorBase):
@@ -994,7 +996,11 @@ class PawControlActivityLevelSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("activity_level", "normal") if health_data else "unknown"
+        return (
+            health_data.get("activity_level", "normal")
+            if health_data
+            else STATE_UNKNOWN
+        )
 
 
 class PawControlLastVetVisitSensor(PawControlSensorBase):
@@ -1061,7 +1067,9 @@ class PawControlHealthStatusSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("health_status", "good") if health_data else "unknown"
+        return (
+            health_data.get("health_status", "good") if health_data else STATE_UNKNOWN
+        )
 
 
 class PawControlMedicationDueSensor(PawControlSensorBase):
@@ -1079,4 +1087,4 @@ class PawControlMedicationDueSensor(PawControlSensorBase):
     @property
     def native_value(self) -> str:
         health_data = self._get_module_data("health")
-        return health_data.get("medication_due", "no") if health_data else "unknown"
+        return health_data.get("medication_due", "no") if health_data else STATE_UNKNOWN


### PR DESCRIPTION
## Summary
- replace raw "unknown" strings with `STATE_UNKNOWN` for health fallback data
- default sensors, binary sensors, and buttons to `STATE_UNKNOWN` when values are missing

## Testing
- `pre-commit run --files custom_components/pawcontrol/coordinator.py custom_components/pawcontrol/sensor.py custom_components/pawcontrol/binary_sensor.py custom_components/pawcontrol/button.py`
- `pytest` *(fails: Module custom_components.pawcontrol was never imported / No data collected)*

------
https://chatgpt.com/codex/tasks/task_e_68b4efed2978833191b0085e52ee32c3