### PR TITLE
refactor health data default helper

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -392,6 +392,14 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except Exception:
             return {"last_feeding": None, "feedings_today": 0}
 
+    def _get_default_health_data(self) -> dict[str, Any]:
+        """Return the default health data dictionary."""
+        return {
+            "current_weight": None,
+            "weight_status": STATE_UNKNOWN,
+            "health_status": STATE_UNKNOWN,
+        }
+
     async def _get_basic_health_data(self, data_manager, dog_id: str) -> dict[str, Any]:
         """Get basic health data as fallback."""
         try:
@@ -414,17 +422,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                         "health_status": "good",
                     }
 
-            return {
-                "current_weight": None,
-                "weight_status": STATE_UNKNOWN,
-                "health_status": STATE_UNKNOWN,
-            }
+            return self._get_default_health_data()
         except Exception:
-            return {
-                "current_weight": None,
-                "weight_status": STATE_UNKNOWN,
-                "health_status": STATE_UNKNOWN,
-            }
+            return self._get_default_health_data()
 
     async def _get_basic_walk_data(self, data_manager, dog_id: str) -> dict[str, Any]:
         """Get basic walk data as fallback."""


### PR DESCRIPTION
## Summary
- deduplicate default health data dictionary via `_get_default_health_data`
- reuse helper in `_get_basic_health_data`

## Testing
- `pre-commit run --files custom_components/pawcontrol/coordinator.py custom_components/pawcontrol/sensor.py custom_components/pawcontrol/button.py`
- `pytest` *(fails: Coverage failure: total of 0 is less than fail-under=95)*

------
https://chatgpt.com/codex/tasks/task_e_68b4f89051fc83318984ff9b7d0761be