### PR TITLE
Remove user-configurable config entry name

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -19,7 +19,6 @@ from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_NAME
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 
@@ -76,13 +75,6 @@ class ValidationCache:
             self._data[key] = (time.time(), value)
 
 
-# Simple schemas
-INTEGRATION_SCHEMA = vol.Schema(
-    {
-        vol.Required(CONF_NAME, default="Paw Control"): cv.string,
-    }
-)
-
 DOG_SCHEMA = vol.Schema(
     {
         vol.Required(CONF_DOG_ID): cv.string,
@@ -132,32 +124,10 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Handle initial setup step."""
-        errors = {}
-
-        if user_input is not None:
-            integration_name = user_input[CONF_NAME].strip()
-
-            # Simple validation
-            if len(integration_name) < 1:
-                errors[CONF_NAME] = "Name required"
-            elif len(integration_name) > 50:
-                errors[CONF_NAME] = "Name too long"
-            else:
-                # Set unique ID
-                unique_id = integration_name.lower().replace(" ", "_")
-                await self.async_set_unique_id(unique_id)
-                self._abort_if_unique_id_configured()
-
-                self._integration_name = integration_name
-                return await self.async_step_add_dog()
-
-        return self.async_show_form(
-            step_id="user",
-            data_schema=INTEGRATION_SCHEMA,
-            errors=errors,
-            description_placeholders={"integration_name": "Paw Control"},
-        )
+        """Handle initial step by ensuring single instance and starting dog setup."""
+        await self.async_set_unique_id(DOMAIN)
+        self._abort_if_unique_id_configured()
+        return await self.async_step_add_dog()
 
     async def async_step_add_dog(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/pawcontrol/test_config_flow.py
+++ b/tests/components/pawcontrol/test_config_flow.py
@@ -18,7 +18,6 @@ from custom_components.pawcontrol.const import (
 )
 from custom_components.pawcontrol.entity_factory import ENTITY_PROFILES
 from homeassistant import config_entries
-from homeassistant.const import CONF_NAME
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import (
@@ -45,12 +44,6 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
     """Test a full successful user initiated config flow."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    assert result["type"] == FlowResultType.FORM
-    assert result["step_id"] == "user"
-
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_NAME: "My Pack"}
     )
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "add_dog"
@@ -92,8 +85,8 @@ async def test_full_user_flow(hass: HomeAssistant) -> None:
         result["flow_id"], user_input={"entity_profile": "standard"}
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["title"] == f"My Pack ({ENTITY_PROFILES['standard']['name']})"
-    assert result["data"]["name"] == "My Pack"
+    assert result["title"] == f"Paw Control ({ENTITY_PROFILES['standard']['name']})"
+    assert result["data"]["name"] == "Paw Control"
     assert len(result["data"]["dogs"]) == 1
     dog_result = result["data"]["dogs"][0]
     assert dog_result[CONF_DOG_ID] == "fido"
@@ -108,9 +101,6 @@ async def test_duplicate_dog_id(hass: HomeAssistant) -> None:
     """Test that duplicate dog IDs are rejected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_NAME: "My Pack"}
     )
     # First dog
     dog_data = {
@@ -157,8 +147,8 @@ async def test_reauth_confirm(hass: HomeAssistant) -> None:
     """Test reauthentication confirmation flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "My Pack", "dogs": [], "entity_profile": "standard"},
-        unique_id="my_pack",
+        data={"name": "Paw Control", "dogs": [], "entity_profile": "standard"},
+        unique_id=DOMAIN,
     )
     entry.add_to_hass(hass)
 
@@ -184,9 +174,9 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
     """Test the reconfigure flow."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "My Pack", "dogs": [], "entity_profile": "standard"},
+        data={"name": "Paw Control", "dogs": [], "entity_profile": "standard"},
         options={"entity_profile": "standard"},
-        unique_id="my_pack",
+        unique_id=DOMAIN,
     )
     entry.add_to_hass(hass)
 
@@ -212,16 +202,13 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
     mock_update.assert_called_once()
 
 
-async def test_user_flow_duplicate_name(hass: HomeAssistant) -> None:
-    """Test user flow when integration name already exists."""
-    entry = MockConfigEntry(domain=DOMAIN, unique_id="my_pack")
+async def test_single_instance(hass: HomeAssistant) -> None:
+    """Test that only a single instance can be configured."""
+    entry = MockConfigEntry(domain=DOMAIN, unique_id=DOMAIN)
     entry.add_to_hass(hass)
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_NAME: "My Pack"}
     )
 
     assert result["type"] == FlowResultType.ABORT
@@ -232,9 +219,6 @@ async def test_invalid_dog_id(hass: HomeAssistant) -> None:
     """Test that invalid dog IDs are rejected."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": config_entries.SOURCE_USER}
-    )
-    result = await hass.config_entries.flow.async_configure(
-        result["flow_id"], user_input={CONF_NAME: "My Pack"}
     )
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -248,8 +232,8 @@ async def test_reauth_confirm_fail(hass: HomeAssistant) -> None:
     """Test reauthentication confirmation failure."""
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={"name": "My Pack", "dogs": [], "entity_profile": "standard"},
-        unique_id="my_pack",
+        data={"name": "Paw Control", "dogs": [], "entity_profile": "standard"},
+        unique_id=DOMAIN,
     )
     entry.add_to_hass(hass)
 


### PR DESCRIPTION
### **User description**
## Summary
- Ensure only a single PawControl instance by removing user-configurable config entry names
- Update config flow tests for new name-free setup and single-instance behavior

## Testing
- `pre-commit run --files custom_components/pawcontrol/config_flow.py tests/components/pawcontrol/test_config_flow.py`
- `pytest tests/components/pawcontrol/test_config_flow.py` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component', installation requires large Home Assistant dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68c7615560388331b7136a2db56e4760


___

### **PR Type**
Enhancement


___

### **Description**
- Remove user-configurable integration name input

- Enforce single instance configuration using domain as unique ID

- Update tests to reflect name-free setup flow

- Simplify config flow by removing initial user step


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User initiates config"] --> B["Set unique ID to DOMAIN"]
  B --> C["Check if already configured"]
  C --> D["Proceed to add_dog step"]
  E["Old flow: user input name"] -.-> F["Removed"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config_flow.py</strong><dd><code>Simplify config flow by removing name input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pawcontrol/config_flow.py

<ul><li>Remove <code>INTEGRATION_SCHEMA</code> and <code>CONF_NAME</code> import<br> <li> Simplify <code>async_step_user</code> to skip name input and go directly to dog <br>setup<br> <li> Set unique ID to <code>DOMAIN</code> constant instead of user-provided name<br> <li> Remove name validation logic and form display</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/441/files#diff-39a4c7bc5e81cfcf31b4d498ff05e1452a79f3e075f16e88aab072d66b5dcc0a">+4/-34</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_config_flow.py</strong><dd><code>Update tests for name-free config flow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/components/pawcontrol/test_config_flow.py

<ul><li>Remove <code>CONF_NAME</code> import and usage in test flows<br> <li> Update test expectations to skip user step and go directly to <code>add_dog</code><br> <li> Change mock config entries to use <code>DOMAIN</code> as unique ID<br> <li> Rename test from <code>test_user_flow_duplicate_name</code> to <code>test_single_instance</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/441/files#diff-858560014645d6b994337a7bb61acb6dae610fa646a970c80664a8c82bc939dd">+11/-27</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

