### PR TITLE
chore: exclude tests from quality checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ markers = ["asyncio: mark a test as using asyncio"]
 [tool.ruff]
 target-version = "py313"
 line-length = 88
-src = ["custom_components/pawcontrol", "tests"]
+src = ["custom_components/pawcontrol"]
+extend-exclude = ["tests"]
 markers = ["asyncio: mark a test as using asyncio"]
 
 [tool.ruff.lint]
@@ -50,6 +51,7 @@ no_implicit_optional = true
 check_untyped_defs = true
 ignore_missing_imports = true
 explicit_package_bases = true
+exclude = "tests/"
 
 [project.optional-dependencies]
 test = ["pytest>=8.3.0", "pytest-asyncio>=1.1.0", "pytest-cov>=5.0", "coverage[toml]>=7.6.0"]


### PR DESCRIPTION
## Summary
- ignore tests directory in quality tools
- restrict type-checking to integration code

## Testing
- `ruff check custom_components/pawcontrol`
- `pytest -q` *(fails: ImportError attempted relative import with no known parent package)*

------
https://chatgpt.com/codex/tasks/task_e_68beee4e9b348331828ff635d3984e80