### PR TITLE
refactor: reuse domain constant

### DIFF
--- a/system_health.py
+++ b/system_health.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
 
-DOMAIN = "pawcontrol"
+from custom_components.pawcontrol.const import DOMAIN
 
 
 @callback

--- a/system_health.py
+++ b/system_health.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
+from custom_components.pawcontrol.const import DOMAIN
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
-
-from custom_components.pawcontrol.const import DOMAIN
 
 
 @callback


### PR DESCRIPTION
### **User description**
## Summary
- reuse shared DOMAIN constant in system health callbacks

## Testing
- `python -m script.hassfest --integration-path custom_components/pawcontrol` (fails: No module named 'script')
- `pytest tests/components/pawcontrol` (fails: No module named 'pytest_homeassistant_custom_component')


------
https://chatgpt.com/codex/tasks/task_e_68c7a47d78148331a1108523c3206a7e


___

### **PR Type**
Enhancement


___

### **Description**
- Replace hardcoded domain string with shared constant


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["system_health.py"] --> B["Import DOMAIN from const.py"]
  B --> C["Remove hardcoded string"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_health.py</strong><dd><code>Use shared DOMAIN constant instead of hardcoded string</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

system_health.py

<ul><li>Replace hardcoded <code>DOMAIN = "pawcontrol"</code> with import from const module<br> <li> Improve code maintainability by using shared constant</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/452/files#diff-e31aa38f0d9a482cb3c7cf028df121930b83eda7fe97cda712ed412fffa4a7de">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

