### PR TITLE
Align duplication and bandit configs with Home Assistant

### DIFF
--- a/.bandit.yml
+++ b/.bandit.yml
@@ -1,91 +1,15 @@
-### This config may optionally select a subset of tests to run or skip by
-### filling out the 'tests' and 'skips' lists given below. If no tests are
-### specified for inclusion then it is assumed all tests are desired. The skips
-### set will remove specific tests from the include set. This can be controlled
-### using the -t/-s CLI options. Note that the same test ID should not appear
-### in both 'tests' and 'skips', this would be nonsensical and is detected by
-### Bandit at runtime.
+# Bandit configuration aligned with Home Assistant guidelines
+exclude_dirs:
+  - tests
 
-# (optional) list included test IDs here, eg '[B101, B406]':
-tests:
-
-# (optional) list skipped test IDs here, eg '[B101, B406]':
-skips: [B101, B102, B105, B106, B107, B113, B202, B401, B402, B403, B404, B405, B406, B407, B408, B409, B413, B307, B311, B507, B603, B608, B610, B611, B614, B703]
-
-### (optional) plugin settings - some test plugins require configuration data
-### that may be given here, per-plugin. All bandit test plugins have a built in
-### set of sensible defaults and these will be used if no configuration is
-### provided. It is not necessary to provide settings for every (or any) plugin
-### if the defaults are acceptable.
-
-any_other_function_with_shell_equals_true:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-execute_with_run_as_root_equals_true:
-  function_names: [ceilometer.utils.execute, cinder.utils.execute, neutron.agent.linux.utils.execute,
-    nova.utils.execute, nova.utils.trycmd]
-hardcoded_tmp_directory:
-  tmp_dirs: [/tmp, /var/tmp, /dev/shm]
-linux_commands_wildcard_injection:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-password_config_option_not_marked_secret:
-  function_names: [oslo.config.cfg.StrOpt, oslo_config.cfg.StrOpt]
-ssl_with_bad_defaults:
-  bad_protocol_versions: [PROTOCOL_SSLv2, SSLv2_METHOD, SSLv23_METHOD, PROTOCOL_SSLv3,
-    PROTOCOL_TLSv1, SSLv3_METHOD, TLSv1_METHOD]
-ssl_with_bad_version:
-  bad_protocol_versions: [PROTOCOL_SSLv2, SSLv2_METHOD, SSLv23_METHOD, PROTOCOL_SSLv3,
-    PROTOCOL_TLSv1, SSLv3_METHOD, TLSv1_METHOD]
-start_process_with_a_shell:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-start_process_with_no_shell:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-start_process_with_partial_path:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-subprocess_popen_with_shell_equals_true:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-subprocess_without_shell_equals_true:
-  no_shell: [os.execl, os.execle, os.execlp, os.execlpe, os.execv, os.execve, os.execvp,
-    os.execvpe, os.spawnl, os.spawnle, os.spawnlp, os.spawnlpe, os.spawnv, os.spawnve,
-    os.spawnvp, os.spawnvpe, os.startfile]
-  shell: [os.system, os.popen, os.popen2, os.popen3, os.popen4, popen2.popen2, popen2.popen3,
-    popen2.popen4, popen2.Popen3, popen2.Popen4, commands.getoutput, commands.getstatusoutput]
-  subprocess: [subprocess.Popen, subprocess.call, subprocess.check_call, subprocess.check_output,
-    utils.execute, utils.execute_with_timeout]
-try_except_continue: {check_typed_exception: false}
-try_except_pass: {check_typed_exception: false}
+skips:
+  - B101  # assert used
+  - B102  # exec used
+  - B110  # try/except/pass
+  - B112  # try/except/continue
+  - B307  # eval
+  - B410  # urllib insecure usage
+  - B603  # subprocess without shell
+  - B608  # hardcoded temp file
+  - B612  # subprocess Popen with shell
+  - B703  # incomplete error handling

--- a/.cfduplication.yml
+++ b/.cfduplication.yml
@@ -1,8 +1,7 @@
-# duplication threshold [10 - 100]
-MinLineCount: 10
+# Minimum duplicated line threshold
+MinLineCount: 50
 
-# files/patterns to exclude
+# Paths to ignore for duplication checking
 IgnorePatterns:
-  - file_name_example.css
-  - src\file_name_example.js
-  - dist\**
+  - docs/**
+  - tests/**


### PR DESCRIPTION
## Summary
- simplify duplication checker config with standard thresholds and ignore patterns for docs and tests
- streamline Bandit configuration to Home Assistant recommended skip list

## Testing
- `pre-commit run --files .cfduplication.yml .bandit.yml`


------
https://chatgpt.com/codex/tasks/task_e_68bf078fcab083319764ec39cca122fd