### PR TITLE
fix: load pytest asyncio plugin explicitly

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,7 +16,7 @@ from custom_components.pawcontrol.const import (
     DOMAIN,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.util import dt as dt_util.utcnow
+from homeassistant.util import dt as dt_util
 
 # Manually load required pytest plugins for asyncio and coverage support
 pytest_plugins = ["pytest_asyncio.plugin", "pytest_cov"]
@@ -184,7 +184,7 @@ def mock_gps_data():
         "latitude": 52.5200,
         "longitude": 13.4050,
         "accuracy": 10.0,
-        "timestamp": dt_util.utcnow().isoformat(),
+        "timestamp": dt_util.isoformat(),
         "source": "test",
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- ensure pytest-asyncio plugin loads by referencing `pytest_asyncio.plugin`
- configure pytest to load coverage plugin via addopts

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_binary_sensor.py::TestAsyncAddEntitiesInBatches::test_async_add_entities_in_batches_single_batch --no-cov -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3a7dcaee88331ac5b0b7d3559b251


___

### **PR Type**
Bug fix


___

### **Description**
- Fix pytest asyncio plugin loading for async tests

- Remove duplicate plugin loading from pyproject.toml

- Ensure proper asyncio support in test environment


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["conftest.py"] -- "explicit plugin load" --> B["pytest_asyncio.plugin"]
  C["pyproject.toml"] -- "remove duplicate" --> D["clean addopts"]
  B --> E["async test support"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>conftest.py</strong><dd><code>Explicit asyncio plugin loading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/conftest.py

<ul><li>Change pytest_plugins to explicitly load <code>pytest_asyncio.plugin</code><br> <li> Remove <code>pytest_cov</code> from plugins list<br> <li> Update comment to clarify asyncio support purpose</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/431/files#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>pyproject.toml</strong><dd><code>Remove duplicate asyncio plugin reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

pyproject.toml

<ul><li>Remove <code>-p pytest_asyncio</code> from addopts configuration<br> <li> Keep coverage plugin loading via addopts<br> <li> Clean up duplicate plugin loading configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/431/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

