### PR TITLE
fix missing import in config_flow_profile

### DIFF
--- a/custom_components/pawcontrol/config_flow_profile.py
+++ b/custom_components/pawcontrol/config_flow_profile.py
@@ -4,6 +4,8 @@ Updates config_flow.py to include entity profile selection.
 Reduces entity count from 54+ to 8-18 per dog based on user needs.
 """
 
+import voluptuous as vol
+
 # Add to config_flow.py - Profile selection step
 
 ENTITY_PROFILES = {


### PR DESCRIPTION
## Summary
- add voluptuous import to config flow profile module

## Testing
- `ruff check custom_components/pawcontrol/config_flow_profile.py`
- `pytest` *(fails: ImportError attempted relative import with no known parent package; SyntaxError nonlocal declared after assignment; ImportError cannot import name 'deep_merge_dicts')*

------
https://chatgpt.com/codex/tasks/task_e_68bec4bc19ec83319c4a9965903a8852