### PR TITLE
fix: ensure pytest-asyncio plugin is available

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "-p pytest-asyncio -q -ra --strict-markers --strict-config --tb=short --disable-warnings --maxfail=3 --cov=custom_components/pawcontrol --cov-report=term-missing --cov-fail-under=95 --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy"
+addopts = "-p pytest_asyncio -q -ra --strict-markers --strict-config --tb=short --disable-warnings --maxfail=3 --cov=custom_components/pawcontrol --cov-report=term-missing --cov-fail-under=95 --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy"
 markers = [
   "asyncio: mark a test as using asyncio",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ asyncio-mqtt>=0.16.0
 cryptography>=44.0.1
 Jinja2>=3.1.6
 pyserial>=3.5
+pytest-asyncio>=1.1.0
 requests>=2.32.4
 urllib3>=2.5.0
 uv>=0.8.6


### PR DESCRIPTION
## Summary
- add pytest-asyncio to test requirements
- fix pytest configuration to use correct plugin module name

## Testing
- `python -m pytest --maxfail=1 --tb=short tests/test_const.py` *(fails: AssertionError: assert ['breakfast',...ner', 'snack'] == ('breakfast',...)*

------
https://chatgpt.com/codex/tasks/task_e_68c3962406e08331b380e56a1f73a8fe