### PR TITLE
refactor: remove deprecated typing aliases

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -350,7 +350,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                     len(dogs_config),
                     (1 - len(needed_platforms) / len(ALL_PLATFORMS)) * 100,
                 )
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.error("Platform setup timed out after 30 seconds")
                 await _async_cleanup_runtime_data(hass, entry, runtime_data)
                 raise ConfigEntryNotReady("Platform setup timed out") from None
@@ -419,7 +419,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 async with asyncio.timeout(10):  # Reduced from 30s to 10s
                     await coordinator.async_config_entry_first_refresh()
                 _LOGGER.debug("Initial data refresh completed successfully")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.warning(
                     "Initial data refresh timed out after 10s, integration will continue with cached data"
                 )
@@ -595,7 +595,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         return unload_success
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         _LOGGER.error("Timeout during platform unloading")
         return False
     except Exception as err:
@@ -685,7 +685,7 @@ async def _async_cleanup_runtime_data(
         try:
             async with asyncio.timeout(20):
                 await asyncio.gather(*shutdown_tasks, return_exceptions=True)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Component cleanup timed out")
 
 

--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Optional
+from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -282,10 +282,10 @@ class PawControlBinarySensorBase(
         dog_name: str,
         sensor_type: str,
         *,
-        device_class: Optional[BinarySensorDeviceClass] = None,
-        icon_on: Optional[str] = None,
-        icon_off: Optional[str] = None,
-        entity_category: Optional[EntityCategory] = None,
+        device_class: BinarySensorDeviceClass | None = None,
+        icon_on: str | None = None,
+        icon_off: str | None = None,
+        entity_category: EntityCategory | None = None,
     ) -> None:
         """Initialize the binary sensor entity.
 
@@ -324,7 +324,7 @@ class PawControlBinarySensorBase(
         }
 
     @property
-    def icon(self) -> Optional[str]:
+    def icon(self) -> str | None:
         """Return the icon to use in the frontend.
 
         Dynamically changes icon based on sensor state for better UX.
@@ -372,7 +372,7 @@ class PawControlBinarySensorBase(
 
         return attrs
 
-    def _get_dog_data(self) -> Optional[dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this sensor's dog from the coordinator.
 
         Returns:
@@ -383,7 +383,7 @@ class PawControlBinarySensorBase(
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         """Get specific module data for this dog.
 
         Args:
@@ -857,7 +857,7 @@ class PawControlWalkInProgressBinarySensor(PawControlBinarySensorBase):
 
         return attrs
 
-    def _estimate_remaining_time(self, walk_data: dict[str, Any]) -> Optional[int]:
+    def _estimate_remaining_time(self, walk_data: dict[str, Any]) -> int | None:
         """Estimate remaining walk time based on typical patterns.
 
         Args:

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.components.button import ButtonDeviceClass, ButtonEntity
 from homeassistant.config_entries import ConfigEntry
@@ -49,12 +49,12 @@ from .exceptions import (
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases for better code readability
-AttributeDict = Dict[str, Any]
+AttributeDict = dict[str, Any]
 
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,
-    entities: List[PawControlButtonBase],
+    entities: list[PawControlButtonBase],
     batch_size: int = 5,
     delay_between_batches: float = 1.0,
 ) -> None:
@@ -122,18 +122,18 @@ async def async_setup_entry(
 
     if runtime_data:
         coordinator: PawControlCoordinator = runtime_data["coordinator"]
-        dogs: List[Dict[str, Any]] = runtime_data.get("dogs", [])
+        dogs: list[dict[str, Any]] = runtime_data.get("dogs", [])
     else:
         coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
         dogs = entry.data.get(CONF_DOGS, [])
 
-    entities: List[PawControlButtonBase] = []
+    entities: list[PawControlButtonBase] = []
 
     # Create button entities for each configured dog
     for dog in dogs:
         dog_id: str = dog[CONF_DOG_ID]
         dog_name: str = dog[CONF_DOG_NAME]
-        modules: Dict[str, bool] = dog.get("modules", {})
+        modules: dict[str, bool] = dog.get("modules", {})
 
         _LOGGER.debug("Creating button entities for dog: %s (%s)", dog_name, dog_id)
 
@@ -167,7 +167,7 @@ async def async_setup_entry(
 
 def _create_base_buttons(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlButtonBase]:
+) -> list[PawControlButtonBase]:
     """Create base buttons that are always present for every dog.
 
     Args:
@@ -187,7 +187,7 @@ def _create_base_buttons(
 
 def _create_feeding_buttons(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlButtonBase]:
+) -> list[PawControlButtonBase]:
     """Create feeding-related buttons for a dog.
 
     Args:
@@ -214,7 +214,7 @@ def _create_feeding_buttons(
 
 def _create_walk_buttons(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlButtonBase]:
+) -> list[PawControlButtonBase]:
     """Create walk-related buttons for a dog.
 
     Args:
@@ -235,7 +235,7 @@ def _create_walk_buttons(
 
 def _create_gps_buttons(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlButtonBase]:
+) -> list[PawControlButtonBase]:
     """Create GPS and location-related buttons for a dog.
 
     Args:
@@ -256,7 +256,7 @@ def _create_gps_buttons(
 
 def _create_health_buttons(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlButtonBase]:
+) -> list[PawControlButtonBase]:
     """Create health and medical-related buttons for a dog.
 
     Args:
@@ -291,10 +291,10 @@ class PawControlButtonBase(CoordinatorEntity[PawControlCoordinator], ButtonEntit
         dog_name: str,
         button_type: str,
         *,
-        device_class: Optional[ButtonDeviceClass] = None,
-        icon: Optional[str] = None,
-        entity_category: Optional[str] = None,
-        action_description: Optional[str] = None,
+        device_class: ButtonDeviceClass | None = None,
+        icon: str | None = None,
+        entity_category: str | None = None,
+        action_description: str | None = None,
     ) -> None:
         """Initialize the button entity.
 
@@ -366,7 +366,7 @@ class PawControlButtonBase(CoordinatorEntity[PawControlCoordinator], ButtonEntit
 
         return attrs
 
-    def _get_dog_data(self) -> Optional[Dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this button's dog from the coordinator.
 
         Returns:
@@ -377,7 +377,7 @@ class PawControlButtonBase(CoordinatorEntity[PawControlCoordinator], ButtonEntit
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[Dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         """Get specific module data for this dog.
 
         Args:

--- a/custom_components/pawcontrol/config_flow_dogs.py
+++ b/custom_components/pawcontrol/config_flow_dogs.py
@@ -102,7 +102,7 @@ class DogManagementMixin:
                 else:
                     errors = validation_result["errors"]
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.error("Dog validation timed out")
                 errors["base"] = "validation_timeout"
             except Exception as err:

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -15,8 +15,9 @@ import asyncio
 import logging
 import weakref
 from collections import defaultdict, deque
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import TYPE_CHECKING, Any
 
 # Newer Home Assistant versions removed STATE_ONLINE from homeassistant.const.
 # Define the constant locally for clarity and future compatibility.
@@ -463,7 +464,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             results = await asyncio.wait_for(
                 asyncio.gather(*tasks, return_exceptions=True), timeout=25.0
             )
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Batch processing timeout for %d dogs", len(batch))
             return {}
 
@@ -610,7 +611,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # Fast fallback
             return {}
-        except (asyncio.TimeoutError, Exception) as err:
+        except (TimeoutError, Exception) as err:
             _LOGGER.debug("GPS data timeout/error for %s: %s", dog_id, err)
             return {}
 
@@ -625,7 +626,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
             return {}
-        except (asyncio.TimeoutError, Exception) as err:
+        except (TimeoutError, Exception) as err:
             _LOGGER.debug("Feeding data timeout/error for %s: %s", dog_id, err)
             return {}
 
@@ -640,7 +641,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
             return {}
-        except (asyncio.TimeoutError, Exception) as err:
+        except (TimeoutError, Exception) as err:
             _LOGGER.debug("Health data timeout/error for %s: %s", dog_id, err)
             return {}
 
@@ -653,7 +654,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 )
 
             return {}
-        except (asyncio.TimeoutError, Exception) as err:
+        except (TimeoutError, Exception) as err:
             _LOGGER.debug("Walk data timeout/error for %s: %s", dog_id, err)
             return {}
 
@@ -747,7 +748,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return None
 
     # Public interface methods
-    def get_dog_data(self, dog_id: str) -> Optional[dict[str, Any]]:
+    def get_dog_data(self, dog_id: str) -> dict[str, Any] | None:
         """Get data for a specific dog."""
         return self._data.get(dog_id)
 

--- a/custom_components/pawcontrol/dashboard_renderer.py
+++ b/custom_components/pawcontrol/dashboard_renderer.py
@@ -176,7 +176,7 @@ class DashboardRenderer:
 
                     return result
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 job.status = "timeout"
                 job.error = "Rendering timed out"
                 _LOGGER.error("Dashboard rendering timeout for job %s", job.job_id)

--- a/custom_components/pawcontrol/data_manager.py
+++ b/custom_components/pawcontrol/data_manager.py
@@ -17,7 +17,7 @@ import json
 import logging
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import aiofiles
 from homeassistant.core import HomeAssistant
@@ -79,8 +79,8 @@ class PawControlDataManager:
         self._cache_ttl = timedelta(minutes=5)
 
         # Background tasks
-        self._cleanup_task: Optional[asyncio.Task] = None
-        self._backup_task: Optional[asyncio.Task] = None
+        self._cleanup_task: asyncio.Task | None = None
+        self._backup_task: asyncio.Task | None = None
 
         # Async locks for thread-safe operations
         self._lock = asyncio.Lock()
@@ -186,7 +186,7 @@ class PawControlDataManager:
             await self._stores["statistics"].async_save(initial_stats)
 
     # Core dog data operations
-    async def async_get_dog_data(self, dog_id: str) -> Optional[dict[str, Any]]:
+    async def async_get_dog_data(self, dog_id: str) -> dict[str, Any] | None:
         """Get all data for a specific dog.
 
         Args:
@@ -427,7 +427,7 @@ class PawControlDataManager:
             raise
 
     async def async_end_walk(
-        self, dog_id: str, walk_data: Optional[dict[str, Any]] = None
+        self, dog_id: str, walk_data: dict[str, Any] | None = None
     ) -> None:
         """End the current walk session for a dog.
 
@@ -495,7 +495,7 @@ class PawControlDataManager:
             self._metrics["errors_count"] += 1
             raise
 
-    async def async_get_current_walk(self, dog_id: str) -> Optional[dict[str, Any]]:
+    async def async_get_current_walk(self, dog_id: str) -> dict[str, Any] | None:
         """Get current active walk for a dog.
 
         Args:
@@ -620,7 +620,7 @@ class PawControlDataManager:
 
         return dog_data.get("health", {}).get("active_medications", [])
 
-    async def async_get_last_vet_visit(self, dog_id: str) -> Optional[dict[str, Any]]:
+    async def async_get_last_vet_visit(self, dog_id: str) -> dict[str, Any] | None:
         """Get last vet visit for a dog.
 
         Args:
@@ -635,7 +635,7 @@ class PawControlDataManager:
         ]
         return vet_visits[-1] if vet_visits else None
 
-    async def async_get_last_grooming(self, dog_id: str) -> Optional[dict[str, Any]]:
+    async def async_get_last_grooming(self, dog_id: str) -> dict[str, Any] | None:
         """Get last grooming session for a dog.
 
         Args:
@@ -708,7 +708,7 @@ class PawControlDataManager:
             self._metrics["errors_count"] += 1
             raise
 
-    async def async_get_current_gps_data(self, dog_id: str) -> Optional[dict[str, Any]]:
+    async def async_get_current_gps_data(self, dog_id: str) -> dict[str, Any] | None:
         """Get current GPS data for a dog.
 
         Args:
@@ -768,7 +768,7 @@ class PawControlDataManager:
             raise
 
     async def async_end_grooming(
-        self, dog_id: str, grooming_data: Optional[dict[str, Any]] = None
+        self, dog_id: str, grooming_data: dict[str, Any] | None = None
     ) -> None:
         """End the current grooming session for a dog.
 
@@ -825,9 +825,9 @@ class PawControlDataManager:
         self,
         module: str,
         dog_id: str,
-        limit: Optional[int] = None,
-        start_date: Optional[datetime] = None,
-        end_date: Optional[datetime] = None,
+        limit: int | None = None,
+        start_date: datetime | None = None,
+        end_date: datetime | None = None,
     ) -> list[dict[str, Any]]:
         """Get module data for a specific dog.
 
@@ -1234,7 +1234,7 @@ class PawControlDataManager:
             await f.write(json.dumps(data, indent=2, default=str, ensure_ascii=False))
 
     async def async_cleanup_old_data(
-        self, retention_days: Optional[int] = None
+        self, retention_days: int | None = None
     ) -> dict[str, int]:
         """Clean up old data based on retention policy."""
         if retention_days is None:

--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from homeassistant.components.device_tracker import SourceType
 from homeassistant.components.device_tracker.config_entry import TrackerEntity
@@ -45,8 +45,8 @@ from .coordinator import PawControlCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases for better code readability
-LocationTuple = Tuple[float, float]  # (latitude, longitude)
-AttributeDict = Dict[str, Any]
+LocationTuple = tuple[float, float]  # (latitude, longitude)
+AttributeDict = dict[str, Any]
 
 # GPS tracking constants
 DEFAULT_GPS_ACCURACY = 100  # meters
@@ -58,7 +58,7 @@ MAX_GPS_AGE = timedelta(minutes=30)  # Maximum age for GPS data
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,
-    entities: List[PawControlDeviceTracker],
+    entities: list[PawControlDeviceTracker],
     batch_size: int = 8,
     delay_between_batches: float = 0.1,
 ) -> None:
@@ -122,18 +122,18 @@ async def async_setup_entry(
 
     if runtime_data:
         coordinator: PawControlCoordinator = runtime_data["coordinator"]
-        dogs: List[Dict[str, Any]] = runtime_data.get("dogs", [])
+        dogs: list[dict[str, Any]] = runtime_data.get("dogs", [])
     else:
         coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
         dogs = entry.data.get(CONF_DOGS, [])
 
-    entities: List[PawControlDeviceTracker] = []
+    entities: list[PawControlDeviceTracker] = []
 
     # Create device tracker entities for dogs with GPS enabled
     for dog in dogs:
         dog_id: str = dog[CONF_DOG_ID]
         dog_name: str = dog[CONF_DOG_NAME]
-        modules: Dict[str, bool] = dog.get("modules", {})
+        modules: dict[str, bool] = dog.get("modules", {})
 
         # Only create device tracker if GPS module is enabled
         if modules.get(MODULE_GPS, False):
@@ -198,13 +198,13 @@ class PawControlDeviceTracker(
         }
 
         # Internal state
-        self._last_known_location: Optional[LocationTuple] = None
-        self._last_update_time: Optional[datetime] = None
-        self._location_history: List[Dict[str, Any]] = []
-        self._current_zone: Optional[str] = None
+        self._last_known_location: LocationTuple | None = None
+        self._last_update_time: datetime | None = None
+        self._location_history: list[dict[str, Any]] = []
+        self._current_zone: str | None = None
 
         # Restore previous state
-        self._restored_data: Dict[str, Any] = {}
+        self._restored_data: dict[str, Any] = {}
 
     async def async_added_to_hass(self) -> None:
         """Called when entity is added to Home Assistant.
@@ -243,7 +243,7 @@ class PawControlDeviceTracker(
         return SourceType.GPS
 
     @property
-    def latitude(self) -> Optional[float]:
+    def latitude(self) -> float | None:
         """Return the latitude of the dog's current location.
 
         Returns:
@@ -260,7 +260,7 @@ class PawControlDeviceTracker(
         return None
 
     @property
-    def longitude(self) -> Optional[float]:
+    def longitude(self) -> float | None:
         """Return the longitude of the dog's current location.
 
         Returns:
@@ -294,7 +294,7 @@ class PawControlDeviceTracker(
         return DEFAULT_GPS_ACCURACY
 
     @property
-    def battery_level(self) -> Optional[int]:
+    def battery_level(self) -> int | None:
         """Return the battery level of the GPS tracker.
 
         Returns:
@@ -311,7 +311,7 @@ class PawControlDeviceTracker(
         return None
 
     @property
-    def location_name(self) -> Optional[str]:
+    def location_name(self) -> str | None:
         """Return the name of the current location/zone.
 
         Determines the current zone based on GPS coordinates and
@@ -341,7 +341,7 @@ class PawControlDeviceTracker(
 
         return STATE_NOT_HOME
 
-    def _determine_zone_from_coordinates(self, lat: float, lon: float) -> Optional[str]:
+    def _determine_zone_from_coordinates(self, lat: float, lon: float) -> str | None:
         """Determine zone name from coordinates.
 
         Checks if the given coordinates fall within any configured
@@ -471,7 +471,7 @@ class PawControlDeviceTracker(
         else:
             return "good"
 
-    def _is_currently_moving(self, gps_data: Dict[str, Any]) -> bool:
+    def _is_currently_moving(self, gps_data: dict[str, Any]) -> bool:
         """Determine if the dog is currently moving.
 
         Args:
@@ -501,7 +501,7 @@ class PawControlDeviceTracker(
 
         return False
 
-    def _get_movement_status(self, gps_data: Dict[str, Any]) -> str:
+    def _get_movement_status(self, gps_data: dict[str, Any]) -> str:
         """Get detailed movement status.
 
         Args:
@@ -521,7 +521,7 @@ class PawControlDeviceTracker(
         else:
             return "stationary"
 
-    def _assess_gps_signal_quality(self, gps_data: Dict[str, Any]) -> str:
+    def _assess_gps_signal_quality(self, gps_data: dict[str, Any]) -> str:
         """Assess GPS signal quality based on accuracy.
 
         Args:
@@ -543,7 +543,7 @@ class PawControlDeviceTracker(
         else:
             return "poor"
 
-    def _assess_data_freshness(self, gps_data: Dict[str, Any]) -> str:
+    def _assess_data_freshness(self, gps_data: dict[str, Any]) -> str:
         """Assess how fresh the GPS data is.
 
         Args:
@@ -571,7 +571,7 @@ class PawControlDeviceTracker(
         except (ValueError, TypeError):
             return "unknown"
 
-    def _get_tracking_status(self, gps_data: Dict[str, Any]) -> str:
+    def _get_tracking_status(self, gps_data: dict[str, Any]) -> str:
         """Get overall tracking status.
 
         Args:
@@ -684,7 +684,7 @@ class PawControlDeviceTracker(
         super()._handle_coordinator_update()
 
     def _update_location_history(
-        self, location: LocationTuple, gps_data: Dict[str, Any]
+        self, location: LocationTuple, gps_data: dict[str, Any]
     ) -> None:
         """Update the location history with a new position.
 
@@ -714,9 +714,7 @@ class PawControlDeviceTracker(
             gps_data.get("accuracy", "unknown"),
         )
 
-    def _handle_zone_change(
-        self, old_zone: Optional[str], new_zone: Optional[str]
-    ) -> None:
+    def _handle_zone_change(self, old_zone: str | None, new_zone: str | None) -> None:
         """Handle zone change events.
 
         Fires events and logs zone transitions for automation purposes.
@@ -769,7 +767,7 @@ class PawControlDeviceTracker(
             new_zone or "unknown",
         )
 
-    def _get_dog_data(self) -> Optional[Dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this tracker's dog from the coordinator.
 
         Returns:
@@ -780,7 +778,7 @@ class PawControlDeviceTracker(
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_gps_data(self) -> Optional[Dict[str, Any]]:
+    def _get_gps_data(self) -> dict[str, Any] | None:
         """Get GPS module data for this dog.
 
         Returns:
@@ -788,7 +786,7 @@ class PawControlDeviceTracker(
         """
         return self.coordinator.get_module_data(self._dog_id, "gps")
 
-    def _get_walk_data(self) -> Optional[Dict[str, Any]]:
+    def _get_walk_data(self) -> dict[str, Any] | None:
         """Get walk module data for this dog.
 
         Returns:
@@ -797,7 +795,7 @@ class PawControlDeviceTracker(
         return self.coordinator.get_module_data(self._dog_id, "walk")
 
     async def async_update_location(
-        self, latitude: float, longitude: float, accuracy: Optional[float] = None
+        self, latitude: float, longitude: float, accuracy: float | None = None
     ) -> None:
         """Manually update the dog's location.
 
@@ -822,7 +820,7 @@ class PawControlDeviceTracker(
         # Trigger coordinator refresh to process the new data
         await self.coordinator.async_refresh_dog(self._dog_id)
 
-    def get_location_history(self, hours: int = 24) -> List[Dict[str, Any]]:
+    def get_location_history(self, hours: int = 24) -> list[dict[str, Any]]:
         """Get location history for the specified time period.
 
         Args:

--- a/custom_components/pawcontrol/diagnostics.py
+++ b/custom_components/pawcontrol/diagnostics.py
@@ -9,7 +9,7 @@ Designed to meet Home Assistant's Platinum quality standards.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -53,7 +53,7 @@ REDACTED_KEYS = {
 
 async def async_get_config_entry_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Return diagnostics for a config entry.
 
     This function collects comprehensive diagnostic information including
@@ -71,7 +71,7 @@ async def async_get_config_entry_diagnostics(
 
     # Get integration data
     integration_data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
-    coordinator: Optional[PawControlCoordinator] = integration_data.get("coordinator")
+    coordinator: PawControlCoordinator | None = integration_data.get("coordinator")
 
     # Base diagnostics structure
     diagnostics = {
@@ -99,7 +99,7 @@ async def async_get_config_entry_diagnostics(
     return redacted_diagnostics
 
 
-async def _get_config_entry_diagnostics(entry: ConfigEntry) -> Dict[str, Any]:
+async def _get_config_entry_diagnostics(entry: ConfigEntry) -> dict[str, Any]:
     """Get configuration entry diagnostic information.
 
     Args:
@@ -128,7 +128,7 @@ async def _get_config_entry_diagnostics(entry: ConfigEntry) -> Dict[str, Any]:
     }
 
 
-async def _get_system_diagnostics(hass: HomeAssistant) -> Dict[str, Any]:
+async def _get_system_diagnostics(hass: HomeAssistant) -> dict[str, Any]:
     """Get Home Assistant system diagnostic information.
 
     Args:
@@ -151,8 +151,8 @@ async def _get_system_diagnostics(hass: HomeAssistant) -> Dict[str, Any]:
 
 
 async def _get_integration_status(
-    hass: HomeAssistant, entry: ConfigEntry, integration_data: Dict[str, Any]
-) -> Dict[str, Any]:
+    hass: HomeAssistant, entry: ConfigEntry, integration_data: dict[str, Any]
+) -> dict[str, Any]:
     """Get integration status diagnostics.
 
     Args:
@@ -185,8 +185,8 @@ async def _get_integration_status(
 
 
 async def _get_coordinator_diagnostics(
-    coordinator: Optional[PawControlCoordinator],
-) -> Dict[str, Any]:
+    coordinator: PawControlCoordinator | None,
+) -> dict[str, Any]:
     """Get coordinator diagnostic information.
 
     Args:
@@ -218,7 +218,7 @@ async def _get_coordinator_diagnostics(
 
 async def _get_entities_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get entities diagnostic information.
 
     Args:
@@ -234,7 +234,7 @@ async def _get_entities_diagnostics(
     entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
 
     # Group entities by platform
-    entities_by_platform: Dict[str, List[Dict[str, Any]]] = {}
+    entities_by_platform: dict[str, list[dict[str, Any]]] = {}
 
     for entity in entities:
         platform = entity.platform
@@ -286,7 +286,7 @@ async def _get_entities_diagnostics(
 
 async def _get_devices_diagnostics(
     hass: HomeAssistant, entry: ConfigEntry
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get devices diagnostic information.
 
     Args:
@@ -328,8 +328,8 @@ async def _get_devices_diagnostics(
 
 
 async def _get_dogs_summary(
-    entry: ConfigEntry, coordinator: Optional[PawControlCoordinator]
-) -> Dict[str, Any]:
+    entry: ConfigEntry, coordinator: PawControlCoordinator | None
+) -> dict[str, Any]:
     """Get summary of configured dogs.
 
     Args:
@@ -381,8 +381,8 @@ async def _get_dogs_summary(
 
 
 async def _get_performance_metrics(
-    coordinator: Optional[PawControlCoordinator],
-) -> Dict[str, Any]:
+    coordinator: PawControlCoordinator | None,
+) -> dict[str, Any]:
     """Get performance metrics.
 
     Args:
@@ -407,7 +407,7 @@ async def _get_performance_metrics(
     }
 
 
-async def _get_data_statistics(integration_data: Dict[str, Any]) -> Dict[str, Any]:
+async def _get_data_statistics(integration_data: dict[str, Any]) -> dict[str, Any]:
     """Get data storage statistics.
 
     Args:
@@ -432,7 +432,7 @@ async def _get_data_statistics(integration_data: Dict[str, Any]) -> Dict[str, An
     }
 
 
-async def _get_recent_errors(entry_id: str) -> List[Dict[str, Any]]:
+async def _get_recent_errors(entry_id: str) -> list[dict[str, Any]]:
     """Get recent error logs for this integration.
 
     Args:
@@ -453,7 +453,7 @@ async def _get_recent_errors(entry_id: str) -> List[Dict[str, Any]]:
 
 async def _get_debug_information(
     hass: HomeAssistant, entry: ConfigEntry
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """Get debug information.
 
     Args:
@@ -487,7 +487,7 @@ async def _get_debug_information(
     }
 
 
-async def _get_loaded_platforms(hass: HomeAssistant, entry: ConfigEntry) -> List[str]:
+async def _get_loaded_platforms(hass: HomeAssistant, entry: ConfigEntry) -> list[str]:
     """Get list of loaded platforms for this entry.
 
     Args:
@@ -519,7 +519,7 @@ async def _get_loaded_platforms(hass: HomeAssistant, entry: ConfigEntry) -> List
     return loaded_platforms
 
 
-async def _get_registered_services(hass: HomeAssistant) -> List[str]:
+async def _get_registered_services(hass: HomeAssistant) -> list[str]:
     """Get list of registered services for this domain.
 
     Args:
@@ -547,7 +547,7 @@ async def _get_registered_services(hass: HomeAssistant) -> List[str]:
     return services
 
 
-def _calculate_module_usage(dogs: List[Dict[str, Any]]) -> Dict[str, Any]:
+def _calculate_module_usage(dogs: list[dict[str, Any]]) -> dict[str, Any]:
     """Calculate module usage statistics across all dogs.
 
     Args:

--- a/custom_components/pawcontrol/discovery.py
+++ b/custom_components/pawcontrol/discovery.py
@@ -173,7 +173,7 @@ class PawControlDiscovery:
 
             return unique_devices
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             _LOGGER.warning("Device discovery timed out after %ds", scan_timeout)
             return list(self._discovered_devices.values())
         except Exception as err:

--- a/custom_components/pawcontrol/dog_manager.py
+++ b/custom_components/pawcontrol/dog_manager.py
@@ -2,22 +2,22 @@ from __future__ import annotations
 
 import asyncio
 import copy
-from typing import Any, Dict
+from typing import Any
 
 
 class DogDataManager:
     """In-memory storage for dog related data."""
 
     def __init__(self) -> None:
-        self._dogs: Dict[str, Dict[str, Any]] = {}
+        self._dogs: dict[str, dict[str, Any]] = {}
         self._lock = asyncio.Lock()
 
-    async def async_ensure_dog(self, dog_id: str, defaults: Dict[str, Any]) -> None:
+    async def async_ensure_dog(self, dog_id: str, defaults: dict[str, Any]) -> None:
         """Ensure a dog entry exists, creating it with defaults if necessary."""
         async with self._lock:
             self._dogs.setdefault(dog_id, defaults.copy())
 
-    async def async_update_dog(self, dog_id: str, data: Dict[str, Any]) -> None:
+    async def async_update_dog(self, dog_id: str, data: dict[str, Any]) -> None:
         """Update data for a given dog."""
         async with self._lock:
             self._dogs.setdefault(dog_id, {}).update(data)
@@ -27,7 +27,7 @@ class DogDataManager:
         async with self._lock:
             self._dogs.pop(dog_id, None)
 
-    async def async_all_dogs(self) -> Dict[str, Dict[str, Any]]:
+    async def async_all_dogs(self) -> dict[str, dict[str, Any]]:
         """Return a copy of all stored dog data."""
         async with self._lock:
             return copy.deepcopy(self._dogs)

--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass(slots=True)
@@ -21,21 +21,21 @@ class FeedingEvent:
 
     time: datetime
     amount: float
-    meal_type: Optional[str] = None
+    meal_type: str | None = None
 
 
 class FeedingManager:
     """Store and retrieve feeding information for dogs."""
 
     def __init__(self) -> None:
-        self._feedings: Dict[str, List[FeedingEvent]] = {}
+        self._feedings: dict[str, list[FeedingEvent]] = {}
 
     async def async_add_feeding(
         self,
         dog_id: str,
         amount: float,
-        meal_type: Optional[str] = None,
-        time: Optional[datetime] = None,
+        meal_type: str | None = None,
+        time: datetime | None = None,
     ) -> FeedingEvent:
         """Record a feeding event for a dog.
 
@@ -50,7 +50,7 @@ class FeedingManager:
         self._feedings.setdefault(dog_id, []).append(event)
         return event
 
-    async def async_get_feedings(self, dog_id: str) -> List[FeedingEvent]:
+    async def async_get_feedings(self, dog_id: str) -> list[FeedingEvent]:
         """Return a copy of the feeding history for ``dog_id``."""
 
         return list(self._feedings.get(dog_id, []))
@@ -72,7 +72,7 @@ class FeedingManager:
             }
 
         now = datetime.utcnow()
-        feedings_today: Dict[str, int] = {}
+        feedings_today: dict[str, int] = {}
         for event in feedings:
             if event.time.date() != now.date():
                 continue

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -60,7 +60,7 @@ class PawControlDataStorage:
         """
         self.hass = hass
         self.config_entry = config_entry
-        self._stores: Dict[str, storage.Store] = {}
+        self._stores: dict[str, storage.Store] = {}
 
         # Initialize storage for each data type
         self._initialize_stores()
@@ -88,7 +88,7 @@ class PawControlDataStorage:
                 atomic_writes=True,
             )
 
-    async def async_load_all_data(self) -> Dict[str, Any]:
+    async def async_load_all_data(self) -> dict[str, Any]:
         """Load all stored data for the integration.
 
         Returns:
@@ -120,7 +120,7 @@ class PawControlDataStorage:
             _LOGGER.error("Failed to load integration data: %s", err)
             raise HomeAssistantError(f"Data loading failed: {err}") from err
 
-    async def _load_store_data(self, store_key: str) -> Dict[str, Any]:
+    async def _load_store_data(self, store_key: str) -> dict[str, Any]:
         """Load data from a specific store.
 
         Args:
@@ -140,7 +140,7 @@ class PawControlDataStorage:
             _LOGGER.error("Failed to load %s store: %s", store_key, err)
             return {}
 
-    async def async_save_data(self, store_key: str, data: Dict[str, Any]) -> None:
+    async def async_save_data(self, store_key: str, data: dict[str, Any]) -> None:
         """Save data to a specific store.
 
         Args:
@@ -183,8 +183,8 @@ class PawControlDataStorage:
                 _LOGGER.error("Failed to cleanup %s data: %s", store_key, err)
 
     def _cleanup_store_data(
-        self, data: Dict[str, Any], cutoff_date: datetime
-    ) -> Dict[str, Any]:
+        self, data: dict[str, Any], cutoff_date: datetime
+    ) -> dict[str, Any]:
         """Remove entries older than cutoff date from store data.
 
         Args:
@@ -231,8 +231,8 @@ class PawControlData:
         self.hass = hass
         self.config_entry = config_entry
         self.storage = PawControlDataStorage(hass, config_entry)
-        self._data: Dict[str, Any] = {}
-        self._dogs: List[Dict[str, Any]] = config_entry.data.get(CONF_DOGS, [])
+        self._data: dict[str, Any] = {}
+        self._dogs: list[dict[str, Any]] = config_entry.data.get(CONF_DOGS, [])
 
     async def async_load_data(self) -> None:
         """Load all data from storage.
@@ -256,7 +256,7 @@ class PawControlData:
             }
 
     async def async_log_feeding(
-        self, dog_id: str, feeding_data: Dict[str, Any]
+        self, dog_id: str, feeding_data: dict[str, Any]
     ) -> None:
         """Log a feeding event for a dog.
 
@@ -302,7 +302,7 @@ class PawControlData:
             _LOGGER.error("Failed to log feeding for %s: %s", dog_id, err)
             raise HomeAssistantError(f"Failed to log feeding: {err}") from err
 
-    async def async_start_walk(self, dog_id: str, walk_data: Dict[str, Any]) -> None:
+    async def async_start_walk(self, dog_id: str, walk_data: dict[str, Any]) -> None:
         """Start a walk for a dog.
 
         Args:
@@ -347,7 +347,7 @@ class PawControlData:
             _LOGGER.error("Failed to start walk for %s: %s", dog_id, err)
             raise HomeAssistantError(f"Failed to start walk: {err}") from err
 
-    async def async_end_walk(self, dog_id: str) -> Optional[Dict[str, Any]]:
+    async def async_end_walk(self, dog_id: str) -> dict[str, Any] | None:
         """End an active walk for a dog.
 
         Args:
@@ -419,7 +419,7 @@ class PawControlData:
             _LOGGER.error("Failed to end walk for %s: %s", dog_id, err)
             raise HomeAssistantError(f"Failed to end walk: {err}") from err
 
-    async def async_log_health(self, dog_id: str, health_data: Dict[str, Any]) -> None:
+    async def async_log_health(self, dog_id: str, health_data: dict[str, Any]) -> None:
         """Log health data for a dog.
 
         Args:
@@ -533,7 +533,7 @@ class PawControlNotificationManager:
         """
         self.hass = hass
         self.config_entry = config_entry
-        self._notification_queue: List[Dict[str, Any]] = []
+        self._notification_queue: list[dict[str, Any]] = []
         self._setup_notification_processor()
 
     def _setup_notification_processor(self) -> None:
@@ -571,7 +571,7 @@ class PawControlNotificationManager:
         title: str,
         message: str,
         priority: str = "normal",
-        data: Optional[Dict[str, Any]] = None,
+        data: dict[str, Any] | None = None,
     ) -> None:
         """Send a notification for a specific dog.
 
@@ -602,7 +602,7 @@ class PawControlNotificationManager:
             # Queue normal and low priority notifications
             self._notification_queue.append(notification)
 
-    async def _send_notification_now(self, notification: Dict[str, Any]) -> None:
+    async def _send_notification_now(self, notification: dict[str, Any]) -> None:
         """Send a notification immediately.
 
         Args:

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from homeassistant.components import persistent_notification
 from homeassistant.core import HomeAssistant, ServiceCall
@@ -111,8 +111,8 @@ class PawControlNotificationManager:
         self._dog_settings: dict[str, dict[str, Any]] = {}
 
         # Background tasks
-        self._cleanup_task: Optional[asyncio.Task] = None
-        self._summary_task: Optional[asyncio.Task] = None
+        self._cleanup_task: asyncio.Task | None = None
+        self._summary_task: asyncio.Task | None = None
 
         # Performance metrics
         self._metrics: dict[str, Any] = {
@@ -187,12 +187,12 @@ class PawControlNotificationManager:
         notification_type: str,
         message: str,
         *,
-        title: Optional[str] = None,
+        title: str | None = None,
         priority: str = PRIORITY_NORMAL,
-        data: Optional[dict[str, Any]] = None,
-        delivery_methods: Optional[list[str]] = None,
+        data: dict[str, Any] | None = None,
+        delivery_methods: list[str] | None = None,
         force: bool = False,
-        actions: Optional[list[dict[str, Any]]] = None,
+        actions: list[dict[str, Any]] | None = None,
     ) -> bool:
         """Send a notification for a specific dog with comprehensive options.
 
@@ -364,7 +364,7 @@ class PawControlNotificationManager:
         )
 
     # Private helper methods
-    def _get_runtime_data(self) -> Optional[dict[str, Any]]:
+    def _get_runtime_data(self) -> dict[str, Any] | None:
         """Get runtime data for the integration using modern HA 2025.8+ approach.
 
         Returns:
@@ -801,7 +801,7 @@ class PawControlNotificationManager:
     async def async_send_summary_notification(
         self,
         timeframe: str = "daily",
-        dogs: Optional[list[str]] = None,
+        dogs: list[str] | None = None,
     ) -> bool:
         """Send a summary notification with activity overview."""
         try:

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -52,7 +52,7 @@ from .coordinator import PawControlCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases for better code readability
-AttributeDict = Dict[str, Any]
+AttributeDict = dict[str, Any]
 
 # Configuration limits and defaults
 DEFAULT_WALK_DURATION_TARGET = 60  # minutes
@@ -63,7 +63,7 @@ DEFAULT_ACTIVITY_GOAL = 100  # percentage
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,
-    entities: List[PawControlNumberBase],
+    entities: list[PawControlNumberBase],
     batch_size: int = 12,
     delay_between_batches: float = 0.1,
 ) -> None:
@@ -127,18 +127,18 @@ async def async_setup_entry(
 
     if runtime_data:
         coordinator: PawControlCoordinator = runtime_data["coordinator"]
-        dogs: List[Dict[str, Any]] = runtime_data.get("dogs", [])
+        dogs: list[dict[str, Any]] = runtime_data.get("dogs", [])
     else:
         coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
         dogs = entry.data.get(CONF_DOGS, [])
 
-    entities: List[PawControlNumberBase] = []
+    entities: list[PawControlNumberBase] = []
 
     # Create number entities for each configured dog
     for dog in dogs:
         dog_id: str = dog[CONF_DOG_ID]
         dog_name: str = dog[CONF_DOG_NAME]
-        modules: Dict[str, bool] = dog.get("modules", {})
+        modules: dict[str, bool] = dog.get("modules", {})
 
         _LOGGER.debug("Creating number entities for dog: %s (%s)", dog_name, dog_id)
 
@@ -173,8 +173,8 @@ def _create_base_numbers(
     coordinator: PawControlCoordinator,
     dog_id: str,
     dog_name: str,
-    dog_config: Dict[str, Any],
-) -> List[PawControlNumberBase]:
+    dog_config: dict[str, Any],
+) -> list[PawControlNumberBase]:
     """Create base numbers that are always present for every dog.
 
     Args:
@@ -195,7 +195,7 @@ def _create_base_numbers(
 
 def _create_feeding_numbers(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlNumberBase]:
+) -> list[PawControlNumberBase]:
     """Create feeding-related numbers for a dog.
 
     Args:
@@ -217,7 +217,7 @@ def _create_feeding_numbers(
 
 def _create_walk_numbers(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlNumberBase]:
+) -> list[PawControlNumberBase]:
     """Create walk-related numbers for a dog.
 
     Args:
@@ -239,7 +239,7 @@ def _create_walk_numbers(
 
 def _create_gps_numbers(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlNumberBase]:
+) -> list[PawControlNumberBase]:
     """Create GPS and location-related numbers for a dog.
 
     Args:
@@ -261,7 +261,7 @@ def _create_gps_numbers(
 
 def _create_health_numbers(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlNumberBase]:
+) -> list[PawControlNumberBase]:
     """Create health and medical-related numbers for a dog.
 
     Args:
@@ -298,15 +298,15 @@ class PawControlNumberBase(
         dog_name: str,
         number_type: str,
         *,
-        device_class: Optional[NumberDeviceClass] = None,
+        device_class: NumberDeviceClass | None = None,
         mode: NumberMode = NumberMode.AUTO,
-        native_unit_of_measurement: Optional[str] = None,
+        native_unit_of_measurement: str | None = None,
         native_min_value: float = 0,
         native_max_value: float = 100,
         native_step: float = 1,
-        icon: Optional[str] = None,
-        entity_category: Optional[EntityCategory] = None,
-        initial_value: Optional[float] = None,
+        icon: str | None = None,
+        entity_category: EntityCategory | None = None,
+        initial_value: float | None = None,
     ) -> None:
         """Initialize the number entity.
 
@@ -384,7 +384,7 @@ class PawControlNumberBase(
                 )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         """Return the current value of the number.
 
         Returns:
@@ -472,7 +472,7 @@ class PawControlNumberBase(
         # Base implementation - subclasses should override
         pass
 
-    def _get_dog_data(self) -> Optional[Dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this number's dog from the coordinator.
 
         Returns:
@@ -483,7 +483,7 @@ class PawControlNumberBase(
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[Dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         """Get specific module data for this dog.
 
         Args:
@@ -516,7 +516,7 @@ class PawControlDogWeightNumber(PawControlNumberBase):
         coordinator: PawControlCoordinator,
         dog_id: str,
         dog_name: str,
-        dog_config: Dict[str, Any],
+        dog_config: dict[str, Any],
     ) -> None:
         """Initialize the dog weight number."""
         current_weight = dog_config.get(CONF_DOG_WEIGHT, 20.0)
@@ -573,7 +573,7 @@ class PawControlDogAgeNumber(PawControlNumberBase):
         coordinator: PawControlCoordinator,
         dog_id: str,
         dog_name: str,
-        dog_config: Dict[str, Any],
+        dog_config: dict[str, Any],
     ) -> None:
         """Initialize the dog age number."""
         current_age = dog_config.get(CONF_DOG_AGE, 3)

--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -9,7 +9,7 @@ Platinum quality standards.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
 import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
@@ -57,7 +57,7 @@ async def async_create_issue(
     entry: ConfigEntry,
     issue_id: str,
     issue_type: str,
-    data: Optional[Dict[str, Any]] = None,
+    data: dict[str, Any] | None = None,
     severity: str = "warning",
 ) -> None:
     """Create a repair issue for the integration.
@@ -433,11 +433,11 @@ class PawControlRepairsFlow(RepairsFlow):
     def __init__(self) -> None:
         """Initialize the repair flow."""
         super().__init__()
-        self._issue_data: Dict[str, Any] = {}
+        self._issue_data: dict[str, Any] = {}
         self._repair_type: str = ""
 
     async def async_step_init(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle the initial step of a repair flow.
 
@@ -475,7 +475,7 @@ class PawControlRepairsFlow(RepairsFlow):
             return await self.async_step_unknown_issue()
 
     async def async_step_missing_dog_config(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle repair flow for missing dog configuration.
 
@@ -524,7 +524,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_add_first_dog(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle adding the first dog.
 
@@ -605,7 +605,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_duplicate_dog_ids(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle repair flow for duplicate dog IDs.
 
@@ -659,7 +659,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_invalid_gps_config(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle repair flow for invalid GPS configuration.
 
@@ -710,7 +710,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_configure_gps(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle GPS configuration step.
 
@@ -775,7 +775,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_missing_notifications(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle repair flow for missing notification services.
 
@@ -830,7 +830,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_performance_warning(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle performance warning repair flow.
 
@@ -880,7 +880,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_complete_repair(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Complete the repair flow.
 
@@ -899,7 +899,7 @@ class PawControlRepairsFlow(RepairsFlow):
         )
 
     async def async_step_unknown_issue(
-        self, user_input: Dict[str, Any] | None = None
+        self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Handle unknown issue types.
 
@@ -1016,7 +1016,7 @@ class PawControlRepairsFlow(RepairsFlow):
 def async_create_repair_flow(
     hass: HomeAssistant,
     issue_id: str,
-    data: Dict[str, Any] | None,
+    data: dict[str, Any] | None,
 ) -> PawControlRepairsFlow:
     """Create a repair flow.
 

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -48,7 +48,7 @@ from .coordinator import PawControlCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases for better code readability
-AttributeDict = Dict[str, Any]
+AttributeDict = dict[str, Any]
 
 # Additional option lists for selects
 WALK_MODES = [
@@ -99,7 +99,7 @@ WEATHER_CONDITIONS = [
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,
-    entities: List[PawControlSelectBase],
+    entities: list[PawControlSelectBase],
     batch_size: int = 10,
     delay_between_batches: float = 0.1,
 ) -> None:
@@ -163,18 +163,18 @@ async def async_setup_entry(
 
     if runtime_data:
         coordinator: PawControlCoordinator = runtime_data["coordinator"]
-        dogs: List[Dict[str, Any]] = runtime_data.get("dogs", [])
+        dogs: list[dict[str, Any]] = runtime_data.get("dogs", [])
     else:
         coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
         dogs = entry.data.get(CONF_DOGS, [])
 
-    entities: List[PawControlSelectBase] = []
+    entities: list[PawControlSelectBase] = []
 
     # Create select entities for each configured dog
     for dog in dogs:
         dog_id: str = dog[CONF_DOG_ID]
         dog_name: str = dog[CONF_DOG_NAME]
-        modules: Dict[str, bool] = dog.get("modules", {})
+        modules: dict[str, bool] = dog.get("modules", {})
 
         _LOGGER.debug("Creating select entities for dog: %s (%s)", dog_name, dog_id)
 
@@ -209,8 +209,8 @@ def _create_base_selects(
     coordinator: PawControlCoordinator,
     dog_id: str,
     dog_name: str,
-    dog_config: Dict[str, Any],
-) -> List[PawControlSelectBase]:
+    dog_config: dict[str, Any],
+) -> list[PawControlSelectBase]:
     """Create base selects that are always present for every dog.
 
     Args:
@@ -231,7 +231,7 @@ def _create_base_selects(
 
 def _create_feeding_selects(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSelectBase]:
+) -> list[PawControlSelectBase]:
     """Create feeding-related selects for a dog.
 
     Args:
@@ -252,7 +252,7 @@ def _create_feeding_selects(
 
 def _create_walk_selects(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSelectBase]:
+) -> list[PawControlSelectBase]:
     """Create walk-related selects for a dog.
 
     Args:
@@ -272,7 +272,7 @@ def _create_walk_selects(
 
 def _create_gps_selects(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSelectBase]:
+) -> list[PawControlSelectBase]:
     """Create GPS and location-related selects for a dog.
 
     Args:
@@ -292,7 +292,7 @@ def _create_gps_selects(
 
 def _create_health_selects(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSelectBase]:
+) -> list[PawControlSelectBase]:
     """Create health and medical-related selects for a dog.
 
     Args:
@@ -328,10 +328,10 @@ class PawControlSelectBase(
         dog_name: str,
         select_type: str,
         *,
-        options: List[str],
-        icon: Optional[str] = None,
-        entity_category: Optional[EntityCategory] = None,
-        initial_option: Optional[str] = None,
+        options: list[str],
+        icon: str | None = None,
+        entity_category: EntityCategory | None = None,
+        initial_option: str | None = None,
     ) -> None:
         """Initialize the select entity.
 
@@ -388,7 +388,7 @@ class PawControlSelectBase(
             )
 
     @property
-    def current_option(self) -> Optional[str]:
+    def current_option(self) -> str | None:
         """Return the current selected option.
 
         Returns:
@@ -472,7 +472,7 @@ class PawControlSelectBase(
         # Base implementation - subclasses should override
         pass
 
-    def _get_dog_data(self) -> Optional[Dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this select's dog from the coordinator.
 
         Returns:
@@ -483,7 +483,7 @@ class PawControlSelectBase(
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[Dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         """Get specific module data for this dog.
 
         Args:
@@ -516,7 +516,7 @@ class PawControlDogSizeSelect(PawControlSelectBase):
         coordinator: PawControlCoordinator,
         dog_id: str,
         dog_name: str,
-        dog_config: Dict[str, Any],
+        dog_config: dict[str, Any],
     ) -> None:
         """Initialize the dog size select."""
         current_size = dog_config.get(CONF_DOG_SIZE, "medium")
@@ -549,7 +549,7 @@ class PawControlDogSizeSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_size_info(self, size: Optional[str]) -> Dict[str, Any]:
+    def _get_size_info(self, size: str | None) -> dict[str, Any]:
         """Get information about the selected size.
 
         Args:
@@ -622,7 +622,7 @@ class PawControlPerformanceModeSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_performance_mode_info(self, mode: Optional[str]) -> Dict[str, Any]:
+    def _get_performance_mode_info(self, mode: str | None) -> dict[str, Any]:
         """Get information about the selected performance mode.
 
         Args:
@@ -713,7 +713,7 @@ class PawControlFoodTypeSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_food_type_info(self, food_type: Optional[str]) -> Dict[str, Any]:
+    def _get_food_type_info(self, food_type: str | None) -> dict[str, Any]:
         """Get information about the selected food type.
 
         Args:
@@ -860,7 +860,7 @@ class PawControlWalkModeSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_walk_mode_info(self, mode: Optional[str]) -> Dict[str, Any]:
+    def _get_walk_mode_info(self, mode: str | None) -> dict[str, Any]:
         """Get information about the selected walk mode.
 
         Args:
@@ -970,7 +970,7 @@ class PawControlGPSSourceSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_gps_source_info(self, source: Optional[str]) -> Dict[str, Any]:
+    def _get_gps_source_info(self, source: str | None) -> dict[str, Any]:
         """Get information about the selected GPS source.
 
         Args:
@@ -1086,7 +1086,7 @@ class PawControlHealthStatusSelect(PawControlSelectBase):
         )
 
     @property
-    def current_option(self) -> Optional[str]:
+    def current_option(self) -> str | None:
         """Return the current health status from data."""
         health_data = self._get_module_data("health")
         if health_data:
@@ -1118,7 +1118,7 @@ class PawControlActivityLevelSelect(PawControlSelectBase):
         )
 
     @property
-    def current_option(self) -> Optional[str]:
+    def current_option(self) -> str | None:
         """Return the current activity level from data."""
         health_data = self._get_module_data("health")
         if health_data:
@@ -1187,7 +1187,7 @@ class PawControlGroomingTypeSelect(PawControlSelectBase):
 
         return attrs
 
-    def _get_grooming_type_info(self, grooming_type: Optional[str]) -> Dict[str, Any]:
+    def _get_grooming_type_info(self, grooming_type: str | None) -> dict[str, Any]:
         """Get information about the selected grooming type.
 
         Args:

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -40,7 +40,7 @@ from .coordinator import PawControlCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases
-SensorValue = Union[str, int, float, datetime, None]
+SensorValue = str | int | float | datetime | None
 AttributeDict = dict[str, Any]
 
 # Entity Registry optimization: reduced logging frequency
@@ -207,11 +207,11 @@ class PawControlSensorBase(CoordinatorEntity[PawControlCoordinator], SensorEntit
         dog_name: str,
         sensor_type: str,
         *,
-        device_class: Optional[SensorDeviceClass] = None,
-        state_class: Optional[SensorStateClass] = None,
-        unit_of_measurement: Optional[str] = None,
-        icon: Optional[str] = None,
-        entity_category: Optional[EntityCategory] = None,
+        device_class: SensorDeviceClass | None = None,
+        state_class: SensorStateClass | None = None,
+        unit_of_measurement: str | None = None,
+        icon: str | None = None,
+        entity_category: EntityCategory | None = None,
     ) -> None:
         super().__init__(coordinator)
         self._dog_id = dog_id
@@ -253,12 +253,12 @@ class PawControlSensorBase(CoordinatorEntity[PawControlCoordinator], SensorEntit
             )
         return attrs
 
-    def _get_dog_data(self) -> Optional[dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         if not self.coordinator.available:
             return None
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         return self.coordinator.get_module_data(self._dog_id, module)
 
     @property
@@ -285,7 +285,7 @@ class PawControlLastActionSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[datetime]:
+    def native_value(self) -> datetime | None:
         """Return the most recent action timestamp."""
         dog_data = self._get_dog_data()
         if not dog_data:
@@ -362,7 +362,7 @@ class PawControlActivityScoreSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         """Calculate and return the activity score."""
         dog_data = self._get_dog_data()
         if not dog_data:
@@ -390,7 +390,7 @@ class PawControlActivityScoreSensor(PawControlSensorBase):
 
         return round((weighted_sum / total_weight) if total_weight > 0 else 0, 1)
 
-    def _calculate_walk_score(self, walk_data: dict) -> Optional[float]:
+    def _calculate_walk_score(self, walk_data: dict) -> float | None:
         """Calculate walk activity score."""
         walks_today = walk_data.get("walks_today", 0)
         total_duration = walk_data.get("total_duration_today", 0)
@@ -403,7 +403,7 @@ class PawControlActivityScoreSensor(PawControlSensorBase):
 
         return walk_count_score + duration_score
 
-    def _calculate_feeding_score(self, feeding_data: dict) -> Optional[float]:
+    def _calculate_feeding_score(self, feeding_data: dict) -> float | None:
         """Calculate feeding regularity score."""
         adherence = feeding_data.get("feeding_schedule_adherence", 0)
         target_met = feeding_data.get("daily_target_met", False)
@@ -414,13 +414,13 @@ class PawControlActivityScoreSensor(PawControlSensorBase):
 
         return min(score, 100)
 
-    def _calculate_gps_score(self, gps_data: dict) -> Optional[float]:
+    def _calculate_gps_score(self, gps_data: dict) -> float | None:
         """Calculate GPS activity score."""
         if not gps_data.get("last_seen"):
             return 0.0
         return 80.0 if gps_data.get("zone") else 0.0
 
-    def _calculate_health_score(self, health_data: dict) -> Optional[float]:
+    def _calculate_health_score(self, health_data: dict) -> float | None:
         """Calculate health maintenance score."""
         status = health_data.get("health_status", "good")
         scores = {
@@ -453,7 +453,7 @@ class PawControlLastFeedingSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[datetime]:
+    def native_value(self) -> datetime | None:
         """Return the last feeding timestamp."""
         feeding_data = self._get_module_data("feeding")
         if not feeding_data:
@@ -489,7 +489,7 @@ class PawControlLastFeedingHoursSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         """Return hours since last feeding."""
         feeding_data = self._get_module_data("feeding")
         return feeding_data.get("last_feeding_hours") if feeding_data else None
@@ -610,7 +610,7 @@ class PawControlFeedingCountTodaySensor(PawControlSensorBase):
                 return 0
 
         # Numeric total cannot be split reliably per meal. Return 0 for meal sensors.
-        if isinstance(feedings_today, (int, float)):
+        if isinstance(feedings_today, int | float):
             _LOGGER.debug(
                 "feedings_today is numeric (%s=%s). Per-meal breakdown not available for '%s'. Returning 0.",
                 type(feedings_today).__name__,
@@ -646,7 +646,7 @@ class PawControlLastWalkSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[datetime]:
+    def native_value(self) -> datetime | None:
         walk_data = self._get_module_data("walk")
         if not walk_data:
             return None
@@ -676,7 +676,7 @@ class PawControlLastWalkHoursSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         walk_data = self._get_module_data("walk")
         return walk_data.get("last_walk_hours") if walk_data else None
 
@@ -696,7 +696,7 @@ class PawControlLastWalkDurationSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[int]:
+    def native_value(self) -> int | None:
         walk_data = self._get_module_data("walk")
         return walk_data.get("last_walk_duration") if walk_data else None
 
@@ -776,7 +776,7 @@ class PawControlAverageWalkDurationSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         walk_data = self._get_module_data("walk")
         return walk_data.get("average_duration") if walk_data else None
 
@@ -799,7 +799,7 @@ class PawControlCurrentSpeedSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         gps_data = self._get_module_data("gps")
         return gps_data.get("current_speed") if gps_data else None
 
@@ -819,7 +819,7 @@ class PawControlDistanceFromHomeSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         gps_data = self._get_module_data("gps")
         return gps_data.get("distance_from_home") if gps_data else None
 
@@ -839,7 +839,7 @@ class PawControlGPSAccuracySensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         gps_data = self._get_module_data("gps")
         return gps_data.get("accuracy") if gps_data else None
 
@@ -859,7 +859,7 @@ class PawControlLastWalkDistanceSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         gps_data = self._get_module_data("gps")
         return gps_data.get("last_walk_distance") if gps_data else None
 
@@ -932,7 +932,7 @@ class PawControlGPSBatteryLevelSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[int]:
+    def native_value(self) -> int | None:
         gps_data = self._get_module_data("gps")
         return gps_data.get("battery") if gps_data else None
 
@@ -956,7 +956,7 @@ class PawControlWeightSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[float]:
+    def native_value(self) -> float | None:
         health_data = self._get_module_data("health")
         return health_data.get("weight") if health_data else None
 
@@ -1017,7 +1017,7 @@ class PawControlLastVetVisitSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[datetime]:
+    def native_value(self) -> datetime | None:
         health_data = self._get_module_data("health")
         if not health_data:
             return None
@@ -1047,7 +1047,7 @@ class PawControlDaysSinceGroomingSensor(PawControlSensorBase):
         )
 
     @property
-    def native_value(self) -> Optional[int]:
+    def native_value(self) -> int | None:
         health_data = self._get_module_data("health")
         return health_data.get("days_since_grooming") if health_data else None
 

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -901,7 +901,7 @@ class PawControlServiceManager:
                 else sum(
                     len(v) if isinstance(v, list) else 0
                     for v in export_data.values()
-                    if isinstance(v, (list, dict))
+                    if isinstance(v, list | dict)
                 ),
             )
 
@@ -1020,7 +1020,7 @@ async def async_setup_daily_reset_scheduler(hass: HomeAssistant, entry: Any) -> 
                 async with asyncio.timeout(60):
                     await hass.services.async_call(DOMAIN, SERVICE_DAILY_RESET, {})
                 _LOGGER.info("Daily reset completed successfully")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.error("Daily reset timed out after 60 seconds")
             except Exception as err:
                 _LOGGER.error("Daily reset task failed: %s", err, exc_info=True)

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -41,12 +41,12 @@ from .coordinator import PawControlCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 # Type aliases for better code readability
-AttributeDict = Dict[str, Any]
+AttributeDict = dict[str, Any]
 
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,
-    entities: List[PawControlSwitchBase],
+    entities: list[PawControlSwitchBase],
     batch_size: int = 14,
     delay_between_batches: float = 0.1,
 ) -> None:
@@ -110,18 +110,18 @@ async def async_setup_entry(
 
     if runtime_data:
         coordinator: PawControlCoordinator = runtime_data["coordinator"]
-        dogs: List[Dict[str, Any]] = runtime_data.get("dogs", [])
+        dogs: list[dict[str, Any]] = runtime_data.get("dogs", [])
     else:
         coordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
         dogs = entry.data.get(CONF_DOGS, [])
 
-    entities: List[PawControlSwitchBase] = []
+    entities: list[PawControlSwitchBase] = []
 
     # Create switch entities for each configured dog
     for dog in dogs:
         dog_id: str = dog[CONF_DOG_ID]
         dog_name: str = dog[CONF_DOG_NAME]
-        modules: Dict[str, bool] = dog.get("modules", {})
+        modules: dict[str, bool] = dog.get("modules", {})
 
         _LOGGER.debug("Creating switch entities for dog: %s (%s)", dog_name, dog_id)
 
@@ -159,7 +159,7 @@ async def async_setup_entry(
 
 def _create_base_switches(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSwitchBase]:
+) -> list[PawControlSwitchBase]:
     """Create base switches that are always present for every dog.
 
     Args:
@@ -181,8 +181,8 @@ def _create_module_switches(
     coordinator: PawControlCoordinator,
     dog_id: str,
     dog_name: str,
-    modules: Dict[str, bool],
-) -> List[PawControlSwitchBase]:
+    modules: dict[str, bool],
+) -> list[PawControlSwitchBase]:
     """Create module control switches for a dog.
 
     Args:
@@ -224,7 +224,7 @@ def _create_module_switches(
 
 def _create_feeding_switches(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSwitchBase]:
+) -> list[PawControlSwitchBase]:
     """Create feeding-related switches for a dog.
 
     Args:
@@ -245,7 +245,7 @@ def _create_feeding_switches(
 
 def _create_gps_switches(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSwitchBase]:
+) -> list[PawControlSwitchBase]:
     """Create GPS and location-related switches for a dog.
 
     Args:
@@ -267,7 +267,7 @@ def _create_gps_switches(
 
 def _create_health_switches(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSwitchBase]:
+) -> list[PawControlSwitchBase]:
     """Create health and medical-related switches for a dog.
 
     Args:
@@ -289,7 +289,7 @@ def _create_health_switches(
 
 def _create_notification_switches(
     coordinator: PawControlCoordinator, dog_id: str, dog_name: str
-) -> List[PawControlSwitchBase]:
+) -> list[PawControlSwitchBase]:
     """Create notification-related switches for a dog.
 
     Args:
@@ -326,9 +326,9 @@ class PawControlSwitchBase(
         dog_name: str,
         switch_type: str,
         *,
-        device_class: Optional[SwitchDeviceClass] = None,
-        icon: Optional[str] = None,
-        entity_category: Optional[EntityCategory] = None,
+        device_class: SwitchDeviceClass | None = None,
+        icon: str | None = None,
+        entity_category: EntityCategory | None = None,
         initial_state: bool = False,
     ) -> None:
         """Initialize the switch entity.
@@ -491,7 +491,7 @@ class PawControlSwitchBase(
         # Base implementation - subclasses should override
         pass
 
-    def _get_dog_data(self) -> Optional[Dict[str, Any]]:
+    def _get_dog_data(self) -> dict[str, Any] | None:
         """Get data for this switch's dog from the coordinator.
 
         Returns:
@@ -502,7 +502,7 @@ class PawControlSwitchBase(
 
         return self.coordinator.get_dog_data(self._dog_id)
 
-    def _get_module_data(self, module: str) -> Optional[Dict[str, Any]]:
+    def _get_module_data(self, module: str) -> dict[str, Any] | None:
         """Get specific module data for this dog.
 
         Args:
@@ -781,7 +781,7 @@ class PawControlModuleSwitch(PawControlSwitchBase):
         # GPS module typically requires additional setup
         return self._module_id == MODULE_GPS
 
-    def _get_module_dependencies(self) -> List[str]:
+    def _get_module_dependencies(self) -> list[str]:
         """Get list of modules this module depends on.
 
         Returns:
@@ -957,7 +957,7 @@ class PawControlGPSTrackingSwitch(PawControlSwitchBase):
 
         return attrs
 
-    def _assess_signal_quality(self, gps_data: Dict[str, Any]) -> str:
+    def _assess_signal_quality(self, gps_data: dict[str, Any]) -> str:
         """Assess GPS signal quality."""
         accuracy = gps_data.get("accuracy")
         if accuracy is None:

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from homeassistant.config_entries import ConfigEntry
 
@@ -30,8 +30,8 @@ DogId = str
 ConfigEntryId = str
 EntityId = str
 Timestamp = datetime
-ServiceData = Dict[str, Any]
-ConfigData = Dict[str, Any]
+ServiceData = dict[str, Any]
+ConfigData = dict[str, Any]
 
 
 class DogConfigData(TypedDict, total=False):
@@ -39,14 +39,14 @@ class DogConfigData(TypedDict, total=False):
 
     dog_id: str
     dog_name: str
-    dog_breed: Optional[str]
-    dog_age: Optional[int]
-    dog_weight: Optional[float]
-    dog_size: Optional[str]
-    dog_color: Optional[str]
-    microchip_id: Optional[str]
-    vet_contact: Optional[str]
-    emergency_contact: Optional[str]
+    dog_breed: str | None
+    dog_age: int | None
+    dog_weight: float | None
+    dog_size: str | None
+    dog_color: str | None
+    microchip_id: str | None
+    vet_contact: str | None
+    emergency_contact: str | None
 
 
 class ModuleConfigData(TypedDict, total=False):
@@ -64,12 +64,12 @@ class ModuleConfigData(TypedDict, total=False):
 class SourceConfigData(TypedDict, total=False):
     """Type definition for source entity configuration."""
 
-    door_sensor: Optional[str]
-    person_entities: List[str]
-    device_trackers: List[str]
-    notify_fallback: Optional[str]
-    calendar: Optional[str]
-    weather: Optional[str]
+    door_sensor: str | None
+    person_entities: list[str]
+    device_trackers: list[str]
+    notify_fallback: str | None
+    calendar: str | None
+    weather: str | None
 
 
 class GPSConfigData(TypedDict, total=False):
@@ -82,7 +82,7 @@ class GPSConfigData(TypedDict, total=False):
     home_zone_radius: int
     auto_walk_detection: bool
     geofencing: bool
-    geofence_zones: List[Dict[str, Any]]
+    geofence_zones: list[dict[str, Any]]
 
 
 class NotificationConfigData(TypedDict, total=False):
@@ -101,12 +101,12 @@ class NotificationConfigData(TypedDict, total=False):
 class FeedingConfigData(TypedDict, total=False):
     """Type definition for feeding configuration."""
 
-    feeding_times: List[str]
-    breakfast_time: Optional[str]
-    lunch_time: Optional[str]
-    dinner_time: Optional[str]
-    snack_times: List[str]
-    daily_food_amount: Optional[float]
+    feeding_times: list[str]
+    breakfast_time: str | None
+    lunch_time: str | None
+    dinner_time: str | None
+    snack_times: list[str]
+    daily_food_amount: float | None
     meals_per_day: int
     food_type: str
 
@@ -134,7 +134,7 @@ class SystemConfigData(TypedDict, total=False):
 class PawControlConfigData(TypedDict, total=False):
     """Complete configuration data structure."""
 
-    dogs: List[DogConfigData]
+    dogs: list[DogConfigData]
     modules: ModuleConfigData
     sources: SourceConfigData
     gps: GPSConfigData
@@ -154,7 +154,7 @@ class FeedingData:
     timestamp: datetime
     notes: str = ""
     logged_by: str = ""
-    calories: Optional[float] = None
+    calories: float | None = None
 
 
 @dataclass
@@ -162,10 +162,10 @@ class WalkData:
     """Data structure for walk information."""
 
     start_time: datetime
-    end_time: Optional[datetime] = None
-    duration: Optional[int] = None  # seconds
-    distance: Optional[float] = None  # meters
-    route: List[Dict[str, float]] = field(default_factory=list)
+    end_time: datetime | None = None
+    duration: int | None = None  # seconds
+    distance: float | None = None  # meters
+    route: list[dict[str, float]] = field(default_factory=list)
     label: str = ""
     location: str = ""
     notes: str = ""
@@ -179,13 +179,13 @@ class HealthData:
     """Data structure for health information."""
 
     timestamp: datetime
-    weight: Optional[float] = None
-    temperature: Optional[float] = None
+    weight: float | None = None
+    temperature: float | None = None
     mood: str = ""
     activity_level: str = ""
     health_status: str = ""
     symptoms: str = ""
-    medication: Optional[Dict[str, Any]] = None
+    medication: dict[str, Any] | None = None
     note: str = ""
     logged_by: str = ""
 
@@ -196,8 +196,8 @@ class GPSLocation:
 
     latitude: float
     longitude: float
-    accuracy: Optional[float] = None
-    altitude: Optional[float] = None
+    accuracy: float | None = None
+    altitude: float | None = None
     timestamp: datetime = field(default_factory=datetime.now)
     source: str = ""
 
@@ -212,7 +212,7 @@ class GeofenceZone:
     radius: float
     zone_type: str = "safe_zone"
     notifications: bool = True
-    auto_actions: List[str] = field(default_factory=list)
+    auto_actions: list[str] = field(default_factory=list)
 
 
 @dataclass
@@ -225,7 +225,7 @@ class NotificationData:
     channel: str = "mobile"
     timestamp: datetime = field(default_factory=datetime.now)
     persistent: bool = False
-    actions: List[Dict[str, str]] = field(default_factory=list)
+    actions: list[dict[str, str]] = field(default_factory=list)
 
 
 @dataclass
@@ -239,8 +239,8 @@ class DailyStats:
     total_walk_time: int = 0  # seconds
     total_walk_distance: float = 0.0  # meters
     health_logs_count: int = 0
-    last_feeding_time: Optional[datetime] = None
-    last_walk_time: Optional[datetime] = None
+    last_feeding_time: datetime | None = None
+    last_walk_time: datetime | None = None
 
 
 @dataclass
@@ -251,8 +251,8 @@ class DogProfile:
     dog_name: str
     config: DogConfigData
     daily_stats: DailyStats
-    current_walk: Optional[WalkData] = None
-    last_location: Optional[GPSLocation] = None
+    current_walk: WalkData | None = None
+    last_location: GPSLocation | None = None
     is_visitor_mode: bool = False
 
 
@@ -270,16 +270,16 @@ class PawControlRuntimeData(TypedDict):
     data_manager: PawControlDataManager
     notification_manager: PawControlNotificationManager
     config_entry: ConfigEntry
-    dogs: List[DogConfigData]
+    dogs: list[DogConfigData]
 
 
 class EntityStateData(TypedDict, total=False):
     """Type definition for entity state data."""
 
-    state: Union[str, int, float, bool, None]
-    attributes: Dict[str, Any]
+    state: str | int | float | bool | None
+    attributes: dict[str, Any]
     last_updated: datetime
-    context_id: Optional[str]
+    context_id: str | None
 
 
 class ServiceCallData(TypedDict, total=False):
@@ -288,21 +288,21 @@ class ServiceCallData(TypedDict, total=False):
     domain: str
     service: str
     service_data: ServiceData
-    target: Optional[Dict[str, Any]]
+    target: dict[str, Any] | None
     blocking: bool
-    context: Optional[Any]
+    context: Any | None
 
 
 class DiagnosticsData(TypedDict):
     """Type definition for diagnostics data."""
 
-    config_entry: Dict[str, Any]
-    dogs: List[Dict[str, Any]]
-    entities: List[Dict[str, Any]]
-    services: List[str]
-    statistics: Dict[str, Any]
-    performance: Dict[str, Any]
-    errors: List[Dict[str, Any]]
+    config_entry: dict[str, Any]
+    dogs: list[dict[str, Any]]
+    entities: list[dict[str, Any]]
+    services: list[str]
+    statistics: dict[str, Any]
+    performance: dict[str, Any]
+    errors: list[dict[str, Any]]
 
 
 class RepairIssueData(TypedDict):
@@ -311,8 +311,8 @@ class RepairIssueData(TypedDict):
     issue_id: str
     translation_key: str
     severity: str
-    learn_more_url: Optional[str]
-    translation_placeholders: Optional[Dict[str, str]]
+    learn_more_url: str | None
+    translation_placeholders: dict[str, str] | None
 
 
 # Type guards for runtime type checking
@@ -335,8 +335,8 @@ def is_gps_location_valid(location: Any) -> bool:
         isinstance(location, dict)
         and "latitude" in location
         and "longitude" in location
-        and isinstance(location["latitude"], (int, float))
-        and isinstance(location["longitude"], (int, float))
+        and isinstance(location["latitude"], int | float)
+        and isinstance(location["longitude"], int | float)
         and -90 <= location["latitude"] <= 90
         and -180 <= location["longitude"] <= 180
     )
@@ -349,7 +349,7 @@ def is_feeding_data_valid(data: Any) -> bool:
         and "meal_type" in data
         and "portion_size" in data
         and isinstance(data["meal_type"], str)
-        and isinstance(data["portion_size"], (int, float))
+        and isinstance(data["portion_size"], int | float)
         and data["portion_size"] >= 0
     )
 
@@ -394,7 +394,7 @@ class PawControlError:
     code: str
     message: str
     timestamp: datetime = field(default_factory=datetime.now)
-    context: Dict[str, Any] = field(default_factory=dict)
+    context: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass
@@ -418,7 +418,7 @@ class GPSError(PawControlError):
     """GPS-related error."""
 
     location_source: str = ""
-    last_known_location: Optional[GPSLocation] = None
+    last_known_location: GPSLocation | None = None
 
 
 @dataclass

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -76,7 +76,7 @@ def performance_monitor(timeout: float = CALCULATION_TIMEOUT) -> Callable:
                     )
 
                 return result
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 _LOGGER.error("Function %s timed out after %ss", func.__name__, timeout)
                 raise
 

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -13,7 +13,6 @@ import copy
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Dict, List, Optional
 
 
 @dataclass(slots=True)
@@ -22,7 +21,7 @@ class WalkSession:
 
     walk_id: str
     start: datetime
-    end: Optional[datetime] = None
+    end: datetime | None = None
     distance: float = 0.0
 
 
@@ -30,8 +29,8 @@ class WalkManager:
     """Track walks for multiple dogs."""
 
     def __init__(self) -> None:
-        self._active: Dict[str, WalkSession] = {}
-        self._history: Dict[str, List[WalkSession]] = {}
+        self._active: dict[str, WalkSession] = {}
+        self._history: dict[str, list[WalkSession]] = {}
 
     async def async_start_walk(self, dog_id: str) -> WalkSession:
         """Start a walk for ``dog_id``.
@@ -48,7 +47,7 @@ class WalkManager:
 
     async def async_end_walk(
         self, dog_id: str, distance: float = 0.0
-    ) -> Optional[WalkSession]:
+    ) -> WalkSession | None:
         """End the current walk for ``dog_id`` and return the session."""
         session = self._active.pop(dog_id, None)
         if not session:
@@ -57,6 +56,6 @@ class WalkManager:
         session.distance = distance
         return session
 
-    async def async_get_walks(self, dog_id: str) -> List[WalkSession]:
+    async def async_get_walks(self, dog_id: str) -> list[WalkSession]:
         """Return a copy of the walk history for ``dog_id``."""
         return [copy.copy(session) for session in self._history.get(dog_id, [])]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -13,7 +13,7 @@ The diagnostics module is critical for support and troubleshooting.
 
 import re
 from datetime import datetime, timedelta
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
@@ -543,7 +543,7 @@ class TestSystemDiagnostics:
         assert diagnostics["timezone"] == "Europe/Berlin"
         assert diagnostics["is_running"] is True
         assert diagnostics["safe_mode"] is False
-        assert isinstance(diagnostics["uptime_seconds"], (int, float))
+        assert isinstance(diagnostics["uptime_seconds"], int | float)
         assert diagnostics["uptime_seconds"] > 0
 
     async def test_get_system_diagnostics_recovery_mode(self, mock_hass_with_states):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -12,7 +12,7 @@ The helpers module is critical for data management and requires thorough testing
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any, Dict, List
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -190,9 +190,7 @@ class TestAsyncSetupEntry:
         mock_notification_manager,
     ):
         """Test setup when coordinator refresh times out."""
-        mock_coordinator.async_config_entry_first_refresh.side_effect = (
-            asyncio.TimeoutError()
-        )
+        mock_coordinator.async_config_entry_first_refresh.side_effect = TimeoutError()
 
         with (
             patch(
@@ -310,7 +308,7 @@ class TestAsyncUnloadEntry:
         with patch.object(
             hass.config_entries,
             "async_unload_platforms",
-            side_effect=asyncio.TimeoutError(),
+            side_effect=TimeoutError(),
         ):
             result = await async_unload_entry(hass, mock_config_entry)
             assert result is False

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -13,7 +13,7 @@ The notification module is critical for user experience and requires thorough te
 
 import asyncio
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, call, patch
 
 import pytest

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -11,7 +11,7 @@ user-guided repair flows, so comprehensive testing is essential.
 """
 
 from datetime import datetime, timedelta
-from typing import Any, Dict
+from typing import Any
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest


### PR DESCRIPTION
## Summary
- replace typing aliases with builtin types for ruff UP fixes

## Testing
- `pre-commit run --files custom_components/pawcontrol/sensor.py tests/test_diagnostics.py tests/test_helpers.py tests/test_notifications.py tests/test_repairs.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiousbwatcher')*

------
https://chatgpt.com/codex/tasks/task_e_68b5d7e626a083318767feab87c9bba3