### PR TITLE
Improve system health module docs and resilience

### DIFF
--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -1,4 +1,5 @@
-# custom_components/pawcontrol/system_health.py
+"""System health support for the PawControl integration."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -13,14 +14,17 @@ DOMAIN = "pawcontrol"
 def async_register(
     hass: HomeAssistant, register: system_health.SystemHealthRegistration
 ) -> None:
+    """Register system health callbacks for PawControl."""
+
     register.async_register_info(system_health_info)
 
 
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
-    # Beispiel: erste Config-Entry prüfen
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
-    runtime = getattr(entry, "runtime_data", None)
-    api = getattr(runtime, "api", None)
+    """Return basic system health information."""
+
+    entry = next(iter(hass.config_entries.async_entries(DOMAIN)), None)
+    runtime = getattr(entry, "runtime_data", None) if entry else None
+    api = getattr(runtime, "api", None) if runtime else None
     return {
         "can_reach_backend": system_health.async_check_can_reach_url(
             hass, getattr(api, "base_url", "https://example.invalid")


### PR DESCRIPTION
### **User description**
## Summary
- add module & function docstrings for system health
- guard system_health_info against missing config entries

## Testing
- `python -m script.hassfest --integration-path custom_components/pawcontrol` *(fails: No module named 'script')*
- `pre-commit run --files custom_components/pawcontrol/system_health.py`
- `pytest tests/components/pawcontrol --cov=custom_components.pawcontrol --cov-report term-missing` *(fails: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68c7978b401083319af922fa13e6fac6


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add comprehensive docstrings to system health module

- Implement safe handling for missing config entries

- Replace unsafe array indexing with iterator pattern

- Add null checks for runtime data and API objects


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["System Health Module"] --> B["Add Docstrings"]
  A --> C["Safe Config Entry Access"]
  C --> D["Replace Direct Indexing"]
  C --> E["Add Null Checks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_health.py</strong><dd><code>Enhanced documentation and safe config handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pawcontrol/system_health.py

<ul><li>Add module-level docstring and function docstrings<br> <li> Replace unsafe <code>[0]</code> indexing with <code>next(iter())</code> pattern<br> <li> Add null checks for <code>entry</code>, <code>runtime</code>, and <code>api</code> objects<br> <li> Improve defensive programming against missing config entries</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/447/files#diff-540fb60028ddc321522fe0d6331abe2df0760b62fd244f65cfc805e2b9523178">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

