### PR TITLE
Fix system health backend reachability check

### DIFF
--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -25,9 +25,9 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     entry = next(iter(hass.config_entries.async_entries(DOMAIN)), None)
     runtime = getattr(entry, "runtime_data", None) if entry else None
     api = getattr(runtime, "api", None) if runtime else None
+    base_url = getattr(api, "base_url", "https://example.invalid")
+    can_reach_backend = await system_health.async_check_can_reach_url(hass, base_url)
     return {
-        "can_reach_backend": system_health.async_check_can_reach_url(
-            hass, getattr(api, "base_url", "https://example.invalid")
-        ),
+        "can_reach_backend": can_reach_backend,
         "remaining_quota": getattr(runtime, "remaining_quota", "unknown"),
     }


### PR DESCRIPTION
### **User description**
## Summary
- await asynchronous backend reachability check in system health info

## Testing
- `pre-commit run --files custom_components/pawcontrol/system_health.py`
- `python -m script.hassfest --integration-path custom_components/pawcontrol` *(fails: No module named 'script')*
- `pytest tests/components/pawcontrol/test_config_flow.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7af8784748331a6cde7228081b766


___

### **PR Type**
Bug fix


___

### **Description**
- Fix async backend reachability check in system health

- Extract base URL to variable for proper await handling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Extract base_url"] --> B["Await async_check_can_reach_url"] --> C["Return system health info"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>system_health.py</strong><dd><code>Fix async backend reachability check</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/pawcontrol/system_health.py

<ul><li>Extract <code>base_url</code> to a separate variable for clarity<br> <li> Add <code>await</code> keyword to properly handle asynchronous backend reachability <br>check<br> <li> Fix potential runtime error from missing async handling</ul>


</details>


  </td>
  <td><a href="https://github.com/Bigdaddy1990/pawcontrol/pull/458/files#diff-540fb60028ddc321522fe0d6331abe2df0760b62fd244f65cfc805e2b9523178">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

