### PR TITLE
chore: simplify utils module docstring

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1,16 +1,4 @@
-"""Optimized utility functions for Paw Control integration.
-
-OPTIMIZED for HA 2025.9.1+ with enhanced performance patterns:
-- Reduced memory allocation
-- Faster async operations
-- Streamlined imports
-- Better type safety
-- Enhanced error handling
-
-Quality Scale: Platinum
-Home Assistant: 2025.9.1+
-Python: 3.13+
-"""
+"""Utility helpers for the PawControl integration."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary
- simplify utils module header to concise docstring

## Testing
- `pre-commit run --files custom_components/pawcontrol/utils.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7a92e39d883318acedc000e3b0072