### PR TITLE
refactor: centralize device info generation

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -44,6 +44,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .exceptions import WalkAlreadyInProgressError, WalkNotInProgressError
+from .utils import create_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -545,16 +546,8 @@ class PawControlButtonBase(CoordinatorEntity[PawControlCoordinator], ButtonEntit
         self._attr_device_class = device_class
         self._attr_icon = icon
         self._attr_entity_category = entity_category
-
-        # Device info
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, dog_id)},
-            "name": dog_name,
-            "manufacturer": "Paw Control",
-            "model": "Smart Dog Monitoring",
-            "sw_version": "2.0.0",  # Updated for profile system
-            "configuration_url": "https://github.com/BigDaddy1990/pawcontrol",
-        }
+        # Device info for proper grouping - HA 2025.8+ compatible with configuration_url
+        self._attr_device_info = create_device_info(dog_id, dog_name)
 
     @property
     def extra_state_attributes(self) -> Dict[str, Any]:

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -34,6 +34,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .entity_factory import EntityFactory
+from .utils import create_device_info
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -180,14 +181,8 @@ class PawControlSensorBase(CoordinatorEntity[PawControlCoordinator], SensorEntit
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._attr_icon = icon
         self._attr_entity_category = entity_category
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, dog_id)},
-            "name": dog_name,
-            "manufacturer": "Paw Control",
-            "model": "Smart Dog Monitoring",
-            "sw_version": "2.0.0",  # Updated version for profile-based system
-            "configuration_url": "https://github.com/BigDaddy1990/pawcontrol",
-        }
+        # Device info for proper grouping - HA 2025.8+ compatible with configuration_url
+        self._attr_device_info = create_device_info(dog_id, dog_name)
 
         # OPTIMIZATION: Per-update module data cache
         self._module_cache: dict[str, Any] = {}

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -25,7 +25,12 @@ from typing import Any, TypeVar, overload
 
 from homeassistant.util import dt as dt_util
 
-from .const import DOG_SIZE_WEIGHT_RANGES, MAX_DOG_WEIGHT, MIN_DOG_WEIGHT
+from .const import (
+    DOG_SIZE_WEIGHT_RANGES,
+    DOMAIN,
+    MAX_DOG_WEIGHT,
+    MIN_DOG_WEIGHT,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -616,6 +621,19 @@ def sanitize_filename_advanced(
     return sanitized
 
 
+# OPTIMIZED: Device info generation helper
+def create_device_info(dog_id: str, dog_name: str) -> dict[str, Any]:
+    """OPTIMIZED: Generate consistent device info with configuration URL."""
+    return {
+        "identifiers": {(DOMAIN, dog_id)},
+        "name": dog_name,
+        "manufacturer": "Paw Control",
+        "model": "Smart Dog Monitoring",
+        "sw_version": "2.0.0",
+        "configuration_url": "https://github.com/BigDaddy1990/pawcontrol",
+    }
+
+
 # OPTIMIZED: Legacy compatibility with deprecation paths
 def safe_float(value: Any, default: float = 0.0) -> float:
     """Legacy compatibility - use safe_convert instead."""
@@ -648,6 +666,7 @@ __all__ = (
     "calculate_bmr_advanced",
     "calculate_trend_advanced",
     # Utilities
+    "create_device_info",
     "safe_convert",
     "deep_merge_dicts_optimized",
     "is_within_time_range_enhanced",


### PR DESCRIPTION
## Summary
- add create_device_info helper for consistent device metadata
- use shared helper in sensor and button entities

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py custom_components/pawcontrol/sensor.py custom_components/pawcontrol/button.py`
- `pytest tests/test_sensor.py tests/test_button.py` *(fails: cannot import name 'PawControlActivityLevelSensor')*


------
https://chatgpt.com/codex/tasks/task_e_68bef3574e288331ac48d7b00af7e067