### PR TITLE
refactor: clean up config validation

### DIFF
--- a/custom_components/pawcontrol/config_flow_dogs.py
+++ b/custom_components/pawcontrol/config_flow_dogs.py
@@ -23,7 +23,6 @@ from custom_components.pawcontrol.config_flow_base import (
     ENTITY_CREATION_DELAY,
     MAX_DOGS_PER_ENTRY,
     VALIDATION_SEMAPHORE,
-    PawControlBaseConfigFlow,
 )
 from custom_components.pawcontrol.const import (
     CONF_BREAKFAST_TIME,
@@ -951,9 +950,7 @@ class DogManagementMixin:
     async def _async_validate_dog_config(
         self, user_input: dict[str, Any]
     ) -> dict[str, Any]:
-        """Validate dog configuration with rate-limiting.
-
-        FIXED: Controlled validation to prevent Entity Registry flooding.
+        """Validate dog configuration with rate limiting.
 
         Args:
             user_input: Dog configuration to validate
@@ -977,7 +974,7 @@ class DogManagementMixin:
             if cache_key in self._validation_cache:
                 cached = self._validation_cache[cache_key]
                 if (
-                    cached.get("timestamp", 0) > asyncio.get_event_loop().time() - 5
+                    cached.get("timestamp", 0) > asyncio.get_running_loop().time() - 5
                 ):  # 5 second cache
                     return cached["result"]
 
@@ -1011,9 +1008,7 @@ class DogManagementMixin:
                     weight_float = float(weight)
                     if weight_float < MIN_DOG_WEIGHT or weight_float > MAX_DOG_WEIGHT:
                         errors[CONF_DOG_WEIGHT] = "weight_out_of_range"
-                    elif not PawControlBaseConfigFlow._is_weight_size_compatible(
-                        self, weight_float, size
-                    ):
+                    elif not self._is_weight_size_compatible(weight_float, size):
                         errors[CONF_DOG_WEIGHT] = "weight_size_mismatch"
                 except (ValueError, TypeError):
                     errors[CONF_DOG_WEIGHT] = "invalid_weight_format"
@@ -1041,7 +1036,7 @@ class DogManagementMixin:
 
             self._validation_cache[cache_key] = {
                 "result": result,
-                "timestamp": asyncio.get_event_loop().time(),
+                "timestamp": asyncio.get_running_loop().time(),
             }
 
             return result

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -812,7 +812,6 @@ class HealthCalculator:
         return (10.0, 30.0)  # Default medium dog range
 
     @staticmethod
-    @staticmethod
     def generate_health_report(health_metrics: HealthMetrics) -> Dict[str, Any]:
         """Generate comprehensive health report with recommendations."""
         report = {


### PR DESCRIPTION
## Summary
- remove redundant decorator in health report generator
- streamline dog config validation with running loop time and direct compatibility check

## Testing
- `pre-commit run --files custom_components/pawcontrol/health_calculator.py custom_components/pawcontrol/config_flow_dogs.py`
- `pytest tests/test_health_calculator_diet_validation.py tests/test_config_flow_dogs_advanced.py` *(fails: No module named 'homeassistant.config_entries')*


------
https://chatgpt.com/codex/tasks/task_e_68c148fccb7c8331aa7ec462e69d4fd9