### PR TITLE
Ensure consistent meal tracking data

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -371,9 +371,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                     "total_feedings_today": 0,
                 }
 
-meal = item.get("meal_type") or "unknown"
-if isinstance(meal, str):
-    feedings_today[meal] = feedings_today.get(meal, 0) + 1
+            feedings_today: dict[str, int] = {}
             for item in feeding_history:
                 meal = item.get("meal_type") or "unknown"
                 if isinstance(meal, str):


### PR DESCRIPTION
## Summary
- Deduplicate feeding count logic in fallback coordinator data by aggregating once with an `"unknown"` meal fallback

## Testing
- `pip install -r requirements_test.txt`
- `pre-commit run --files custom_components/pawcontrol/coordinator.py`
- `pytest --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4fcf222208331b597c1e39b59629f