### PR TITLE
Add Codecov configuration

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,22 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: auto
+        threshold: 1%
+
+comment: false
+
+ignore:
+  - "tests/"
+  - "docs/"


### PR DESCRIPTION
## Summary
- add Codecov configuration file to manage coverage thresholds and ignore rules

## Testing
- `pre-commit run --files .codecov.yml`
- `pytest` *(fails: ImportError: cannot import name 'is_within_quiet_hours')*

------
https://chatgpt.com/codex/tasks/task_e_68bf0cd53bd083319632c96bfe4e3f2e