### PR TITLE
refactor: import domain constant

### DIFF
--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -7,7 +7,7 @@ from typing import Any
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
 
-DOMAIN = "pawcontrol"
+from .const import DOMAIN
 
 
 @callback


### PR DESCRIPTION
### **User description**
## Summary
- import `DOMAIN` constant from const module in system health support

## Testing
- `ruff check custom_components/pawcontrol/system_health.py`
- ⚠️ `python -m script.hassfest --integration-path custom_components/pawcontrol` (module not found)
- ⚠️ `pytest` (missing pytest_homeassistant_custom_component)


------
https://chatgpt.com/codex/tasks/task_e_68c7a5cd34e083318013f561a44c3234


___

### **PR Type**
Enhancement


___

### **Description**
- Import `DOMAIN` constant from const module instead of hardcoding


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_health.py</strong><dd><code>Import DOMAIN constant from const module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pawcontrol/system_health.py

<ul><li>Replace hardcoded <code>DOMAIN = "pawcontrol"</code> with import from const module<br> <li> Add import statement <code>from .const import DOMAIN</code></ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/453/files#diff-540fb60028ddc321522fe0d6331abe2df0760b62fd244f65cfc805e2b9523178">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

