### PR TITLE
Add edge case feeding tests and refactor coordinator

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -380,14 +380,15 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 default=None,
             )
 
+            feedings_today: dict[str, int] = {}
+            for item in feeding_history:
+                meal = item.get("meal_type")
+                if isinstance(meal, str):
+                    feedings_today[meal] = feedings_today.get(meal, 0) + 1
+            total_today = sum(feedings_today.values())
+
             if most_recent:
                 timestamp = self._parse_datetime_safely(most_recent.get("timestamp"))
-
-                feedings_today: dict[str, int] = {}
-                for item in feeding_history:
-                    meal = item.get("meal_type")
-                    if isinstance(meal, str):
-                        feedings_today[meal] = feedings_today.get(meal, 0) + 1
 
                 return {
                     "last_feeding": timestamp.isoformat() if timestamp else None,
@@ -396,19 +397,13 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     if timestamp
                     else None,
                     "feedings_today": feedings_today,
-                    "total_feedings_today": sum(feedings_today.values()),
+                    "total_feedings_today": total_today,
                 }
-
-            feedings_today: dict[str, int] = {}
-            for item in feeding_history:
-                meal = item.get("meal_type")
-                if isinstance(meal, str):
-                    feedings_today[meal] = feedings_today.get(meal, 0) + 1
 
             return {
                 "last_feeding": None,
                 "feedings_today": feedings_today,
-                "total_feedings_today": sum(feedings_today.values()),
+                "total_feedings_today": total_today,
             }
         except Exception:
             return {

--- a/tests/test_feeding_manager.py
+++ b/tests/test_feeding_manager.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
-import pytest
-
+import sys
+from datetime import datetime, timedelta
 from importlib import util
 from pathlib import Path
+
+import pytest
 
 SPEC = util.spec_from_file_location(
     "feeding_manager",
@@ -46,3 +48,34 @@ async def test_feeding_manager_empty_history() -> None:
 
     assert data["feedings_today"] == {}
     assert data["total_feedings_today"] == 0
+
+
+@pytest.mark.asyncio
+async def test_feeding_manager_none_meal_type_defaults_to_unknown() -> None:
+    """Feedings with no meal type are categorized as 'unknown'."""
+
+    manager = FeedingManager()
+    await manager.async_add_feeding("dog", 1.0, meal_type=None)
+
+    data = await manager.async_get_feeding_data("dog")
+
+    assert data["feedings_today"] == {"unknown": 1}
+    assert data["total_feedings_today"] == 1
+
+
+@pytest.mark.asyncio
+async def test_feeding_manager_ignores_feedings_from_previous_days() -> None:
+    """Feedings from earlier days should not appear in today's counts."""
+
+    manager = FeedingManager()
+    yesterday = datetime.utcnow() - timedelta(days=1)
+
+    # Feeding yesterday should be ignored
+    await manager.async_add_feeding("dog", 1.0, meal_type="breakfast", time=yesterday)
+    # Feeding today should be counted
+    await manager.async_add_feeding("dog", 1.0, meal_type="dinner")
+
+    data = await manager.async_get_feeding_data("dog")
+
+    assert data["feedings_today"] == {"dinner": 1}
+    assert data["total_feedings_today"] == 1


### PR DESCRIPTION
## Summary
- test FeedingManager with `None` meal types and prior-day feedings
- refactor coordinator to calculate daily feedings once

## Testing
- `pip install -r requirements_test.txt`
- `pre-commit run --files tests/test_feeding_manager.py custom_components/pawcontrol/coordinator.py`
- `pytest --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4f723f69483318ddeb563b961e54c