### PR TITLE
Avoid system health network call without API

### DIFF
--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -25,9 +25,15 @@ async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     entry = next(iter(hass.config_entries.async_entries(DOMAIN)), None)
     runtime = getattr(entry, "runtime_data", None) if entry else None
     api = getattr(runtime, "api", None) if runtime else None
-    base_url = getattr(api, "base_url", "https://example.invalid")
-    can_reach_backend = await system_health.async_check_can_reach_url(hass, base_url)
+    remaining_quota = getattr(runtime, "remaining_quota", "unknown")
+
+    if not api or not getattr(api, "base_url", None):
+        return {"can_reach_backend": False, "remaining_quota": remaining_quota}
+
+    can_reach_backend = await system_health.async_check_can_reach_url(
+        hass, api.base_url
+    )
     return {
         "can_reach_backend": can_reach_backend,
-        "remaining_quota": getattr(runtime, "remaining_quota", "unknown"),
+        "remaining_quota": remaining_quota,
     }

--- a/tests/components/pawcontrol/test_system_health.py
+++ b/tests/components/pawcontrol/test_system_health.py
@@ -1,0 +1,28 @@
+from unittest.mock import patch
+
+import pytest
+from custom_components.pawcontrol import system_health as system_health_module
+from custom_components.pawcontrol.const import DOMAIN
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+pytestmark = pytest.mark.usefixtures("enable_custom_integrations")
+
+
+async def test_system_health_no_api(hass: HomeAssistant) -> None:
+    """Return defaults when API is unavailable."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Paw Control", "dogs": [], "entity_profile": "standard"},
+        unique_id=DOMAIN,
+    )
+    entry.add_to_hass(hass)
+
+    with patch(
+        "custom_components.pawcontrol.system_health.system_health.async_check_can_reach_url"
+    ) as mock_check:
+        info = await system_health_module.system_health_info(hass)
+
+    assert info["can_reach_backend"] is False
+    assert info["remaining_quota"] == "unknown"
+    mock_check.assert_not_called()


### PR DESCRIPTION
## Summary
- prevent unnecessary network checks when system health API is unavailable
- add regression test for system health without API

## Testing
- `pre-commit run --files custom_components/pawcontrol/system_health.py tests/components/pawcontrol/test_system_health.py`
- `pytest tests/components/pawcontrol/test_system_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68c7bf2030848331bee30fe3e153ed9c