### PR TITLE
Ignore imports in duplication checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ source = ["custom_components/pawcontrol"]
 show_missing = true
 skip_covered = false
 precision = 2
+
+[tool.pylint.similarities]
+ignore-imports = "yes"


### PR DESCRIPTION
## Summary
- configure Pylint to ignore import statements when detecting duplicate code

## Testing
- `pre-commit run --files pyproject.toml`

------
https://chatgpt.com/codex/tasks/task_e_68bf038b76a0833184083e304da4f2f3