### PR TITLE
test: isolate pytest from external plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,14 @@ explicit_package_bases = true
 exclude = "tests/"
 
 [project.optional-dependencies]
-test = ["pytest>=8.3.0", "pytest-asyncio>=1.1.0", "pytest-cov>=5.0", "coverage[toml]>=7.6.0"]
+test = [
+    "pytest>=8.3.0",
+    "pytest-asyncio>=1.1.0",
+    "pytest-cov>=5.0",
+    "coverage[toml]>=7.6.0",
+    "aiofiles>=23.1.0",
+    "voluptuous>=0.14.0",
+]
 
 [tool.coverage.run]
 branch = true

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -11,3 +11,4 @@ pytest-asyncio>=1.1.0
 pytest-cov>=5.0
 pytest-homeassistant-custom-component  # follows daily HA version
 pytest>=8.3.0
+voluptuous>=0.14.0

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -144,7 +144,11 @@ except Exception:  # pragma: no cover - create minimal stubs
     async def async_track_time_interval(*args, **kwargs):  # pragma: no cover - stub
         return None
 
+    async def async_track_time(*args, **kwargs):  # pragma: no cover - stub
+        return None
+
     event.async_track_time_interval = async_track_time_interval  # type: ignore[attr-defined]
+    event.async_track_time = async_track_time  # type: ignore[attr-defined]
     helpers.event = event  # type: ignore[attr-defined]
     sys.modules["homeassistant.helpers.event"] = event
 


### PR DESCRIPTION
## Summary
- ensure required plugins and deps for tests (aiofiles, voluptuous)
- stub `async_track_time` in Home Assistant event helper

## Testing
- `pre-commit run --files pyproject.toml requirements_test.txt sitecustomize.py`
- `pytest -q` *(fails: ImportError: cannot import name 'PawControlActivityLevelSensor')*


------
https://chatgpt.com/codex/tasks/task_e_68bf28f90f608331a6f5a1e0d319f03d