### PR TITLE
test: extend HA stubs and expose setup error

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -27,6 +27,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
+from .exceptions import PawControlSetupError
 from .types import DogConfigData
 
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -203,6 +203,19 @@ class ConfigurationError(PawControlError):
         self.valid_values = valid_values
 
 
+class PawControlSetupError(PawControlError):
+    """Exception raised when integration setup fails."""
+
+    def __init__(self, message: str, error_code: str = "setup_failed") -> None:
+        """Initialize setup error."""
+        super().__init__(
+            message,
+            error_code=error_code,
+            severity=ErrorSeverity.CRITICAL,
+            category=ErrorCategory.CONFIGURATION,
+        )
+
+
 class DogNotFoundError(PawControlError):
     """Exception raised when a dog with the specified ID is not found."""
 
@@ -844,6 +857,7 @@ EXCEPTION_MAP: Final[dict[str, type[PawControlError]]] = {
     "notification_send_failed": NotificationError,
     "data_export_failed": DataExportError,
     "data_import_failed": DataImportError,
+    "setup_failed": PawControlSetupError,
 }
 
 


### PR DESCRIPTION
## Summary
- drop eager pytest plugin imports to avoid rewrite conflicts
- broaden fallback Home Assistant stubs (constants, exceptions, util.dt, entity helpers, config entries)
- add PawControlSetupError exception and export from package

## Testing
- `pre-commit run --files sitecustomize.py custom_components/pawcontrol/exceptions.py custom_components/pawcontrol/__init__.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'homeassistant.data_entry_flow')*


------
https://chatgpt.com/codex/tasks/task_e_68c1c59fa0a08331bd3ca6aa9e43b4b3