### PR TITLE
test: ensure homeassistant stubs

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -10,7 +10,9 @@ Python: 3.13+
 
 from __future__ import annotations
 
+import asyncio
 import logging
+from contextlib import suppress
 from datetime import timedelta
 from typing import Any
 
@@ -34,6 +36,8 @@ from .const import (
 from .types import DogConfigData
 
 _LOGGER = logging.getLogger(__name__)
+
+MAINTENANCE_INTERVAL = 3600
 
 
 class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -249,3 +253,27 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             "update_interval_seconds": self.update_interval.total_seconds(),
             "dogs_tracked": len(self._data),
         }
+
+    async def async_start_background_tasks(self) -> None:
+        """Start background maintenance task."""
+        self._maintenance_task = self.hass.loop.create_task(self._maintenance_loop())
+
+    async def _maintenance_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(MAINTENANCE_INTERVAL)
+                await self._perform_maintenance()
+        except asyncio.CancelledError:
+            pass
+
+    async def _perform_maintenance(self) -> None:
+        """Perform periodic maintenance."""
+        _LOGGER.debug("Performing maintenance")
+
+    async def async_shutdown(self) -> None:
+        """Stop background tasks."""
+        task = getattr(self, "_maintenance_task", None)
+        if task:
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-q -ra --strict-markers --strict-config --tb=short --disable-warnings --maxfail=5"
+addopts = "-q -ra --strict-markers --strict-config --tb=short --disable-warnings --maxfail=5 -p pytest_asyncio"
 asyncio_mode = "auto"
 markers = [
   "asyncio: mark a test as using asyncio",


### PR DESCRIPTION
## Summary
- extend Home Assistant test scaffolding with config entry stubs and ensure pytest-asyncio loads
- add validation cache helpers and concurrency constants for config flow tests
- expose maintenance interval and background task hooks in coordinator

## Testing
- `pre-commit run --files sitecustomize.py pyproject.toml custom_components/pawcontrol/config_flow.py custom_components/pawcontrol/coordinator.py`
- `pytest -q` *(fails: DeprecationWarning: Inheritance class HomeAssistantApplication from web.Application is discouraged; ImportError: cannot import name 'PawControlSetupError' from 'custom_components.pawcontrol')*


------
https://chatgpt.com/codex/tasks/task_e_68c1b7e3e6e48331882105084b7d8474