### PR TITLE
Improve system health callbacks

### DIFF
--- a/system_health.py
+++ b/system_health.py
@@ -1,4 +1,5 @@
-# custom_components/pawcontrol/system_health.py
+"""System health callbacks for the PawControl integration."""
+
 from __future__ import annotations
 
 from typing import Any
@@ -13,17 +14,28 @@ DOMAIN = "pawcontrol"
 def async_register(
     hass: HomeAssistant, register: system_health.SystemHealthRegistration
 ) -> None:
+    """Register system health callbacks for PawControl."""
     register.async_register_info(system_health_info)
 
 
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
-    # Beispiel: erste Config-Entry prüfen
-    entry = hass.config_entries.async_entries(DOMAIN)[0]
+    """Return system health information for PawControl."""
+    entries = hass.config_entries.async_entries(DOMAIN)
+    if not entries:
+        return {
+            "can_reach_backend": False,
+            "remaining_quota": "unknown",
+        }
+
+    entry = entries[0]
     runtime = getattr(entry, "runtime_data", None)
     api = getattr(runtime, "api", None)
+    base_url = getattr(api, "base_url", "https://example.invalid")
+    remaining_quota = getattr(runtime, "remaining_quota", "unknown")
+
     return {
-        "can_reach_backend": system_health.async_check_can_reach_url(
-            hass, getattr(api, "base_url", "https://example.invalid")
+        "can_reach_backend": await system_health.async_check_can_reach_url(
+            hass, base_url
         ),
-        "remaining_quota": getattr(runtime, "remaining_quota", "unknown"),
+        "remaining_quota": remaining_quota,
     }


### PR DESCRIPTION
## Summary
- add descriptive docstrings and safer entry handling in system health callbacks
- await backend connectivity check and provide default values when integration isn't set up

## Testing
- `ruff check system_health.py`
- `pytest`
- `python -m script.hassfest --integration-path custom_components/pawcontrol` *(fails: No module named 'script')*
- `python -m homeassistant.scripts.hassfest --integration-path custom_components/pawcontrol` *(fails: No module named homeassistant.scripts.hassfest)*

------
https://chatgpt.com/codex/tasks/task_e_68c79762a5348331945d04a07c3db3d6