### PR TITLE
chore: remove unused auth exception

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -9,7 +9,7 @@ from typing import Any, Final
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
@@ -122,7 +122,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
 
     Raises:
         ConfigEntryNotReady: If setup prerequisites not met
-        ConfigEntryAuthFailed: If authentication fails (future use)
     """
     _LOGGER.debug("Setting up Paw Control integration entry: %s", entry.entry_id)
 


### PR DESCRIPTION
### **User description**
## Summary
- remove unused ConfigEntryAuthFailed import and docstring reference

## Testing
- `pre-commit run --files custom_components/pawcontrol/__init__.py`
- `python -m script.hassfest --integration-path custom_components/pawcontrol` *(fails: No module named 'script')*
- `pytest` *(fails: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_68c7973368308331990155ad85006572


___

### **PR Type**
Other


___

### **Description**
- Remove unused `ConfigEntryAuthFailed` import from PawControl integration

- Clean up docstring reference to removed exception


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Remove unused authentication exception import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pawcontrol/__init__.py

<ul><li>Remove unused <code>ConfigEntryAuthFailed</code> import from <br>homeassistant.exceptions<br> <li> Remove corresponding docstring reference in <code>async_setup_entry</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/448/files#diff-5b138e35f4fdcde56b900cd888253e9e160dfba572483b66d6718afa86f1b31f">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

