### PR TITLE
Simplify module headers for PawControl managers

### DIFF
--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -1,16 +1,4 @@
-"""Optimized feeding management with health-integrated portion calculation.
-
-Quality Scale: Platinum
-Home Assistant: 2025.9.0+
-Python: 3.13+
-
-Features:
-- Health-aware portion calculation
-- Advanced calorie management
-- Body condition score integration
-- Medical condition adjustments
-- Event-based reminders with caching
-"""
+"""Feeding management with health-aware portions for PawControl."""
 
 from __future__ import annotations
 

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -1,12 +1,4 @@
-"""Specialized walk and GPS management for PawControl integration.
-
-Quality Scale: Platinum
-Home Assistant: 2025.9.0+
-Python: 3.13+
-
-Handles walk tracking, GPS data processing, and location-based features
-separated from the main coordinator for better maintainability.
-"""
+"""Walk and GPS management for PawControl."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- Condense walk manager module header to a single-line description
- Streamline feeding manager module header for concise documentation

## Testing
- `pre-commit run --files custom_components/pawcontrol/walk_manager.py custom_components/pawcontrol/feeding_manager.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_68c75dd21a148331aba7a2cdd0911ef4