### PR TITLE
refactor: centralize dashboard mode options

### DIFF
--- a/custom_components/pawcontrol/config_flow_dashboard_extension.py
+++ b/custom_components/pawcontrol/config_flow_dashboard_extension.py
@@ -23,6 +23,7 @@ from .const import (
     CONF_DASHBOARD_MODE,
     CONF_DASHBOARD_PER_DOG,
     CONF_DASHBOARD_THEME,
+    DASHBOARD_MODE_SELECTOR_OPTIONS,
     DEFAULT_DASHBOARD_AUTO_CREATE,
     DEFAULT_DASHBOARD_MODE,
     DEFAULT_DASHBOARD_THEME,
@@ -103,20 +104,7 @@ class DashboardFlowMixin:
                     default=DEFAULT_DASHBOARD_MODE if has_multiple_dogs else "cards",
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=[
-                            {
-                                "value": "full",
-                                "label": "Full - Complete dashboard with all features",
-                            },
-                            {
-                                "value": "cards",
-                                "label": "Cards - Organized card-based layout",
-                            },
-                            {
-                                "value": "minimal",
-                                "label": "Minimal - Essential information only",
-                            },
-                        ],
+                        options=DASHBOARD_MODE_SELECTOR_OPTIONS,
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 ),

--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -208,6 +208,20 @@ ACTIVITY_LEVELS: Final = ("very_low", "low", "normal", "high", "very_high")
 
 # OPTIMIZED: Dashboard configuration
 DASHBOARD_MODES: Final = ("full", "cards", "minimal")
+DASHBOARD_MODE_SELECTOR_OPTIONS: Final = [
+    {
+        "value": "full",
+        "label": "Full - Complete dashboard with all features",
+    },
+    {
+        "value": "cards",
+        "label": "Cards - Organized card-based layout",
+    },
+    {
+        "value": "minimal",
+        "label": "Minimal - Essential information only",
+    },
+]
 
 CONF_DASHBOARD_ENABLED: Final = "dashboard_enabled"
 CONF_DASHBOARD_AUTO_CREATE: Final = "dashboard_auto_create"

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -40,6 +40,7 @@ from .const import (
     CONF_QUIET_START,
     CONF_REMINDER_REPEAT_MIN,
     CONF_RESET_TIME,
+    DASHBOARD_MODE_SELECTOR_OPTIONS,
     DEFAULT_GPS_ACCURACY_FILTER,
     DEFAULT_GPS_DISTANCE_FILTER,
     DEFAULT_GPS_UPDATE_INTERVAL,
@@ -1535,20 +1536,7 @@ class PawControlOptionsFlow(OptionsFlow):
                     ),
                 ): selector.SelectSelector(
                     selector.SelectSelectorConfig(
-                        options=[
-                            {
-                                "value": "full",
-                                "label": "Full - All information displayed",
-                            },
-                            {
-                                "value": "cards",
-                                "label": "Cards - Organized card layout",
-                            },
-                            {
-                                "value": "minimal",
-                                "label": "Minimal - Essential information only",
-                            },
-                        ],
+                        options=DASHBOARD_MODE_SELECTOR_OPTIONS,
                         mode=selector.SelectSelectorMode.DROPDOWN,
                     )
                 ),


### PR DESCRIPTION
## Summary
- consolidate dashboard mode options into a shared constant
- reuse dashboard mode selector in options and config flows

## Testing
- `pre-commit run --files custom_components/pawcontrol/const.py custom_components/pawcontrol/options_flow.py custom_components/pawcontrol/config_flow_dashboard_extension.py`
- `pytest` *(fails: ImportError and SyntaxError in tests)*


------
https://chatgpt.com/codex/tasks/task_e_68bef38bbb3883319c6c162cb85ab397