### PR TITLE
Use tmp_path for export_json test

### DIFF
--- a/tests/test_data_manager.py
+++ b/tests/test_data_manager.py
@@ -3,7 +3,6 @@
 import asyncio
 import json
 from datetime import datetime, timedelta
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, Mock, mock_open, patch
 
 import pytest
@@ -833,10 +832,10 @@ class TestPawControlDataManager:
             assert backup_data["dogs"] == dogs_data
 
     @pytest.mark.asyncio
-    async def test_export_json(self, data_manager):
+    async def test_export_json(self, data_manager, tmp_path):
         """Test JSON export functionality."""
         test_data = {"test": "data", "number": 123}
-        test_path = Path("/tmp/test.json")
+        test_path = tmp_path / "test.json"
 
         mock_file = mock_open()
 


### PR DESCRIPTION
## Summary
- replace hard-coded `/tmp/test.json` with pytest's `tmp_path` fixture in export JSON test
- remove unused `Path` import

## Testing
- `pre-commit run --files tests/test_data_manager.py`
- `pytest tests/test_data_manager.py::TestPawControlDataManager::test_export_json -q` *(fails: ModuleNotFoundError: No module named 'homeassistant')*


------
https://chatgpt.com/codex/tasks/task_e_68bef2f1b3d08331a8968e2b2355f072