### PR TITLE
Refactor feeding summary and expand tests

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -370,6 +370,12 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "total_feedings_today": 0,
                 }
 
+            feedings_today: dict[str, int] = {}
+            for item in feeding_history:
+                meal = item.get("meal_type")
+                if isinstance(meal, str):
+                    feedings_today[meal] = feedings_today.get(meal, 0) + 1
+
             # Get most recent feeding
             most_recent = max(
                 feeding_history,
@@ -382,13 +388,6 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             if most_recent:
                 timestamp = self._parse_datetime_safely(most_recent.get("timestamp"))
-
-                feedings_today: dict[str, int] = {}
-                for item in feeding_history:
-                    meal = item.get("meal_type")
-                    if isinstance(meal, str):
-                        feedings_today[meal] = feedings_today.get(meal, 0) + 1
-
                 return {
                     "last_feeding": timestamp.isoformat() if timestamp else None,
                     "last_feeding_type": most_recent.get("meal_type"),
@@ -398,12 +397,6 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "feedings_today": feedings_today,
                     "total_feedings_today": sum(feedings_today.values()),
                 }
-
-            feedings_today: dict[str, int] = {}
-            for item in feeding_history:
-                meal = item.get("meal_type")
-                if isinstance(meal, str):
-                    feedings_today[meal] = feedings_today.get(meal, 0) + 1
 
             return {
                 "last_feeding": None,

--- a/tests/test_feeding_manager.py
+++ b/tests/test_feeding_manager.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import pytest
 
+import sys
 from importlib import util
 from pathlib import Path
+from datetime import datetime, timedelta
 
 SPEC = util.spec_from_file_location(
     "feeding_manager",
@@ -46,3 +48,34 @@ async def test_feeding_manager_empty_history() -> None:
 
     assert data["feedings_today"] == {}
     assert data["total_feedings_today"] == 0
+
+
+@pytest.mark.asyncio
+async def test_feeding_manager_unknown_meal_type() -> None:
+    """Feeding with None meal_type is categorized as 'unknown'."""
+
+    manager = FeedingManager()
+    await manager.async_add_feeding("dog", 1.0, meal_type=None)
+
+    data = await manager.async_get_feeding_data("dog")
+
+    assert data["feedings_today"]["unknown"] == 1
+    assert data["total_feedings_today"] == 1
+
+
+@pytest.mark.asyncio
+async def test_feeding_manager_excludes_previous_days() -> None:
+    """Feedings from other days are excluded from today's totals."""
+
+    manager = FeedingManager()
+    yesterday = datetime.utcnow() - timedelta(days=1)
+    await manager.async_add_feeding(
+        "dog", 1.0, meal_type="breakfast", time=yesterday
+    )
+    await manager.async_add_feeding("dog", 1.0, meal_type="dinner")
+
+    data = await manager.async_get_feeding_data("dog")
+
+    assert "breakfast" not in data["feedings_today"]
+    assert data["feedings_today"]["dinner"] == 1
+    assert data["total_feedings_today"] == 1

--- a/tests/test_feeding_manager.py
+++ b/tests/test_feeding_manager.py
@@ -69,9 +69,7 @@ async def test_feeding_manager_excludes_previous_days() -> None:
 
     manager = FeedingManager()
     yesterday = datetime.utcnow() - timedelta(days=1)
-    await manager.async_add_feeding(
-        "dog", 1.0, meal_type="breakfast", time=yesterday
-    )
+    await manager.async_add_feeding("dog", 1.0, meal_type="breakfast", time=yesterday)
     await manager.async_add_feeding("dog", 1.0, meal_type="dinner")
 
     data = await manager.async_get_feeding_data("dog")


### PR DESCRIPTION
## Summary
- Avoid duplicate feedings_today calculations in coordinator fallback
- Import sys directly for feeding manager tests
- Test unknown meal types and ignore prior-day feedings

## Testing
- `pip install -r requirements_test.txt`
- `pytest --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f715a380833187350ee945a71e93