### PR TITLE
fix: add system health diagnostics and restore service helpers

### DIFF
--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -877,7 +877,7 @@ class PawControlStartWalkButton(PawControlButtonBase):
             await self.hass.services.async_call(
                 DOMAIN,
                 SERVICE_START_WALK,
-                data={
+                service_data={
                     ATTR_DOG_ID: self._dog_id,
                     "label": "Manual walk",
                 },
@@ -930,7 +930,7 @@ class PawControlEndWalkButton(PawControlButtonBase):
             await self.hass.services.async_call(
                 DOMAIN,
                 SERVICE_END_WALK,
-                data={ATTR_DOG_ID: self._dog_id},
+                service_data={ATTR_DOG_ID: self._dog_id},
                 blocking=False,
             )
 
@@ -974,7 +974,7 @@ class PawControlQuickWalkButton(PawControlButtonBase):
             await self.hass.services.async_call(
                 DOMAIN,
                 SERVICE_START_WALK,
-                data={
+                service_data={
                     ATTR_DOG_ID: self._dog_id,
                     "label": "Quick walk",
                 },
@@ -984,7 +984,7 @@ class PawControlQuickWalkButton(PawControlButtonBase):
             await self.hass.services.async_call(
                 DOMAIN,
                 SERVICE_END_WALK,
-                data={
+                service_data={
                     ATTR_DOG_ID: self._dog_id,
                     "duration": 10,
                     "distance": 800,

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -13,16 +13,20 @@ DOMAIN = "pawcontrol"
 def async_register(
     hass: HomeAssistant, register: system_health.SystemHealthRegistration
 ) -> None:
+    """Register system health callbacks."""
     register.async_register_info(system_health_info)
 
 
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
-    # Beispiel: erste Config-Entry prüfen
+    """Provide system health information for PawControl."""
+    if not hass.config_entries.async_entries(DOMAIN):
+        return {}
+
     entry = hass.config_entries.async_entries(DOMAIN)[0]
     runtime = getattr(entry, "runtime_data", None)
     api = getattr(runtime, "api", None)
     return {
-        "can_reach_backend": system_health.async_check_can_reach_url(
+        "can_reach_backend": await system_health.async_check_can_reach_url(
             hass, getattr(api, "base_url", "https://example.invalid")
         ),
         "remaining_quota": getattr(runtime, "remaining_quota", "unknown"),


### PR DESCRIPTION
## Summary
- add system health diagnostics with safe config entry handling
- restore manager setup and notifications platform handling
- fix walk service buttons using `service_data`

## Testing
- `pre-commit run --files custom_components/pawcontrol/__init__.py custom_components/pawcontrol/button.py custom_components/pawcontrol/system_health.py`
- `pytest -q` *(fails: ImportError: cannot import name 'DataUpdateCoordinator' from 'homeassistant.helpers.update_coordinator')*


------
https://chatgpt.com/codex/tasks/task_e_68c2d659ce74833188b9b0458131379e