### PR TITLE
chore: simplify integration headers

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -1,13 +1,4 @@
-"""Simplified configuration flow for Paw Control integration.
-
-SIMPLIFIED: Collapsed 5 mixin inheritance chain into single class.
-Removed ValidationCache, complex async patterns, enterprise features.
-Maintains core functionality: per-dog config, entity profiles, module selection.
-
-Quality Scale: Platinum
-Home Assistant: 2025.9.1+
-Python: 3.13+
-"""
+"""Config flow for PawControl integration."""
 
 from __future__ import annotations
 

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -1,12 +1,4 @@
-"""Simplified coordinator for PawControl integration.
-
-SIMPLIFIED: Removed enterprise patterns (7+ managers, batch processing, performance monitoring).
-Maintains core DataUpdateCoordinator functionality with basic dog data management.
-
-Quality Scale: Platinum
-Home Assistant: 2025.9.1+
-Python: 3.13+
-"""
+"""Coordinator for PawControl integration."""
 
 from __future__ import annotations
 
@@ -41,7 +33,7 @@ STATE_ONLINE = "online"
 
 
 class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
-    """Simplified coordinator for PawControl integration.
+    """Coordinator for PawControl integration.
 
     Responsibilities:
     - Fetch and coordinate dog data updates


### PR DESCRIPTION
## Summary
- replace verbose module headers with concise docstrings
- clarify coordinator class docstring

## Testing
- `pre-commit run --files custom_components/pawcontrol/config_flow.py custom_components/pawcontrol/coordinator.py`
- `pre-commit run --files custom_components/pawcontrol/coordinator.py`
- `python -m script.hassfest --integration-path custom_components/pawcontrol` *(fails: ModuleNotFoundError: No module named 'script')*
- `pytest tests/components/pawcontrol`


------
https://chatgpt.com/codex/tasks/task_e_68c77e66ab988331b3fbf969caf0bc3e