### PR TITLE
refactor: incorporate review feedback

### DIFF
--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -55,6 +55,18 @@ _LOGGER = logging.getLogger(__name__)
 # OPTIMIZATION: Schema cache for faster validation
 _SCHEMA_CACHE: dict[str, vol.Schema] = {}
 
+# Constant mapping for health data fields to feeding manager attributes
+_HEALTH_DATA_FIELD_MAP: Final[dict[str, str]] = {
+    "weight": "dog_weight",
+    "ideal_weight": "ideal_weight",
+    "body_condition_score": "body_condition_score",
+    "age_months": "age_months",
+    "activity_level": "activity_level",
+    "health_conditions": "health_conditions",
+    "weight_goal": "weight_goal",
+    "spayed_neutered": "spayed_neutered",
+}
+
 
 def _get_cached_schema(schema_id: str, builder: Callable[[], vol.Schema]) -> vol.Schema:
     """Get cached schema or build new one.
@@ -942,18 +954,7 @@ class PawControlServiceManager:
         if feeding_manager:
             config = feeding_manager._configs.get(dog_id)
             if config:
-                field_map = {
-                    "weight": "dog_weight",
-                    "ideal_weight": "ideal_weight",
-                    "body_condition_score": "body_condition_score",
-                    "age_months": "age_months",
-                    "activity_level": "activity_level",
-                    "health_conditions": "health_conditions",
-                    "weight_goal": "weight_goal",
-                    "spayed_neutered": "spayed_neutered",
-                }
-
-                for field, attr in field_map.items():
+                for field, attr in _HEALTH_DATA_FIELD_MAP.items():
                     if field in health_data:
                         setattr(config, attr, health_data[field])
 
@@ -983,18 +984,7 @@ class PawControlServiceManager:
         if not config:
             return
 
-        field_map = {
-            "weight": "dog_weight",
-            "ideal_weight": "ideal_weight",
-            "body_condition_score": "body_condition_score",
-            "age_months": "age_months",
-            "activity_level": "activity_level",
-            "health_conditions": "health_conditions",
-            "weight_goal": "weight_goal",
-            "spayed_neutered": "spayed_neutered",
-        }
-
-        for key, attr in field_map.items():
+        for key, attr in _HEALTH_DATA_FIELD_MAP.items():
             if key in health_data:
                 setattr(config, attr, health_data[key])
 


### PR DESCRIPTION
## Summary
- reuse constant field map when updating feeding manager health data
- remove redundant precision parameter and promote threshold constants in utilities
- clamp trend confidence to valid range

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py custom_components/pawcontrol/services.py`
- `pytest` *(fails: No module named 'homeassistant.config_entries')*

------
https://chatgpt.com/codex/tasks/task_e_68c1279dc3308331a368045548c9c2b4