### PR TITLE
Fix discovery imports and standardize data handling

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Optional, TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.const import STATE_ONLINE
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
     UpdateFailed,
@@ -28,7 +29,6 @@ from homeassistant.helpers.storage import Store
 from .const import (
     CONF_DOGS,
     CONF_DOG_ID,
-    CONF_DOG_NAME,
     CONF_GPS_UPDATE_INTERVAL,
     DEFAULT_GPS_UPDATE_INTERVAL,
     DOMAIN,
@@ -235,14 +235,13 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             Complete data structure for the dog
         """
         dog_id = dog[CONF_DOG_ID]
-        dog[CONF_DOG_NAME]
         enabled_modules = dog.get("modules", {})
 
         # Base dog data structure
         dog_data: dict[str, Any] = {
             "dog_info": dog,
             "last_update": dt_util.utcnow().isoformat(),
-            "status": "online",
+            "status": STATE_ONLINE,
             "enabled_modules": [
                 mod for mod, enabled in enabled_modules.items() if enabled
             ],
@@ -363,8 +362,21 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             feeding_history = await data_manager.async_get_feeding_history(
                 dog_id, days=1
             )
+
+            meal_counts = {"breakfast": 0, "lunch": 0, "dinner": 0, "snack": 0}
             if not feeding_history:
-                return {"last_feeding": None, "feedings_today": 0}
+                return {
+                    "last_feeding": None,
+                    "feedings_today": meal_counts,
+                    "total_feedings_today": 0,
+                }
+
+            for entry in feeding_history:
+                meal_type = entry.get("meal_type")
+                if meal_type in meal_counts:
+                    meal_counts[meal_type] += 1
+
+            total_feedings = sum(meal_counts.values())
 
             # Get most recent feeding
             most_recent = max(
@@ -376,20 +388,33 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 default=None,
             )
 
-            if most_recent:
-                timestamp = self._parse_datetime_safely(most_recent.get("timestamp"))
-                return {
-                    "last_feeding": timestamp.isoformat() if timestamp else None,
-                    "last_feeding_type": most_recent.get("meal_type"),
-                    "last_feeding_hours": self._calculate_hours_since(timestamp)
-                    if timestamp
-                    else None,
-                    "feedings_today": len(feeding_history),
-                }
+            last_feeding_ts = None
+            last_feeding_type = None
+            last_feeding_hours = None
 
-            return {"last_feeding": None, "feedings_today": len(feeding_history)}
+            if most_recent:
+                last_feeding_type = most_recent.get("meal_type")
+                last_feeding_ts = self._parse_datetime_safely(
+                    most_recent.get("timestamp")
+                )
+                if last_feeding_ts:
+                    last_feeding_hours = self._calculate_hours_since(last_feeding_ts)
+
+            return {
+                "last_feeding": last_feeding_ts.isoformat()
+                if last_feeding_ts
+                else None,
+                "last_feeding_type": last_feeding_type,
+                "last_feeding_hours": last_feeding_hours,
+                "feedings_today": meal_counts,
+                "total_feedings_today": total_feedings,
+            }
         except Exception:
-            return {"last_feeding": None, "feedings_today": 0}
+            return {
+                "last_feeding": None,
+                "feedings_today": {"breakfast": 0, "lunch": 0, "dinner": 0, "snack": 0},
+                "total_feedings_today": 0,
+            }
 
     async def _get_basic_health_data(self, data_manager, dog_id: str) -> dict[str, Any]:
         """Get basic health data as fallback."""

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -412,7 +412,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception:
             return {
                 "last_feeding": None,
-                "feedings_today": {"breakfast": 0, "lunch": 0, "dinner": 0, "snack": 0},
+                "feedings_today": {meal: 0 for meal in MEAL_TYPES},
                 "total_feedings_today": 0,
             }
 

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -363,7 +363,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 dog_id, days=1
             )
 
-            meal_counts = {"breakfast": 0, "lunch": 0, "dinner": 0, "snack": 0}
+            meal_counts = {meal: 0 for meal in MEAL_TYPES}
             if not feeding_history:
                 return {
                     "last_feeding": None,

--- a/custom_components/pawcontrol/dashboard_generator.py
+++ b/custom_components/pawcontrol/dashboard_generator.py
@@ -25,7 +25,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.storage import Store
 from homeassistant.util import slugify
-from homeassistant.util.dt import utcnow
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_DOG_ID,
@@ -196,7 +196,7 @@ class PawControlDashboardGenerator:
                     "url": dashboard_url,
                     "title": dashboard_title,
                     "path": dashboard_path,
-                    "created": utcnow().isoformat(),
+                    "created": dt_util.utcnow().isoformat(),
                     "type": "main",
                     "dogs": [
                         dog[CONF_DOG_ID] for dog in dogs_config if dog.get(CONF_DOG_ID)
@@ -278,7 +278,7 @@ class PawControlDashboardGenerator:
                     "url": dashboard_url,
                     "title": dashboard_title,
                     "path": dashboard_path,
-                    "created": utcnow().isoformat(),
+                    "created": dt_util.utcnow().isoformat(),
                     "type": "dog",
                     "dog_id": dog_id,
                     "dog_name": dog_name,
@@ -360,7 +360,7 @@ class PawControlDashboardGenerator:
                 )
 
                 # Update stored info
-                dashboard_info["updated"] = utcnow().isoformat()
+                dashboard_info["updated"] = dt_util.utcnow().isoformat()
                 if options:
                     dashboard_info["options"] = options
 
@@ -1491,7 +1491,7 @@ class PawControlDashboardGenerator:
 
             # Update configuration
             dashboard_data["data"]["config"] = config
-            dashboard_data["data"]["updated"] = utcnow().isoformat()
+            dashboard_data["data"]["updated"] = dt_util.utcnow().isoformat()
 
             # Write updated dashboard
             async with aiofiles.open(dashboard_file, "w", encoding="utf-8") as file:
@@ -1533,7 +1533,7 @@ class PawControlDashboardGenerator:
             await self._store.async_save(
                 {
                     "dashboards": self._dashboards,
-                    "updated": utcnow().isoformat(),
+                    "updated": dt_util.utcnow().isoformat(),
                     "version": DASHBOARD_STORAGE_VERSION,
                     "entry_id": self.entry.entry_id,
                 }

--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -382,7 +382,7 @@ class PawControlDiscovery:
             try:
                 await zeroconf.async_get_instance(self.hass)
             except Exception:
-                _LOGGER.debug("Zeroconf not available for discovery")
+                _LOGGER.debug("Zeroconf not available for discovery", exc_info=True)
                 return discovered
 
             # Zeroconf service patterns for dog devices

--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -18,12 +18,13 @@ from dataclasses import dataclass
 from datetime import timedelta
 from typing import Any, Final
 
-from homeassistant.components import bluetooth, usb
+from homeassistant.components import bluetooth, dhcp, usb, zeroconf
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util.dt import utcnow
 
+from .const import DOMAIN
 from .exceptions import PawControlError
 
 _LOGGER = logging.getLogger(__name__)
@@ -377,6 +378,13 @@ class PawControlDiscovery:
         discovered = []
 
         try:
+            # Ensure zeroconf integration is initialized
+            try:
+                await zeroconf.async_get_instance(self.hass)
+            except Exception:
+                _LOGGER.debug("Zeroconf not available for discovery")
+                return discovered
+
             # Zeroconf service patterns for dog devices
             service_patterns = {
                 "_petnet._tcp.local.": {
@@ -454,6 +462,13 @@ class PawControlDiscovery:
         discovered = []
 
         try:
+            # Ensure DHCP integration is initialized
+            try:
+                await dhcp.async_get_dhcp_entries(self.hass)
+            except Exception:
+                _LOGGER.debug("DHCP not available for discovery")
+                return discovered
+
             # DHCP hostname patterns for dog devices
             hostname_patterns = {
                 r"tractive.*": {
@@ -751,6 +766,7 @@ async def async_get_discovered_devices(hass: HomeAssistant) -> list[dict[str, An
         List of discovered devices in legacy format
     """
     discovery = PawControlDiscovery(hass)
+    hass.data.setdefault(DOMAIN, {})["legacy_discovery"] = discovery
 
     try:
         await discovery.async_initialize()
@@ -779,6 +795,7 @@ async def async_get_discovered_devices(hass: HomeAssistant) -> list[dict[str, An
         return []
     finally:
         await discovery.async_shutdown()
+        hass.data[DOMAIN].pop("legacy_discovery", None)
 
 
 async def async_start_discovery() -> bool:

--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -466,7 +466,7 @@ class PawControlDiscovery:
             try:
                 await dhcp.async_get_dhcp_entries(self.hass)
             except Exception:
-                _LOGGER.debug("DHCP not available for discovery")
+                _LOGGER.debug("DHCP not available for discovery", exc_info=True)
                 return discovered
 
             # DHCP hostname patterns for dog devices


### PR DESCRIPTION
## Summary
- restore zeroconf and DHCP discovery imports and domain tracking
- ensure coordinator uses constants and consistent feeding data structures
- unify dashboard timestamps via `dt_util.utcnow`

## Testing
- `pre-commit run --files custom_components/pawcontrol/discovery.py custom_components/pawcontrol/coordinator.py custom_components/pawcontrol/dashboard_generator.py`

------
https://chatgpt.com/codex/tasks/task_e_68b4f0026fb48331891aafa9c16865fe