### PR TITLE
Improve integration code style

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -1,8 +1,4 @@
-"""Core setup for the Paw Control integration.
-
-Provides entry point for PawControl integration with Platinum-level compliance.
-Supports multiple dogs with modular features (GPS, feeding, health, walks).
-"""
+"""Core setup for the PawControl integration."""
 
 from __future__ import annotations
 
@@ -44,10 +40,14 @@ from .walk_manager import WalkManager
 
 # Minimal DogDataManager stub for patching in tests
 class DogDataManager:  # pragma: no cover - simple stub
+    """Trivial dog data manager used for test patching."""
+
     async def async_initialize(self, dogs: list[Any] | None = None) -> None:
+        """Initialize the stub manager."""
         return None
 
     async def async_shutdown(self) -> None:
+        """Shut down the stub manager."""
         return None
 
 

--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -37,8 +37,6 @@ MINIMUM_NUTRITION_PORTION_G = 50.1
 # Defines min/max allowable portion size as fraction of daily ration
 MIN_PORTION_SAFETY_FACTOR = 0.1  # Minimum 10% of daily ration per portion
 MAX_PORTION_SAFETY_FACTOR = 0.6  # Maximum 60% of daily ration per portion
-MIN_PORTION_SAFETY_FACTOR = 0.1
-MAX_PORTION_SAFETY_FACTOR = 0.6
 
 
 class MealType(Enum):


### PR DESCRIPTION
## Summary
- Clarify PawControl setup by adding concise module header and stub documentation
- Clean up feeding manager constants to avoid redundant definitions

## Testing
- `pre-commit run --files custom_components/pawcontrol/feeding_manager.py custom_components/pawcontrol/__init__.py`
- `pytest ./tests/components/pawcontrol --cov=custom_components.pawcontrol --cov-report term-missing` *(fails: Required test coverage of 95.0% not reached)*

------
https://chatgpt.com/codex/tasks/task_e_68c77b64a99483319704e1b1dcdd947f