### PR TITLE
Refine portion safeguards in feeding manager

### DIFF
--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -304,8 +304,12 @@ class FeedingConfig:
         portion = max(portion, MINIMUM_NUTRITION_PORTION_G)
 
         # Apply safety limits
-        min_portion = adjusted_daily_grams * MIN_PORTION_SAFETY_FACTOR  # Min 10% of daily amount
-        max_portion = adjusted_daily_grams * MAX_PORTION_SAFETY_FACTOR  # Max 60% of daily amount
+        min_portion = (
+            adjusted_daily_grams * MIN_PORTION_SAFETY_FACTOR
+        )  # Min 10% of daily amount
+        max_portion = (
+            adjusted_daily_grams * MAX_PORTION_SAFETY_FACTOR
+        )  # Max 60% of daily amount
         portion = max(min_portion, min(portion, max_portion))
 
         # Log diet validation adjustments if applied

--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -304,8 +304,8 @@ class FeedingConfig:
         portion = max(portion, MINIMUM_NUTRITION_PORTION_G)
 
         # Apply safety limits
-        min_portion = adjusted_daily_grams * 0.1  # Min 10% of daily amount
-        max_portion = adjusted_daily_grams * 0.6  # Max 60% of daily amount
+        min_portion = adjusted_daily_grams * MIN_PORTION_SAFETY_FACTOR  # Min 10% of daily amount
+        max_portion = adjusted_daily_grams * MAX_PORTION_SAFETY_FACTOR  # Max 60% of daily amount
         portion = max(min_portion, min(portion, max_portion))
 
         # Log diet validation adjustments if applied


### PR DESCRIPTION
## Summary
- extract portion safeguard magic numbers into named constants
- apply nutritional minimum before safety clamp to respect maximum limits

## Testing
- `pre-commit run --files custom_components/pawcontrol/feeding_manager.py custom_components/pawcontrol/system_health.py`
- `pytest -o addopts= tests/test_feeding_manager.py` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68bec13462ac8331a6e9060bf3d094c9