### PR TITLE
Forward config entry to coordinator base

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -84,6 +84,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._dogs_config: list[DogConfigData] = entry.data.get(CONF_DOGS, [])
         self.dogs = self._dogs_config
 
+        # Store config entry for use during setup and runtime
+        self.config_entry = entry
+
         # OPTIMIZED: Calculate optimal update interval with improved heuristics
         update_interval = self._calculate_optimal_update_interval()
 
@@ -93,7 +96,6 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             name="PawControl Data",
             update_interval=timedelta(seconds=update_interval),
             always_update=False,
-            config_entry=entry,
         )
 
         # OPTIMIZED: Initialize specialized managers with reduced memory footprint


### PR DESCRIPTION
## Summary
- store `ConfigEntry` on `PawControlCoordinator` before computing update interval
- remove unsupported `config_entry` parameter from `DataUpdateCoordinator` initialization

## Testing
- `pre-commit run --files custom_components/pawcontrol/coordinator.py`
- `pytest` *(fails: cannot import name 'CoordinatorUpdateFailed' from 'homeassistant.helpers.update_coordinator'; ModuleNotFoundError: No module named 'aiofiles')*


------
https://chatgpt.com/codex/tasks/task_e_68c0cf80a1a48331af1413cc234ec037