### PR TITLE
Optimize config flow caching and profile previews

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -31,6 +31,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .data_manager import PawControlDataManager
+from .entity_factory import EntityFactory
 from .exceptions import PawControlSetupError
 from .feeding_manager import FeedingManager
 from .health_calculator import HealthCalculator
@@ -310,9 +311,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
             hass.config_entries.async_forward_entry_setups(entry, platforms),
             timeout=60.0,  # Allow more time for platform setup
         )
-    except TimeoutError:
+    except TimeoutError as err:
         await _cleanup_managers(initialized_managers)
-        raise ConfigEntryNotReady("Platform setup timeout after 60 seconds")
+        raise ConfigEntryNotReady("Platform setup timeout after 60 seconds") from err
     except Exception as err:
         # Cleanup managers if platform setup fails
         await _cleanup_managers(initialized_managers)

--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -128,7 +128,11 @@ async def timed_operation(operation_name: str):
     try:
         yield
     finally:
-        duration = time.time() - start_time
+    start_time = time.monotonic()
+    try:
+        yield
+    finally:
+        duration = time.monotonic() - start_time
         config_flow_monitor.record_operation(operation_name, duration)
         if duration > 2.0:
             _LOGGER.warning(
@@ -136,10 +140,6 @@ async def timed_operation(operation_name: str):
                 operation_name,
                 duration,
             )
-
-
-# Modules schema using constants with better validation
-MODULES_SCHEMA = vol.Schema(
     {
         vol.Optional(MODULE_FEEDING, default=True): cv.boolean,
         vol.Optional(MODULE_WALK, default=True): cv.boolean,

--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 import logging
 import re
+import time
+from contextlib import asynccontextmanager
 from typing import Any
 
 import voluptuous as vol
@@ -22,6 +24,7 @@ from homeassistant.config_entries import (
 )
 from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_DOG_AGE,
@@ -46,7 +49,7 @@ from .const import (
     MODULE_NOTIFICATIONS,
     MODULE_WALK,
 )
-from .entity_factory import ENTITY_PROFILES
+from .entity_factory import ENTITY_PROFILES, EntityFactory
 from .options_flow import PawControlOptionsFlow
 from .types import DogConfigData, is_dog_config_valid
 
@@ -75,6 +78,68 @@ DOG_SCHEMA = vol.Schema(
         vol.Optional(CONF_DOG_SIZE, default="medium"): vol.In(VALID_DOG_SIZES),
     }
 )
+
+
+class ConfigFlowPerformanceMonitor:
+    """Monitor performance of config flow operations."""
+
+    def __init__(self) -> None:
+        self.operation_times: dict[str, list[float]] = {}
+        self.validation_counts: dict[str, int] = {}
+
+    def record_operation(self, operation: str, duration: float) -> None:
+        """Record timing information for an operation."""
+
+        times = self.operation_times.setdefault(operation, [])
+        times.append(duration)
+
+        # Keep cache size bounded to avoid memory bloat
+        if len(times) > 100:
+            self.operation_times[operation] = times[-50:]
+
+    def record_validation(self, validation_type: str) -> None:
+        """Record a validation invocation."""
+
+        self.validation_counts[validation_type] = (
+            self.validation_counts.get(validation_type, 0) + 1
+        )
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return aggregated statistics for diagnostics."""
+
+        stats: dict[str, Any] = {}
+        for operation, times in self.operation_times.items():
+            if not times:
+                continue
+            stats[operation] = {
+                "avg_time": sum(times) / len(times),
+                "max_time": max(times),
+                "count": len(times),
+            }
+
+        stats["validations"] = self.validation_counts.copy()
+        return stats
+
+
+config_flow_monitor = ConfigFlowPerformanceMonitor()
+
+
+@asynccontextmanager
+async def timed_operation(operation_name: str):
+    """Async context manager that records operation duration."""
+
+    start_time = time.time()
+    try:
+        yield
+    finally:
+        duration = time.time() - start_time
+        config_flow_monitor.record_operation(operation_name, duration)
+        if duration > 2.0:
+            _LOGGER.warning(
+                "Slow config flow operation: %s took %.2fs",
+                operation_name,
+                duration,
+            )
 
 # Modules schema using constants with better validation
 MODULES_SCHEMA = vol.Schema(
@@ -117,6 +182,11 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         self.reauth_entry: ConfigEntry | None = None
         self._discovery_info: dict[str, Any] = {}
         self._existing_dog_ids: set[str] = set()  # Performance: O(1) lookups
+        self._entity_factory = EntityFactory(None)
+
+        # Validation and estimation caches for improved responsiveness
+        self._validation_cache: dict[str, tuple[dict[str, Any], Any, str]] = {}
+        self._profile_estimates_cache: dict[str, int] = {}
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -129,14 +199,15 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             Config flow result
         """
-        # Ensure single instance with improved messaging
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured(
-            updates={},
-            reload_on_update=False,
-        )
-        
-        return await self.async_step_add_dog()
+        async with timed_operation("user_step"):
+            # Ensure single instance with improved messaging
+            await self.async_set_unique_id(DOMAIN)
+            self._abort_if_unique_id_configured(
+                updates={},
+                reload_on_update=False,
+            )
+
+            return await self.async_step_add_dog()
 
     async def async_step_zeroconf(
         self, discovery_info: dict[str, Any]
@@ -260,75 +331,144 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         """
         _LOGGER.debug("Import configuration: %s", import_config)
         
-        # Ensure single instance
-        await self.async_set_unique_id(DOMAIN)
-        self._abort_if_unique_id_configured()
-        
-        try:
-            # Validate and convert import configuration
-            validated_config = await self._validate_import_config(import_config)
-            
-            # Create config entry directly from import
-            return self.async_create_entry(
-                title=f"PawControl (Imported)",
-                data=validated_config["data"],
-                options=validated_config["options"],
-            )
-            
-        except vol.Invalid as err:
-            _LOGGER.error("Invalid import configuration: %s", err)
-            return self.async_abort(reason="invalid_import_config")
+        async with timed_operation("import_step"):
+            # Ensure single instance
+            await self.async_set_unique_id(DOMAIN)
+            self._abort_if_unique_id_configured()
+
+            try:
+                validated_config = await self._validate_import_config_enhanced(
+                    import_config
+                )
+
+                return self.async_create_entry(
+                    title="PawControl (Imported)",
+                    data=validated_config["data"],
+                    options=validated_config["options"],
+                )
+
+            except vol.Invalid as err:
+                _LOGGER.error("Invalid import configuration: %s", err)
+                return self.async_abort(reason="invalid_import_config")
 
     async def _validate_import_config(
         self, import_config: dict[str, Any]
     ) -> dict[str, Any]:
-        """Validate imported configuration.
+        """Backward-compatible wrapper for enhanced import validation."""
 
-        Args:
-            import_config: Raw import configuration
+        return await self._validate_import_config_enhanced(import_config)
 
-        Returns:
-            Validated configuration data
+    async def _validate_import_config_enhanced(
+        self, import_config: dict[str, Any]
+    ) -> dict[str, Any]:
+        """Enhanced validation for imported configuration with better error reporting."""
 
-        Raises:
-            vol.Invalid: If configuration is invalid
-        """
-        # Extract dogs configuration
-        dogs_config = import_config.get(CONF_DOGS, [])
-        if not isinstance(dogs_config, list):
-            raise vol.Invalid("Dogs configuration must be a list")
+        config_flow_monitor.record_validation("import_attempt")
 
-        validated_dogs = []
-        for dog_config in dogs_config:
+        async with timed_operation("import_validation"):
+            validation_errors: list[str] = []
+
             try:
-                validated_dog = DOG_SCHEMA(dog_config)
-                if is_dog_config_valid(validated_dog):
-                    validated_dogs.append(validated_dog)
-                else:
-                    raise vol.Invalid(f"Invalid dog configuration: {dog_config}")
-            except vol.Invalid as err:
-                raise vol.Invalid(f"Dog validation failed: {err}") from err
+                dogs_config = import_config.get(CONF_DOGS, [])
+                if not isinstance(dogs_config, list):
+                    raise vol.Invalid("Dogs configuration must be a list")
 
-        if not validated_dogs:
-            raise vol.Invalid("No valid dogs found in import configuration")
+                validated_dogs = []
+                seen_ids: set[str] = set()
+                seen_names: set[str] = set()
 
-        # Validate profile
-        profile = import_config.get("entity_profile", "standard")
-        if profile not in VALID_PROFILES:
-            profile = "standard"
+                for index, dog_config in enumerate(dogs_config):
+                    try:
+                        validated_dog = DOG_SCHEMA(dog_config)
 
-        return {
-            "data": {
-                "name": import_config.get("name", "PawControl (Imported)"),
-                CONF_DOGS: validated_dogs,
-                "entity_profile": profile,
-            },
-            "options": {
-                "entity_profile": profile,
-                "dashboard_enabled": import_config.get("dashboard_enabled", True),
-                "dashboard_auto_create": import_config.get("dashboard_auto_create", True),
-            },
-        }
+                        dog_id = validated_dog.get(CONF_DOG_ID)
+                        dog_name = validated_dog.get(CONF_DOG_NAME)
+
+                        if dog_id in seen_ids:
+                            validation_errors.append(
+                                f"Duplicate dog ID '{dog_id}' at position {index + 1}"
+                            )
+                            continue
+
+                        if dog_name in seen_names:
+                            validation_errors.append(
+                                f"Duplicate dog name '{dog_name}' at position {index + 1}"
+                            )
+                            continue
+
+                        if not is_dog_config_valid(validated_dog):
+                            validation_errors.append(
+                                f"Invalid dog configuration at position {index + 1}: {dog_config}"
+                            )
+                            continue
+
+                        seen_ids.add(dog_id)
+                        seen_names.add(dog_name)
+                        validated_dogs.append(validated_dog)
+                        config_flow_monitor.record_validation("import_dog_valid")
+
+                    except vol.Invalid as err:
+                        validation_errors.append(
+                            f"Dog validation failed at position {index + 1}: {err}"
+                        )
+                        config_flow_monitor.record_validation("import_dog_invalid")
+
+                if not validated_dogs:
+                    if validation_errors:
+                        raise vol.Invalid(
+                            "No valid dogs found. Errors: "
+                            + "; ".join(validation_errors)
+                        )
+                    raise vol.Invalid("No valid dogs found in import configuration")
+
+                profile = import_config.get("entity_profile", "standard")
+                if profile not in VALID_PROFILES:
+                    validation_errors.append(
+                        f"Invalid profile '{profile}', using 'standard'"
+                    )
+                    profile = "standard"
+
+                for dog in validated_dogs:
+                    modules = dog.get("modules", {})
+                    if not self._entity_factory.validate_profile_for_modules(
+                        profile, modules
+                    ):
+                        validation_errors.append(
+                            f"Profile '{profile}' may not be optimal for dog '{dog.get(CONF_DOG_NAME)}'"
+                        )
+
+                if validation_errors:
+                    _LOGGER.warning(
+                        "Import validation warnings: %s",
+                        "; ".join(validation_errors),
+                    )
+
+                config_flow_monitor.record_validation("import_validated")
+
+                return {
+                    "data": {
+                        "name": import_config.get("name", "PawControl (Imported)"),
+                        CONF_DOGS: validated_dogs,
+                        "entity_profile": profile,
+                        "import_warnings": validation_errors,
+                        "import_timestamp": dt_util.utcnow().isoformat(),
+                    },
+                    "options": {
+                        "entity_profile": profile,
+                        "dashboard_enabled": import_config.get(
+                            "dashboard_enabled", True
+                        ),
+                        "dashboard_auto_create": import_config.get(
+                            "dashboard_auto_create", True
+                        ),
+                        "import_source": "configuration_yaml",
+                    },
+                }
+
+            except Exception as err:
+                raise vol.Invalid(
+                    f"Import configuration validation failed: {err}"
+                ) from err
 
     def _is_supported_device(
         self, hostname: str, properties: dict[str, Any]
@@ -392,36 +532,115 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             Config flow result
         """
-        errors: dict[str, str] = {}
+        async with timed_operation("add_dog_step"):
+            errors: dict[str, str] = {}
 
-        if user_input is not None:
-            # Pre-validate for early exit
-            try:
-                validated_input = await self._validate_dog_input_optimized(user_input)
-                if validated_input:
-                    dog_config = self._create_dog_config(validated_input)
-                    self._dogs.append(dog_config)
-                    # Update existing IDs set for O(1) lookups
-                    self._existing_dog_ids.add(dog_config[CONF_DOG_ID])
-                    return await self.async_step_dog_modules()
-                    
-            except ValueError as err:
-                _LOGGER.warning("Dog validation failed: %s", err)
-                errors["base"] = "invalid_dog_data"
-            except Exception as err:
-                _LOGGER.error("Unexpected error during dog validation: %s", err)
-                errors["base"] = "unknown_error"
+            if user_input is not None:
+                try:
+                    validated_input = await self._validate_dog_input_cached(user_input)
+                    if validated_input:
+                        dog_config = self._create_dog_config(validated_input)
+                        self._dogs.append(dog_config)
+                        self._existing_dog_ids.add(dog_config[CONF_DOG_ID])
+                        self._invalidate_profile_caches()
+                        return await self.async_step_dog_modules()
 
-        return self.async_show_form(
-            step_id="add_dog",
-            data_schema=DOG_SCHEMA,
-            errors=errors,
-            description_placeholders={
-                "dogs_configured": str(len(self._dogs)),
-                "max_dogs": str(MAX_DOGS_PER_INTEGRATION),
-                "discovery_hint": self._get_discovery_hint(),
-            },
+                except ValueError as err:
+                    _LOGGER.warning("Dog validation failed: %s", err)
+                    errors["base"] = "invalid_dog_data"
+                except Exception as err:
+                    _LOGGER.error("Unexpected error during dog validation: %s", err)
+                    errors["base"] = "unknown_error"
+
+            return self.async_show_form(
+                step_id="add_dog",
+                data_schema=DOG_SCHEMA,
+                errors=errors,
+                description_placeholders={
+                    "dogs_configured": str(len(self._dogs)),
+                    "max_dogs": str(MAX_DOGS_PER_INTEGRATION),
+                    "discovery_hint": self._get_discovery_hint(),
+                },
+            )
+
+    def _get_validation_state_signature(self) -> str:
+        """Get a signature representing current validation state."""
+
+        existing_ids = "|".join(sorted(self._existing_dog_ids))
+        return f"{len(self._dogs)}::{existing_ids}"
+
+    async def _validate_dog_input_cached(
+        self, user_input: dict[str, Any]
+    ) -> dict[str, Any] | None:
+        """Validate dog input with caching for repeated validations."""
+
+        config_flow_monitor.record_validation("dog_input_attempt")
+
+        cache_key = "_".join(
+            [
+                user_input.get("dog_id", ""),
+                user_input.get("dog_name", ""),
+                str(user_input.get("dog_weight", 0)),
+            ]
         )
+        state_signature = self._get_validation_state_signature()
+        cached_entry = self._validation_cache.get(cache_key)
+        now = dt_util.utcnow()
+
+        if cached_entry:
+            cached_result, cache_time, cached_state = cached_entry
+            if (
+                cached_state == state_signature
+                and (now - cache_time).total_seconds() < 60
+            ):
+                config_flow_monitor.record_validation("dog_input_cache_hit")
+                return dict(cached_result)
+
+        try:
+            result = await self._validate_dog_input_optimized(user_input)
+        except ValueError:
+            config_flow_monitor.record_validation("dog_input_error")
+            raise
+
+        cache_payload = (dict(result), now, state_signature)
+        self._validation_cache[cache_key] = cache_payload
+        config_flow_monitor.record_validation("dog_input_validated")
+        return result
+
+    def _invalidate_profile_caches(self) -> None:
+        """Invalidate cached profile estimates when configuration changes."""
+
+        self._profile_estimates_cache.clear()
+
+    def _estimate_total_entities_cached(self) -> int:
+        """Estimate total entities with improved caching."""
+
+        dogs_signature = hash(
+            str(
+                [
+                    (
+                        dog.get("dog_id"),
+                        tuple(sorted(dog.get("modules", {}).items())),
+                    )
+                    for dog in self._dogs
+                ]
+            )
+        )
+        cache_key = f"{self._entity_profile}_{len(self._dogs)}_{dogs_signature}"
+
+        cached = self._profile_estimates_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        total = 0
+        for dog in self._dogs:
+            modules = dog.get("modules", {})
+            total += self._entity_factory.estimate_entity_count(
+                self._entity_profile, modules
+            )
+
+        self._profile_estimates_cache[cache_key] = total
+        return total
 
     def _get_discovery_hint(self) -> str:
         """Get hint text based on discovery info.
@@ -538,6 +757,7 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Validate modules configuration
                 modules = MODULES_SCHEMA(user_input or {})
                 current_dog[CONF_MODULES] = modules
+                self._invalidate_profile_caches()
                 return await self.async_step_add_another()
                 
             except vol.Invalid as err:
@@ -751,63 +971,63 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             Config flow result
         """
-        if not self._dogs:
-            return self.async_abort(reason="no_dogs_configured")
+        async with timed_operation("final_setup"):
+            if not self._dogs:
+                return self.async_abort(reason="no_dogs_configured")
 
-        # Enhanced validation of all configurations
-        validation_results = await self._perform_comprehensive_validation()
-        if not validation_results["valid"]:
-            _LOGGER.error("Final validation failed: %s", validation_results["errors"])
-            return self.async_abort(reason="setup_validation_failed")
+            validation_results = await self._perform_comprehensive_validation()
+            if not validation_results["valid"]:
+                _LOGGER.error(
+                    "Final validation failed: %s", validation_results["errors"]
+                )
+                return self.async_abort(reason="setup_validation_failed")
 
-        # Validate profile compatibility
-        if not self._validate_profile_compatibility():
-            _LOGGER.warning("Profile compatibility issues detected")
+            if not self._validate_profile_compatibility():
+                _LOGGER.warning("Profile compatibility issues detected")
 
-        try:
-            # Create optimized config entry data
-            config_data, options_data = self._build_config_entry_data()
-            
-            profile_info = ENTITY_PROFILES[self._entity_profile]
-            title = self._generate_entry_title(profile_info)
+            try:
+                config_data, options_data = self._build_config_entry_data()
 
-            return self.async_create_entry(
-                title=title,
-                data=config_data,
-                options=options_data,
-            )
-            
-        except Exception as err:
-            _LOGGER.error("Final setup failed: %s", err)
-            return self.async_abort(reason="setup_failed")
+                profile_info = ENTITY_PROFILES[self._entity_profile]
+                title = self._generate_entry_title(profile_info)
+
+                return self.async_create_entry(
+                    title=title,
+                    data=config_data,
+                    options=options_data,
+                )
+
+            except Exception as err:
+                _LOGGER.error("Final setup failed: %s", err)
+                return self.async_abort(reason="setup_failed")
 
     async def _perform_comprehensive_validation(self) -> dict[str, Any]:
-        """Perform comprehensive final validation.
-        
-        Returns:
-            Validation results
-        """
-        errors = []
-        
-        # Validate all dog configurations
-        for dog in self._dogs:
-            if not is_dog_config_valid(dog):
-                errors.append(f"Invalid dog configuration: {dog.get(CONF_DOG_ID, 'unknown')}")
+        """Perform comprehensive final validation."""
 
-        # Validate entity count limits
-        estimated_entities = self._estimate_total_entities()
-        if estimated_entities > 200:  # Reasonable upper limit
-            errors.append(f"Too many estimated entities: {estimated_entities}")
+        async with timed_operation("final_validation"):
+            errors: list[str] = []
 
-        # Validate profile exists
-        if self._entity_profile not in VALID_PROFILES:
-            errors.append(f"Invalid profile: {self._entity_profile}")
+            for dog in self._dogs:
+                if not is_dog_config_valid(dog):
+                    errors.append(
+                        f"Invalid dog configuration: {dog.get(CONF_DOG_ID, 'unknown')}"
+                    )
 
-        return {
-            "valid": len(errors) == 0,
-            "errors": errors,
-            "estimated_entities": estimated_entities,
-        }
+            estimated_entities = self._estimate_total_entities_cached()
+            if estimated_entities > 200:
+                errors.append(f"Too many estimated entities: {estimated_entities}")
+
+            if self._entity_profile not in VALID_PROFILES:
+                errors.append(f"Invalid profile: {self._entity_profile}")
+
+            result = {
+                "valid": len(errors) == 0,
+                "errors": errors,
+                "estimated_entities": estimated_entities,
+            }
+
+        config_flow_monitor.record_validation("final_validation")
+        return result
 
     def _validate_profile_compatibility(self) -> bool:
         """Validate profile compatibility with configuration.
@@ -815,16 +1035,13 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             True if profile is compatible
         """
-        from .entity_factory import EntityFactory
-        
-        # Use entity factory to validate profile compatibility
-        factory = EntityFactory(None)  # Coordinator not needed for validation
-        
         for dog in self._dogs:
             modules = dog.get("modules", {})
-            if not factory.validate_profile_for_modules(self._entity_profile, modules):
+            if not self._entity_factory.validate_profile_for_modules(
+                self._entity_profile, modules
+            ):
                 return False
-                
+
         return True
 
     def _build_config_entry_data(self) -> tuple[dict[str, Any], dict[str, Any]]:
@@ -871,25 +1088,11 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
 
     def _estimate_total_entities(self) -> int:
         """Estimate total entities with caching.
-        
+
         Returns:
             Estimated total entity count
         """
-        if hasattr(self, '_cached_entity_estimate'):
-            return self._cached_entity_estimate
-            
-        from .entity_factory import EntityFactory
-        
-        # Create temporary factory for estimation
-        factory = EntityFactory(None)
-        
-        total = 0
-        for dog in self._dogs:
-            modules = dog.get("modules", {})
-            total += factory.estimate_entity_count(self._entity_profile, modules)
-            
-        self._cached_entity_estimate = total
-        return total
+        return self._estimate_total_entities_cached()
 
     def _format_dogs_list_enhanced(self) -> str:
         """Format enhanced list of configured dogs.
@@ -1121,14 +1324,11 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         Returns:
             Compatibility check results
         """
-        from .entity_factory import EntityFactory
-        
-        factory = EntityFactory(None)
         warnings = []
-        
+
         for dog in dogs:
             modules = dog.get("modules", {})
-            if not factory.validate_profile_for_modules(profile, modules):
+            if not self._entity_factory.validate_profile_for_modules(profile, modules):
                 warnings.append(f"Profile '{profile}' may not be optimal for {dog.get('dog_name', 'unknown')}")
         
         return {

--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -77,18 +77,20 @@ MODULE_MEDICATION: Final[str] = "medication"
 MODULE_TRAINING: Final[str] = "training"
 
 # OPTIMIZED: All modules as frozenset for O(1) membership testing
-ALL_MODULES: Final[frozenset[str]] = frozenset([
-    MODULE_GPS,
-    MODULE_FEEDING,
-    MODULE_HEALTH,
-    MODULE_WALK,
-    MODULE_NOTIFICATIONS,
-    MODULE_DASHBOARD,
-    MODULE_VISITOR,
-    MODULE_GROOMING,
-    MODULE_MEDICATION,
-    MODULE_TRAINING,
-])
+ALL_MODULES: Final[frozenset[str]] = frozenset(
+    [
+        MODULE_GPS,
+        MODULE_FEEDING,
+        MODULE_HEALTH,
+        MODULE_WALK,
+        MODULE_NOTIFICATIONS,
+        MODULE_DASHBOARD,
+        MODULE_VISITOR,
+        MODULE_GROOMING,
+        MODULE_MEDICATION,
+        MODULE_TRAINING,
+    ]
+)
 
 # OPTIMIZED: Source entities configuration
 CONF_SOURCES: Final[str] = "sources"
@@ -179,11 +181,11 @@ GPS_ACCURACY_FILTER_SELECTOR: Final[selector.NumberSelector] = selector.NumberSe
 
 # OPTIMIZED: Food types as tuple for immutability (better performance than list)
 FOOD_TYPES: Final[tuple[str, ...]] = (
-    "dry_food", 
-    "wet_food", 
-    "barf", 
-    "home_cooked", 
-    "mixed"
+    "dry_food",
+    "wet_food",
+    "barf",
+    "home_cooked",
+    "mixed",
 )
 
 # OPTIMIZED: Special diet options as tuple
@@ -205,28 +207,13 @@ SPECIAL_DIET_OPTIONS: Final[tuple[str, ...]] = (
 )
 
 # OPTIMIZED: Schedule types as tuple for better performance
-FEEDING_SCHEDULE_TYPES: Final[tuple[str, ...]] = (
-    "flexible", 
-    "strict", 
-    "custom"
-)
+FEEDING_SCHEDULE_TYPES: Final[tuple[str, ...]] = ("flexible", "strict", "custom")
 
 # OPTIMIZED: Meal types as tuple
-MEAL_TYPES: Final[tuple[str, ...]] = (
-    "breakfast", 
-    "lunch", 
-    "dinner", 
-    "snack"
-)
+MEAL_TYPES: Final[tuple[str, ...]] = ("breakfast", "lunch", "dinner", "snack")
 
 # OPTIMIZED: Dog sizes as tuple for consistency and performance
-DOG_SIZES: Final[tuple[str, ...]] = (
-    "toy", 
-    "small", 
-    "medium", 
-    "large", 
-    "giant"
-)
+DOG_SIZES: Final[tuple[str, ...]] = ("toy", "small", "medium", "large", "giant")
 
 # OPTIMIZED: Size-weight mapping for validation (frozenset for fast lookup)
 DOG_SIZE_WEIGHT_RANGES: Final[dict[str, tuple[float, float]]] = {
@@ -259,20 +246,20 @@ HEALTH_STATUS_OPTIONS: Final[tuple[str, ...]] = (
 )
 
 MOOD_OPTIONS: Final[tuple[str, ...]] = (
-    "happy", 
-    "neutral", 
-    "sad", 
-    "angry", 
-    "anxious", 
-    "tired"
+    "happy",
+    "neutral",
+    "sad",
+    "angry",
+    "anxious",
+    "tired",
 )
 
 ACTIVITY_LEVELS: Final[tuple[str, ...]] = (
-    "very_low", 
-    "low", 
-    "normal", 
-    "high", 
-    "very_high"
+    "very_low",
+    "low",
+    "normal",
+    "high",
+    "very_high",
 )
 
 # OPTIMIZED: Dashboard configuration
@@ -327,13 +314,15 @@ SERVICE_GPS_POST_LOCATION: Final[str] = "gps_post_location"
 SERVICE_GPS_EXPORT_ROUTE: Final[str] = "gps_export_last_route"
 
 # OPTIMIZED: Core services as frozenset for fast lookup
-CORE_SERVICES: Final[frozenset[str]] = frozenset([
-    SERVICE_FEED_DOG,
-    SERVICE_START_WALK,
-    SERVICE_END_WALK,
-    SERVICE_LOG_HEALTH,
-    SERVICE_NOTIFY_TEST,
-])
+CORE_SERVICES: Final[frozenset[str]] = frozenset(
+    [
+        SERVICE_FEED_DOG,
+        SERVICE_START_WALK,
+        SERVICE_END_WALK,
+        SERVICE_LOG_HEALTH,
+        SERVICE_NOTIFY_TEST,
+    ]
+)
 
 # OPTIMIZED: Entity and event identifiers
 ENTITY_ID_FORMAT: Final[str] = "pawcontrol_{dog_id}_{entity_type}_{purpose}"
@@ -373,15 +362,24 @@ SECONDS_IN_DAY: Final[int] = 86400
 MINUTES_IN_HOUR: Final[int] = 60
 
 # OPTIMIZED: Type definitions as tuples
-GEOFENCE_TYPES: Final[tuple[str, ...]] = ("safe_zone", "restricted_area", "point_of_interest")
-NOTIFICATION_CHANNELS: Final[tuple[str, ...]] = ("mobile", "persistent", "email", "slack")
+GEOFENCE_TYPES: Final[tuple[str, ...]] = (
+    "safe_zone",
+    "restricted_area",
+    "point_of_interest",
+)
+NOTIFICATION_CHANNELS: Final[tuple[str, ...]] = (
+    "mobile",
+    "persistent",
+    "email",
+    "slack",
+)
 
 # FIX: Update intervals with consistent key naming throughout codebase
 UPDATE_INTERVALS: Final[dict[str, int]] = {
-    "minimal": 300,    # 5 minutes - power saving
-    "balanced": 120,   # 2 minutes - balanced (FIX: consistent key)
-    "frequent": 60,    # 1 minute - responsive
-    "real_time": 30,   # 30 seconds - high performance
+    "minimal": 300,  # 5 minutes - power saving
+    "balanced": 120,  # 2 minutes - balanced (FIX: consistent key)
+    "frequent": 60,  # 1 minute - responsive
+    "real_time": 30,  # 30 seconds - high performance
 }
 
 # OPTIMIZED: Data file names as constants
@@ -410,10 +408,10 @@ ERROR_SERVICE_UNAVAILABLE: Final[str] = "service_unavailable"
 
 # OPTIMIZED: Performance thresholds for monitoring
 PERFORMANCE_THRESHOLDS: Final[dict[str, float]] = {
-    "update_timeout": 30.0,        # seconds
-    "cache_hit_rate_min": 70.0,    # percentage
-    "memory_usage_max": 100.0,     # MB
-    "response_time_max": 2.0,      # seconds
+    "update_timeout": 30.0,  # seconds
+    "cache_hit_rate_min": 70.0,  # percentage
+    "memory_usage_max": 100.0,  # MB
+    "response_time_max": 2.0,  # seconds
 }
 
 # OPTIMIZED: Streamlined exports - only frequently used constants

--- a/custom_components/pawcontrol/data_manager.py
+++ b/custom_components/pawcontrol/data_manager.py
@@ -20,7 +20,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.storage import Store
 from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_DATA_RETENTION_DAYS, DOMAIN, STORAGE_VERSION
+from .const import DOMAIN, STORAGE_VERSION
 from .exceptions import StorageError
 from .utils import deep_merge_dicts
 
@@ -177,20 +177,20 @@ class AdaptiveCache:
 
     async def cleanup_expired(self) -> int:
         """FIX: Cleanup expired entries to prevent memory leaks.
-        
+
         Returns:
             Number of entries cleaned up
         """
         now = dt_util.utcnow()
         expired_keys = []
-        
+
         for key, metadata in self._metadata.items():
             if now > metadata["expiry"]:
                 expired_keys.append(key)
-        
+
         for key in expired_keys:
             await self._evict(key)
-        
+
         return len(expired_keys)
 
     def _estimate_size(self, value: Any) -> int:
@@ -614,7 +614,7 @@ class PawControlDataManager:
         cleaned_entries = await self._cache.cleanup_expired()
         if cleaned_entries > 0:
             _LOGGER.debug("Cleaned up %d expired cache entries", cleaned_entries)
-        
+
         # Update performance score
         cache_stats = self._cache.get_stats()
         self._metrics["performance_score"] = (
@@ -667,7 +667,7 @@ class PawControlDataManager:
         """Get module data with optimized filtering."""
         try:
             # Check index for quick stats
-            index_info = self._storage.query_index(module, dog_id)
+            self._storage.query_index(module, dog_id)
 
             # Get module data
             module_data = await self._get_namespace_data(module)

--- a/custom_components/pawcontrol/diagnostics.py
+++ b/custom_components/pawcontrol/diagnostics.py
@@ -78,9 +78,7 @@ async def async_get_config_entry_diagnostics(
     diagnostics = {
         "config_entry": await _get_config_entry_diagnostics(entry),
         "system_info": await _get_system_diagnostics(hass),
-        "integration_status": await _get_integration_status(
-            hass, entry, runtime_data
-        ),
+        "integration_status": await _get_integration_status(hass, entry, runtime_data),
         "coordinator_info": await _get_coordinator_diagnostics(coordinator),
         "entities": await _get_entities_diagnostics(hass, entry),
         "devices": await _get_devices_diagnostics(hass, entry),
@@ -93,7 +91,7 @@ async def async_get_config_entry_diagnostics(
 
     # Redact sensitive information
     redacted_diagnostics = _redact_sensitive_data(diagnostics)
-    
+
     _LOGGER.info("Diagnostics generated successfully for entry %s", entry.entry_id)
     return redacted_diagnostics
 
@@ -150,9 +148,7 @@ async def _get_system_diagnostics(hass: HomeAssistant) -> dict[str, Any]:
 
 
 async def _get_integration_status(
-    hass: HomeAssistant, 
-    entry: ConfigEntry, 
-    runtime_data: dict[str, Any] | None
+    hass: HomeAssistant, entry: ConfigEntry, runtime_data: dict[str, Any] | None
 ) -> dict[str, Any]:
     """Get integration status diagnostics.
 
@@ -217,7 +213,9 @@ async def _get_coordinator_diagnostics(
         if coordinator.last_update_time
         else None,
         "update_interval_seconds": coordinator.update_interval.total_seconds(),
-        "update_method": str(coordinator.update_method) if hasattr(coordinator, "update_method") else "unknown",
+        "update_method": str(coordinator.update_method)
+        if hasattr(coordinator, "update_method")
+        else "unknown",
         "logger_name": coordinator.logger.name,
         "name": coordinator.name,
         "statistics": stats,
@@ -382,7 +380,9 @@ async def _get_dogs_summary(
                 else:
                     dog_summary["coordinator_data_available"] = False
             except Exception as err:
-                _LOGGER.debug("Could not get coordinator data for dog %s: %s", dog_id, err)
+                _LOGGER.debug(
+                    "Could not get coordinator data for dog %s: %s", dog_id, err
+                )
                 dog_summary["coordinator_data_available"] = False
 
         dogs_summary.append(dog_summary)
@@ -524,10 +524,10 @@ async def _get_loaded_platforms(hass: HomeAssistant, entry: ConfigEntry) -> list
     # Check which platforms have been loaded by checking entity registry
     entity_registry = er.async_get(hass)
     entities = er.async_entries_for_config_entry(entity_registry, entry.entry_id)
-    
+
     # Get unique platforms
     loaded_platforms = list(set(entity.platform for entity in entities))
-    
+
     return loaded_platforms
 
 
@@ -540,9 +540,8 @@ async def _get_registered_services(hass: HomeAssistant) -> list[str]:
     Returns:
         List of registered service names
     """
-    services = []
     domain_services = hass.services.async_services().get(DOMAIN, {})
-    
+
     return list(domain_services.keys())
 
 

--- a/custom_components/pawcontrol/entity_factory.py
+++ b/custom_components/pawcontrol/entity_factory.py
@@ -108,7 +108,7 @@ ENTITY_PROFILES: Final[dict[str, dict[str, Any]]] = {
 
 class EntityFactory:
     """Factory for creating entities based on profile and configuration.
-    
+
     Provides centralized entity creation with performance optimization
     based on selected profile and module configuration.
     """
@@ -132,14 +132,14 @@ class EntityFactory:
 
         Returns:
             Estimated entity count
-            
+
         Raises:
             ValueError: If profile is invalid
         """
         if not self._validate_profile(profile):
             _LOGGER.warning("Invalid profile %s, using standard", profile)
             profile = "standard"
-            
+
         if not self._validate_modules(modules):
             _LOGGER.warning("Invalid modules configuration, using defaults")
             modules = self._get_default_modules()
@@ -150,74 +150,74 @@ class EntityFactory:
         # Module-based estimates with profile-specific variations
         module_estimates = {
             "feeding": {
-                "basic": 3,      # feeding_status, last_feeding, next_feeding
-                "standard": 6,   # + portion_today, schedule_active, food_level
+                "basic": 3,  # feeding_status, last_feeding, next_feeding
+                "standard": 6,  # + portion_today, schedule_active, food_level
                 "advanced": 10,  # + nutrition_tracking, feeding_history, alerts
                 "health_focus": 6,  # Health-optimized feeding entities
-                "gps_focus": 3,     # Minimal feeding for GPS focus
+                "gps_focus": 3,  # Minimal feeding for GPS focus
             },
             "walk": {
-                "basic": 2,         # walk_status, daily_walks
-                "standard": 4,      # + current_walk_duration, last_walk_distance
-                "advanced": 6,      # + walk_history, activity_score, route_map
-                "gps_focus": 5,     # GPS-optimized walk tracking
+                "basic": 2,  # walk_status, daily_walks
+                "standard": 4,  # + current_walk_duration, last_walk_distance
+                "advanced": 6,  # + walk_history, activity_score, route_map
+                "gps_focus": 5,  # GPS-optimized walk tracking
                 "health_focus": 4,  # Health metrics from walks
             },
             "gps": {
-                "basic": 2,         # location, battery
-                "standard": 4,      # + accuracy, zone_status
-                "advanced": 5,      # + altitude, speed, heading
-                "gps_focus": 6,     # All GPS features optimized
+                "basic": 2,  # location, battery
+                "standard": 4,  # + accuracy, zone_status
+                "advanced": 5,  # + altitude, speed, heading
+                "gps_focus": 6,  # All GPS features optimized
                 "health_focus": 3,  # Basic GPS for health context
             },
             "health": {
-                "basic": 2,         # health_status, weight
-                "standard": 4,      # + mood, activity_level
-                "advanced": 6,      # + detailed_metrics, trends, alerts
+                "basic": 2,  # health_status, weight
+                "standard": 4,  # + mood, activity_level
+                "advanced": 6,  # + detailed_metrics, trends, alerts
                 "health_focus": 8,  # Comprehensive health monitoring
-                "gps_focus": 3,     # Basic health for GPS context
+                "gps_focus": 3,  # Basic health for GPS context
             },
             "notifications": {
-                "basic": 1,         # notification_status
-                "standard": 2,      # + pending_notifications
-                "advanced": 3,      # + notification_history
-                "gps_focus": 2,     # GPS-related notifications
+                "basic": 1,  # notification_status
+                "standard": 2,  # + pending_notifications
+                "advanced": 3,  # + notification_history
+                "gps_focus": 2,  # GPS-related notifications
                 "health_focus": 2,  # Health-related notifications
             },
             "dashboard": {
-                "basic": 0,         # No dashboard entities
-                "standard": 1,      # dashboard_status
-                "advanced": 2,      # + dashboard_config
-                "gps_focus": 1,     # GPS dashboard
+                "basic": 0,  # No dashboard entities
+                "standard": 1,  # dashboard_status
+                "advanced": 2,  # + dashboard_config
+                "gps_focus": 1,  # GPS dashboard
                 "health_focus": 1,  # Health dashboard
             },
             "visitor": {
-                "basic": 1,         # visitor_mode
-                "standard": 2,      # + visitor_schedule
-                "advanced": 3,      # + visitor_history
-                "gps_focus": 2,     # GPS-enhanced visitor mode
+                "basic": 1,  # visitor_mode
+                "standard": 2,  # + visitor_schedule
+                "advanced": 3,  # + visitor_history
+                "gps_focus": 2,  # GPS-enhanced visitor mode
                 "health_focus": 1,  # Basic visitor mode
             },
             "medication": {
-                "basic": 2,         # medication_due, last_dose
-                "standard": 3,      # + medication_schedule
-                "advanced": 5,      # + medication_history, side_effects
+                "basic": 2,  # medication_due, last_dose
+                "standard": 3,  # + medication_schedule
+                "advanced": 5,  # + medication_history, side_effects
                 "health_focus": 6,  # Comprehensive medication tracking
-                "gps_focus": 2,     # Basic medication for GPS users
+                "gps_focus": 2,  # Basic medication for GPS users
             },
             "training": {
-                "basic": 1,         # training_status
-                "standard": 3,      # + training_progress, sessions_today
-                "advanced": 5,      # + training_history, skill_levels
-                "gps_focus": 2,     # Location-based training
+                "basic": 1,  # training_status
+                "standard": 3,  # + training_progress, sessions_today
+                "advanced": 5,  # + training_history, skill_levels
+                "gps_focus": 2,  # Location-based training
                 "health_focus": 3,  # Health-integrated training
             },
             "grooming": {
-                "basic": 1,         # grooming_due
-                "standard": 2,      # + last_grooming
-                "advanced": 3,      # + grooming_schedule
+                "basic": 1,  # grooming_due
+                "standard": 2,  # + last_grooming
+                "advanced": 3,  # + grooming_schedule
                 "health_focus": 3,  # Health-integrated grooming
-                "gps_focus": 1,     # Basic grooming status
+                "gps_focus": 1,  # Basic grooming status
             },
         }
 
@@ -292,14 +292,14 @@ class EntityFactory:
         **kwargs: Any,
     ) -> bool:
         """Apply profile-specific rules for entity creation.
-        
+
         Args:
             profile: Entity profile name
             entity_type: Type of entity
             module: Module name
             priority: Entity priority
             **kwargs: Additional parameters
-            
+
         Returns:
             True if entity should be created
         """
@@ -320,8 +320,8 @@ class EntityFactory:
             essential_types = {"sensor", "button", "binary_sensor"}
             essential_modules = {"feeding", "health", "walk"}
             return (
-                entity_type in essential_types 
-                and module in essential_modules 
+                entity_type in essential_types
+                and module in essential_modules
                 and priority >= 7
             )
 
@@ -329,20 +329,16 @@ class EntityFactory:
             # GPS-related entities prioritized
             preferred_modules = profile_config.get("preferred_modules", [])
             gps_types = {"device_tracker", "sensor", "binary_sensor", "number"}
-            return (
-                entity_type in gps_types and (
-                    module in preferred_modules or priority >= 7
-                )
+            return entity_type in gps_types and (
+                module in preferred_modules or priority >= 7
             )
 
         elif profile == "health_focus":
             # Health-related entities prioritized
             preferred_modules = profile_config.get("preferred_modules", [])
             health_types = {"sensor", "number", "date", "text", "binary_sensor"}
-            return (
-                entity_type in health_types and (
-                    module in preferred_modules or priority >= 7
-                )
+            return entity_type in health_types and (
+                module in preferred_modules or priority >= 7
             )
 
         elif profile == "advanced":
@@ -439,7 +435,9 @@ class EntityFactory:
         if not dog_id or not entity_type or not module:
             _LOGGER.error(
                 "Missing required parameters: dog_id=%s, entity_type=%s, module=%s",
-                dog_id, entity_type, module
+                dog_id,
+                entity_type,
+                module,
             )
             return None
 
@@ -482,7 +480,7 @@ class EntityFactory:
         """
         if profile in self._profile_cache:
             return self._profile_cache[profile]
-            
+
         info = ENTITY_PROFILES.get(profile, ENTITY_PROFILES["standard"]).copy()
         self._profile_cache[profile] = info
         return info
@@ -495,44 +493,50 @@ class EntityFactory:
         """
         # Sort profiles by performance impact and max entities
         profiles = list(ENTITY_PROFILES.keys())
-        
+
         # Custom sort order: basic, standard, focused profiles, advanced
         sort_order = ["basic", "standard", "gps_focus", "health_focus", "advanced"]
-        return sorted(profiles, key=lambda p: sort_order.index(p) if p in sort_order else 99)
+        return sorted(
+            profiles, key=lambda p: sort_order.index(p) if p in sort_order else 99
+        )
 
-    def validate_profile_for_modules(self, profile: str, modules: dict[str, bool]) -> bool:
+    def validate_profile_for_modules(
+        self, profile: str, modules: dict[str, bool]
+    ) -> bool:
         """Validate if a profile is suitable for the given modules.
-        
+
         Args:
             profile: Profile name to validate
             modules: Dictionary of enabled modules
-            
+
         Returns:
             True if profile is suitable
         """
         if not self._validate_profile(profile) or not self._validate_modules(modules):
             return False
-            
+
         profile_config = ENTITY_PROFILES[profile]
-        
+
         # Check for preferred modules alignment
         preferred_modules = profile_config.get("preferred_modules", [])
         if preferred_modules:
-            enabled_preferred = sum(1 for mod in preferred_modules if modules.get(mod, False))
+            enabled_preferred = sum(
+                1 for mod in preferred_modules if modules.get(mod, False)
+            )
             enabled_total = sum(1 for enabled in modules.values() if enabled)
-            
+
             # At least 50% of enabled modules should align with preferred modules
             if enabled_total > 0 and (enabled_preferred / enabled_total) < 0.5:
                 return False
-        
+
         return True
 
     def _validate_profile(self, profile: str) -> bool:
         """Validate profile name.
-        
+
         Args:
             profile: Profile name to validate
-            
+
         Returns:
             True if profile is valid
         """
@@ -540,22 +544,22 @@ class EntityFactory:
 
     def _validate_modules(self, modules: dict[str, bool]) -> bool:
         """Validate modules configuration.
-        
+
         Args:
             modules: Modules dictionary to validate
-            
+
         Returns:
             True if modules configuration is valid
         """
         if not isinstance(modules, dict):
             return False
-            
+
         # Check that all values are boolean
         return all(isinstance(enabled, bool) for enabled in modules.values())
 
     def _get_default_modules(self) -> dict[str, bool]:
         """Get default modules configuration.
-        
+
         Returns:
             Default modules configuration
         """
@@ -567,28 +571,33 @@ class EntityFactory:
             "notifications": True,
         }
 
-    def get_performance_metrics(self, profile: str, modules: dict[str, bool]) -> dict[str, Any]:
+    def get_performance_metrics(
+        self, profile: str, modules: dict[str, bool]
+    ) -> dict[str, Any]:
         """Get performance metrics for a profile and module combination.
-        
+
         Args:
             profile: Profile name
             modules: Enabled modules
-            
+
         Returns:
             Performance metrics dictionary
         """
         if not self._validate_profile(profile):
             profile = "standard"
-            
+
         estimated_entities = self.estimate_entity_count(profile, modules)
         profile_config = ENTITY_PROFILES[profile]
-        
+
         return {
             "profile": profile,
             "estimated_entities": estimated_entities,
             "max_entities": profile_config["max_entities"],
             "performance_impact": profile_config["performance_impact"],
-            "utilization_percentage": (estimated_entities / profile_config["max_entities"]) * 100,
+            "utilization_percentage": (
+                estimated_entities / profile_config["max_entities"]
+            )
+            * 100,
             "enabled_modules": sum(1 for enabled in modules.values() if enabled),
             "total_modules": len(modules),
         }

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -13,10 +13,11 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
-from typing import Any, Callable
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
@@ -35,7 +36,7 @@ CONFIG_CACHE_SIZE_LIMIT = 100
 
 class NotificationType(Enum):
     """Types of notifications with priority hints."""
-    
+
     FEEDING_REMINDER = "feeding_reminder"
     FEEDING_OVERDUE = "feeding_overdue"
     WALK_REMINDER = "walk_reminder"
@@ -48,12 +49,12 @@ class NotificationType(Enum):
     SYSTEM_WARNING = "system_warning"
     SYSTEM_ERROR = "system_error"
     GEOFENCE_ALERT = "geofence_alert"  # OPTIMIZE: Added geofence alerts
-    BATTERY_LOW = "battery_low"         # OPTIMIZE: Added battery alerts
+    BATTERY_LOW = "battery_low"  # OPTIMIZE: Added battery alerts
 
 
 class NotificationPriority(Enum):
     """Notification priority levels with numeric values for comparison."""
-    
+
     LOW = "low"
     NORMAL = "normal"
     HIGH = "high"
@@ -64,7 +65,7 @@ class NotificationPriority(Enum):
         """Get numeric value for priority comparison."""
         mapping = {
             "low": 1,
-            "normal": 2, 
+            "normal": 2,
             "high": 3,
             "urgent": 4,
         }
@@ -73,37 +74,43 @@ class NotificationPriority(Enum):
 
 class NotificationChannel(Enum):
     """Available notification channels."""
-    
+
     PERSISTENT = "persistent"  # Home Assistant persistent notifications
-    MOBILE = "mobile"          # Mobile app notifications
-    EMAIL = "email"            # Email notifications
-    SMS = "sms"               # SMS notifications
-    WEBHOOK = "webhook"        # Custom webhook
-    TTS = "tts"               # Text-to-speech
+    MOBILE = "mobile"  # Mobile app notifications
+    EMAIL = "email"  # Email notifications
+    SMS = "sms"  # SMS notifications
+    WEBHOOK = "webhook"  # Custom webhook
+    TTS = "tts"  # Text-to-speech
     MEDIA_PLAYER = "media_player"  # Media player announcements
-    SLACK = "slack"            # OPTIMIZE: Added Slack notifications
-    DISCORD = "discord"        # OPTIMIZE: Added Discord notifications
+    SLACK = "slack"  # OPTIMIZE: Added Slack notifications
+    DISCORD = "discord"  # OPTIMIZE: Added Discord notifications
 
 
 @dataclass
 class NotificationConfig:
     """Enhanced configuration for notification delivery."""
-    
+
     enabled: bool = True
-    channels: list[NotificationChannel] = field(default_factory=lambda: [NotificationChannel.PERSISTENT])
+    channels: list[NotificationChannel] = field(
+        default_factory=lambda: [NotificationChannel.PERSISTENT]
+    )
     priority_threshold: NotificationPriority = NotificationPriority.NORMAL
     quiet_hours: tuple[int, int] | None = None  # (start_hour, end_hour)
     retry_failed: bool = True
     custom_settings: dict[str, Any] = field(default_factory=dict)
-    rate_limit: dict[str, int] = field(default_factory=dict)  # OPTIMIZE: Added rate limiting
+    rate_limit: dict[str, int] = field(
+        default_factory=dict
+    )  # OPTIMIZE: Added rate limiting
     batch_enabled: bool = True  # OPTIMIZE: Allow batching per config
-    template_overrides: dict[str, str] = field(default_factory=dict)  # OPTIMIZE: Custom templates
+    template_overrides: dict[str, str] = field(
+        default_factory=dict
+    )  # OPTIMIZE: Custom templates
 
 
 @dataclass
 class NotificationEvent:
     """Enhanced individual notification event."""
-    
+
     id: str
     dog_id: str | None
     notification_type: NotificationType
@@ -119,12 +126,12 @@ class NotificationEvent:
     retry_count: int = 0
     acknowledged: bool = False
     acknowledged_at: datetime | None = None
-    
+
     # OPTIMIZE: Enhanced metadata
     grouped_with: list[str] = field(default_factory=list)  # For batched notifications
     template_used: str | None = None
     send_attempts: dict[str, int] = field(default_factory=dict)  # Per-channel attempts
-    
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for storage."""
         return {
@@ -142,7 +149,9 @@ class NotificationEvent:
             "failed_channels": [channel.value for channel in self.failed_channels],
             "retry_count": self.retry_count,
             "acknowledged": self.acknowledged,
-            "acknowledged_at": self.acknowledged_at.isoformat() if self.acknowledged_at else None,
+            "acknowledged_at": self.acknowledged_at.isoformat()
+            if self.acknowledged_at
+            else None,
             "grouped_with": self.grouped_with,
             "template_used": self.template_used,
             "send_attempts": self.send_attempts,
@@ -150,10 +159,10 @@ class NotificationEvent:
 
     def can_be_batched_with(self, other: NotificationEvent) -> bool:
         """Check if this notification can be batched with another.
-        
+
         Args:
             other: Other notification event
-            
+
         Returns:
             True if notifications can be batched
         """
@@ -171,7 +180,7 @@ class NotificationCache:
 
     def __init__(self, max_size: int = CONFIG_CACHE_SIZE_LIMIT) -> None:
         """Initialize notification cache.
-        
+
         Args:
             max_size: Maximum cache entries
         """
@@ -183,10 +192,10 @@ class NotificationCache:
 
     def get_config(self, config_key: str) -> NotificationConfig | None:
         """Get cached configuration.
-        
+
         Args:
             config_key: Configuration key
-            
+
         Returns:
             Cached configuration or None
         """
@@ -201,18 +210,21 @@ class NotificationCache:
 
     def set_config(self, config_key: str, config: NotificationConfig) -> None:
         """Set configuration with LRU eviction.
-        
+
         Args:
             config_key: Configuration key
             config: Configuration to cache
         """
         # Evict oldest if at capacity
-        if len(self._config_cache) >= self._max_size and config_key not in self._config_cache:
+        if (
+            len(self._config_cache) >= self._max_size
+            and config_key not in self._config_cache
+        ):
             oldest = self._access_order.popleft()
             del self._config_cache[oldest]
 
         self._config_cache[config_key] = (config, dt_util.now())
-        
+
         # Update access order
         if config_key in self._access_order:
             self._access_order.remove(config_key)
@@ -220,10 +232,10 @@ class NotificationCache:
 
     def is_quiet_time_cached(self, config_key: str) -> tuple[bool, bool]:
         """Check if quiet time status is cached.
-        
+
         Args:
             config_key: Configuration key
-            
+
         Returns:
             Tuple of (is_cached, is_quiet_time)
         """
@@ -235,69 +247,72 @@ class NotificationCache:
 
     def set_quiet_time_cache(self, config_key: str, is_quiet: bool) -> None:
         """Cache quiet time status.
-        
+
         Args:
             config_key: Configuration key
             is_quiet: Whether it's currently quiet time
         """
         self._quiet_time_cache[config_key] = (is_quiet, dt_util.now())
 
-    def check_rate_limit(self, config_key: str, channel: str, limit_minutes: int) -> bool:
+    def check_rate_limit(
+        self, config_key: str, channel: str, limit_minutes: int
+    ) -> bool:
         """Check if rate limit allows sending.
-        
+
         Args:
             config_key: Configuration key
             channel: Notification channel
             limit_minutes: Rate limit in minutes
-            
+
         Returns:
             True if sending is allowed
         """
         now = dt_util.now()
-        rate_key = f"{config_key}_{channel}"
-        
+
         if config_key not in self._rate_limit_cache:
             self._rate_limit_cache[config_key] = {}
-        
+
         channel_cache = self._rate_limit_cache[config_key]
-        
+
         if channel in channel_cache:
             last_sent = channel_cache[channel]
             if (now - last_sent).total_seconds() < limit_minutes * 60:
                 return False
-        
+
         # Update rate limit cache
         channel_cache[channel] = now
         return True
 
     def cleanup_expired(self) -> int:
         """Clean up expired cache entries.
-        
+
         Returns:
             Number of entries cleaned up
         """
         now = dt_util.now()
         cleaned = 0
-        
+
         # Clean quiet time cache
         expired_quiet_keys = [
-            key for key, (_, cache_time) in self._quiet_time_cache.items()
+            key
+            for key, (_, cache_time) in self._quiet_time_cache.items()
             if (now - cache_time).total_seconds() > QUIET_TIME_CACHE_TTL
         ]
         for key in expired_quiet_keys:
             del self._quiet_time_cache[key]
             cleaned += 1
-        
+
         # Clean rate limit cache (older than 24 hours)
-        for config_key, channels in self._rate_limit_cache.items():
+        for channels in self._rate_limit_cache.values():
             expired_channels = [
-                channel for channel, last_sent in channels.items()
+                channel
+                for channel, last_sent in channels.items()
                 if (now - last_sent).total_seconds() > 86400
             ]
             for channel in expired_channels:
                 del channels[channel]
                 cleaned += 1
-        
+
         return cleaned
 
     def get_stats(self) -> dict[str, Any]:
@@ -305,21 +320,23 @@ class NotificationCache:
         return {
             "config_entries": len(self._config_cache),
             "quiet_time_entries": len(self._quiet_time_cache),
-            "rate_limit_entries": sum(len(channels) for channels in self._rate_limit_cache.values()),
+            "rate_limit_entries": sum(
+                len(channels) for channels in self._rate_limit_cache.values()
+            ),
             "cache_utilization": len(self._config_cache) / self._max_size * 100,
         }
 
 
 class PawControlNotificationManager:
     """Advanced notification management system with performance optimizations.
-    
+
     OPTIMIZE: Enhanced with batch processing, advanced caching, rate limiting,
     and comprehensive performance monitoring for Platinum-level quality.
     """
-    
+
     def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
         """Initialize advanced notification manager.
-        
+
         Args:
             hass: Home Assistant instance
             entry_id: Config entry ID for namespacing
@@ -330,17 +347,17 @@ class PawControlNotificationManager:
         self._configs: dict[str, NotificationConfig] = {}
         self._handlers: dict[NotificationChannel, Callable] = {}
         self._lock = asyncio.Lock()
-        
+
         # OPTIMIZE: Enhanced background tasks
         self._retry_task: asyncio.Task | None = None
         self._cleanup_task: asyncio.Task | None = None
         self._batch_task: asyncio.Task | None = None
-        
+
         # OPTIMIZE: Advanced caching and batching
         self._cache = NotificationCache()
         self._batch_queue: deque[NotificationEvent] = deque()
         self._pending_batches: dict[str, list[NotificationEvent]] = {}
-        
+
         # OPTIMIZE: Performance monitoring
         self._performance_metrics = {
             "notifications_sent": 0,
@@ -351,7 +368,7 @@ class PawControlNotificationManager:
             "rate_limit_blocks": 0,
             "average_delivery_time_ms": 0.0,
         }
-        
+
         # OPTIMIZE: Template system for customizable notifications
         self._templates: dict[str, str] = {
             "feeding_reminder": "🍽️ {title}\n{message}",
@@ -359,10 +376,10 @@ class PawControlNotificationManager:
             "health_alert": "⚕️ {title}\n{message}",
             "batch_summary": "📋 {count} notifications for {dog_name}:\n{summary}",
         }
-        
+
         # Setup default handlers
         self._setup_default_handlers()
-    
+
     def _setup_default_handlers(self) -> None:
         """Setup default notification handlers with error handling."""
         handlers = {
@@ -373,23 +390,26 @@ class PawControlNotificationManager:
             NotificationChannel.SLACK: self._send_slack_notification,
             NotificationChannel.DISCORD: self._send_discord_notification,
         }
-        
+
         # Wrap handlers with error handling and performance monitoring
         for channel, handler in handlers.items():
-            self._handlers[channel] = self._wrap_handler_with_monitoring(handler, channel)
-    
+            self._handlers[channel] = self._wrap_handler_with_monitoring(
+                handler, channel
+            )
+
     def _wrap_handler_with_monitoring(
         self, handler: Callable, channel: NotificationChannel
     ) -> Callable:
         """Wrap handler with performance monitoring.
-        
+
         Args:
             handler: Original handler function
             channel: Notification channel
-            
+
         Returns:
             Wrapped handler with monitoring
         """
+
         async def wrapped_handler(notification: NotificationEvent) -> None:
             start_time = dt_util.now()
             try:
@@ -399,7 +419,9 @@ class PawControlNotificationManager:
                 self._performance_metrics["notifications_failed"] += 1
                 _LOGGER.error(
                     "Handler for %s failed on notification %s: %s",
-                    channel.value, notification.id, err
+                    channel.value,
+                    notification.id,
+                    err,
                 )
                 raise
             finally:
@@ -407,22 +429,26 @@ class PawControlNotificationManager:
                 delivery_time_ms = (dt_util.now() - start_time).total_seconds() * 1000
                 current_avg = self._performance_metrics["average_delivery_time_ms"]
                 total_sent = self._performance_metrics["notifications_sent"]
-                
+
                 if total_sent > 0:
-                    new_avg = (current_avg * (total_sent - 1) + delivery_time_ms) / total_sent
+                    new_avg = (
+                        current_avg * (total_sent - 1) + delivery_time_ms
+                    ) / total_sent
                     self._performance_metrics["average_delivery_time_ms"] = new_avg
 
         return wrapped_handler
-    
-    async def async_initialize(self, notification_configs: dict[str, dict[str, Any]] | None = None) -> None:
+
+    async def async_initialize(
+        self, notification_configs: dict[str, dict[str, Any]] | None = None
+    ) -> None:
         """Initialize notification configurations with enhanced validation.
-        
+
         Args:
             notification_configs: Configuration for each dog/system
         """
         async with self._lock:
             configs = notification_configs or {}
-            
+
             for config_id, config_data in configs.items():
                 try:
                     # Parse channels with validation
@@ -431,26 +457,28 @@ class PawControlNotificationManager:
                         try:
                             channels.append(NotificationChannel(channel_str))
                         except ValueError:
-                            _LOGGER.warning("Invalid notification channel: %s", channel_str)
-                    
+                            _LOGGER.warning(
+                                "Invalid notification channel: %s", channel_str
+                            )
+
                     # Parse priority threshold
                     priority_threshold = NotificationPriority(
                         config_data.get("priority_threshold", "normal")
                     )
-                    
+
                     # Parse quiet hours
                     quiet_hours = None
                     if "quiet_hours" in config_data:
                         quiet_start = config_data["quiet_hours"].get("start", 22)
                         quiet_end = config_data["quiet_hours"].get("end", 7)
                         quiet_hours = (quiet_start, quiet_end)
-                    
+
                     # Parse rate limits
                     rate_limit = config_data.get("rate_limit", {})
-                    
+
                     # Parse template overrides
                     template_overrides = config_data.get("template_overrides", {})
-                    
+
                     config = NotificationConfig(
                         enabled=config_data.get("enabled", True),
                         channels=channels,
@@ -462,30 +490,32 @@ class PawControlNotificationManager:
                         batch_enabled=config_data.get("batch_enabled", True),
                         template_overrides=template_overrides,
                     )
-                    
+
                     self._configs[config_id] = config
                     self._cache.set_config(config_id, config)
-                    
+
                 except Exception as err:
                     _LOGGER.error("Failed to parse config for %s: %s", config_id, err)
-        
+
         # Start background tasks
         await self._start_background_tasks()
-    
+
     async def _start_background_tasks(self) -> None:
         """Start background processing tasks."""
         # Start retry task
         if self._retry_task is None:
             self._retry_task = asyncio.create_task(self._retry_failed_notifications())
-        
+
         # Start cleanup task
         if self._cleanup_task is None:
-            self._cleanup_task = asyncio.create_task(self._cleanup_expired_notifications())
-        
+            self._cleanup_task = asyncio.create_task(
+                self._cleanup_expired_notifications()
+            )
+
         # Start batch processing task
         if self._batch_task is None:
             self._batch_task = asyncio.create_task(self._process_batch_notifications())
-    
+
     async def async_send_notification(
         self,
         notification_type: NotificationType,
@@ -499,9 +529,9 @@ class PawControlNotificationManager:
         allow_batching: bool = True,
     ) -> str:
         """Send a notification with advanced processing.
-        
+
         OPTIMIZE: Enhanced with batching, caching, rate limiting, and templates.
-        
+
         Args:
             notification_type: Type of notification
             title: Notification title
@@ -512,23 +542,25 @@ class PawControlNotificationManager:
             expires_in: Optional expiration time
             force_channels: Optional forced channels (bypasses config)
             allow_batching: Whether this notification can be batched
-            
+
         Returns:
             Notification ID
         """
         async with self._lock:
             # Generate notification ID
-            notification_id = f"{notification_type.value}_{int(dt_util.now().timestamp())}"
-            
+            notification_id = (
+                f"{notification_type.value}_{int(dt_util.now().timestamp())}"
+            )
+
             # Determine configuration to use
             config_key = dog_id if dog_id else "system"
             config = await self._get_config_cached(config_key)
-            
+
             # Check if notifications are enabled
             if not config.enabled:
                 _LOGGER.debug("Notifications disabled for %s", config_key)
                 return notification_id
-            
+
             # Check priority threshold with optimized comparison
             if priority.value_numeric < config.priority_threshold.value_numeric:
                 _LOGGER.debug(
@@ -537,34 +569,38 @@ class PawControlNotificationManager:
                     config.priority_threshold.value,
                 )
                 return notification_id
-            
+
             # OPTIMIZE: Check quiet hours with caching
             if await self._is_quiet_time_cached(config_key, config, priority):
                 _LOGGER.debug("Notification suppressed due to quiet hours")
                 return notification_id
-            
+
             # OPTIMIZE: Check rate limits
             channels = force_channels if force_channels else config.channels
             allowed_channels = []
             for channel in channels:
                 rate_limit_key = f"{channel.value}_limit_minutes"
                 limit_minutes = config.rate_limit.get(rate_limit_key, 0)
-                
-                if limit_minutes == 0 or self._cache.check_rate_limit(config_key, channel.value, limit_minutes):
+
+                if limit_minutes == 0 or self._cache.check_rate_limit(
+                    config_key, channel.value, limit_minutes
+                ):
                     allowed_channels.append(channel)
                 else:
                     self._performance_metrics["rate_limit_blocks"] += 1
-                    _LOGGER.debug("Rate limit blocked %s for %s", channel.value, config_key)
-            
+                    _LOGGER.debug(
+                        "Rate limit blocked %s for %s", channel.value, config_key
+                    )
+
             if not allowed_channels:
                 _LOGGER.warning("All channels rate limited for %s", config_key)
                 return notification_id
-            
+
             # Apply template if available
             formatted_title, formatted_message = self._apply_template(
                 notification_type, title, message, config, data or {}
             )
-            
+
             # Calculate expiration
             expires_at = None
             if expires_in:
@@ -576,7 +612,7 @@ class PawControlNotificationManager:
             ]:
                 # Auto-expire reminders after 24 hours
                 expires_at = dt_util.now() + timedelta(hours=NOTIFICATION_EXPIRE_HOURS)
-            
+
             # Create notification event
             notification = NotificationEvent(
                 id=notification_id,
@@ -591,12 +627,16 @@ class PawControlNotificationManager:
                 data=data or {},
                 template_used=self._get_template_name(notification_type),
             )
-            
+
             # Store notification
             self._notifications[notification_id] = notification
-            
+
             # OPTIMIZE: Handle batching for eligible notifications
-            if allow_batching and config.batch_enabled and self._should_batch(notification):
+            if (
+                allow_batching
+                and config.batch_enabled
+                and self._should_batch(notification)
+            ):
                 await self._add_to_batch_queue(notification)
                 _LOGGER.debug("Added notification %s to batch queue", notification_id)
             else:
@@ -608,15 +648,15 @@ class PawControlNotificationManager:
                     formatted_title,
                     priority.value,
                 )
-            
+
             return notification_id
 
     async def _get_config_cached(self, config_key: str) -> NotificationConfig:
         """Get configuration with caching.
-        
+
         Args:
             config_key: Configuration key
-            
+
         Returns:
             Notification configuration
         """
@@ -625,58 +665,58 @@ class PawControlNotificationManager:
         if cached_config:
             self._performance_metrics["cache_hits"] += 1
             return cached_config
-        
+
         # Get from configs
         config = self._configs.get(config_key, NotificationConfig())
         self._cache.set_config(config_key, config)
         self._performance_metrics["cache_misses"] += 1
-        
+
         return config
 
     async def _is_quiet_time_cached(
-        self, 
+        self,
         config_key: str,
-        config: NotificationConfig, 
-        priority: NotificationPriority
+        config: NotificationConfig,
+        priority: NotificationPriority,
     ) -> bool:
         """Check if it's currently quiet time with caching.
-        
+
         OPTIMIZE: Cache quiet time calculations to reduce repeated computations.
-        
+
         Args:
             config_key: Configuration key for caching
             config: Notification configuration
             priority: Notification priority
-            
+
         Returns:
             True if in quiet time and should suppress notification
         """
         # Urgent notifications always go through
         if priority == NotificationPriority.URGENT:
             return False
-        
+
         if not config.quiet_hours:
             return False
-        
+
         # Check cache first
         is_cached, is_quiet = self._cache.is_quiet_time_cached(config_key)
         if is_cached:
             return is_quiet
-        
+
         # Calculate quiet time status
         now = dt_util.now()
         current_hour = now.hour
         start_hour, end_hour = config.quiet_hours
-        
+
         # Handle quiet hours that cross midnight
         if start_hour > end_hour:  # e.g., 22:00 to 07:00
             is_quiet = current_hour >= start_hour or current_hour < end_hour
         else:  # e.g., 01:00 to 06:00
             is_quiet = start_hour <= current_hour < end_hour
-        
+
         # Cache result
         self._cache.set_quiet_time_cache(config_key, is_quiet)
-        
+
         return is_quiet
 
     def _apply_template(
@@ -688,28 +728,27 @@ class PawControlNotificationManager:
         data: dict[str, Any],
     ) -> tuple[str, str]:
         """Apply template formatting to notification.
-        
+
         Args:
             notification_type: Type of notification
             title: Original title
             message: Original message
             config: Notification configuration
             data: Additional data for templating
-            
+
         Returns:
             Tuple of (formatted_title, formatted_message)
         """
         template_name = self._get_template_name(notification_type)
-        
+
         # Check for config override first
         template = config.template_overrides.get(
-            template_name,
-            self._templates.get(template_name)
+            template_name, self._templates.get(template_name)
         )
-        
+
         if not template:
             return title, message
-        
+
         try:
             # Prepare template variables
             template_vars = {
@@ -717,26 +756,26 @@ class PawControlNotificationManager:
                 "message": message,
                 **data,
             }
-            
+
             formatted = template.format(**template_vars)
-            
+
             # Split back into title and message if template contains both
             if "\n" in formatted:
                 parts = formatted.split("\n", 1)
                 return parts[0], parts[1]
             else:
                 return formatted, message
-                
+
         except (KeyError, ValueError) as err:
             _LOGGER.warning("Template formatting failed for %s: %s", template_name, err)
             return title, message
 
     def _get_template_name(self, notification_type: NotificationType) -> str:
         """Get template name for notification type.
-        
+
         Args:
             notification_type: Notification type
-            
+
         Returns:
             Template name
         """
@@ -744,10 +783,10 @@ class PawControlNotificationManager:
 
     def _should_batch(self, notification: NotificationEvent) -> bool:
         """Determine if notification should be batched.
-        
+
         Args:
             notification: Notification event
-            
+
         Returns:
             True if notification should be batched
         """
@@ -757,7 +796,7 @@ class PawControlNotificationManager:
             NotificationType.WALK_REMINDER,
             NotificationType.HEALTH_ALERT,
         }
-        
+
         return (
             notification.notification_type in batchable_types
             and notification.priority != NotificationPriority.URGENT
@@ -766,12 +805,12 @@ class PawControlNotificationManager:
 
     async def _add_to_batch_queue(self, notification: NotificationEvent) -> None:
         """Add notification to batch queue.
-        
+
         Args:
             notification: Notification to batch
         """
         self._batch_queue.append(notification)
-        
+
         # Add to pending batches by dog
         if notification.dog_id:
             batch_key = f"{notification.dog_id}_{notification.notification_type.value}"
@@ -781,22 +820,24 @@ class PawControlNotificationManager:
 
     async def _process_batch_notifications(self) -> None:
         """Background task to process batch notifications.
-        
+
         OPTIMIZE: Process notifications in batches for better user experience.
         """
         while True:
             try:
                 await asyncio.sleep(60)  # Process batches every minute
-                
+
                 async with self._lock:
                     if not self._pending_batches:
                         continue
-                    
+
                     # Process each batch
                     batches_to_send = {}
                     for batch_key, notifications in self._pending_batches.items():
                         if len(notifications) >= BATCH_PROCESSING_SIZE:
-                            batches_to_send[batch_key] = notifications[:BATCH_PROCESSING_SIZE]
+                            batches_to_send[batch_key] = notifications[
+                                :BATCH_PROCESSING_SIZE
+                            ]
                             # Remove processed notifications
                             del self._pending_batches[batch_key]
                         elif notifications:
@@ -806,12 +847,12 @@ class PawControlNotificationManager:
                             if age > 300:  # 5 minutes
                                 batches_to_send[batch_key] = notifications
                                 del self._pending_batches[batch_key]
-                    
+
                     # Send batches
                     for batch_key, notifications in batches_to_send.items():
                         await self._send_batch(notifications)
                         self._performance_metrics["batch_operations"] += 1
-            
+
             except asyncio.CancelledError:
                 break
             except Exception as err:
@@ -819,37 +860,37 @@ class PawControlNotificationManager:
 
     async def _send_batch(self, notifications: list[NotificationEvent]) -> None:
         """Send a batch of notifications.
-        
+
         Args:
             notifications: List of notifications to send as batch
         """
         if not notifications:
             return
-        
+
         # Group notifications and create batch notification
         dog_id = notifications[0].dog_id
         dog_name = dog_id.replace("_", " ").title() if dog_id else "System"
-        
+
         # Create summary
         summary_lines = []
         for notification in notifications:
             summary_lines.append(f"• {notification.title}")
-        
+
         # Create batch notification
         batch_title = f"📋 {len(notifications)} notifications for {dog_name}"
         batch_message = "\n".join(summary_lines)
-        
+
         # Find common channels
         common_channels = set(notifications[0].channels)
         for notification in notifications[1:]:
             common_channels &= set(notification.channels)
-        
+
         if not common_channels:
             # Fall back to individual sends if no common channels
             for notification in notifications:
                 await self._send_to_channels(notification)
             return
-        
+
         # Create batch notification event
         batch_id = f"batch_{int(dt_util.now().timestamp())}"
         batch_notification = NotificationEvent(
@@ -866,14 +907,14 @@ class PawControlNotificationManager:
                 "individual_ids": [n.id for n in notifications],
             },
         )
-        
+
         # Mark individual notifications as grouped
         for notification in notifications:
             notification.grouped_with.append(batch_id)
-        
+
         # Send batch notification
         await self._send_to_channels(batch_notification)
-        
+
         _LOGGER.info(
             "Sent batch notification with %d individual notifications for %s",
             len(notifications),
@@ -882,9 +923,9 @@ class PawControlNotificationManager:
 
     async def _send_to_channels(self, notification: NotificationEvent) -> None:
         """Send notification to all configured channels with enhanced error handling.
-        
+
         OPTIMIZE: Parallel channel sending with individual error handling.
-        
+
         Args:
             notification: Notification to send
         """
@@ -893,22 +934,26 @@ class PawControlNotificationManager:
         for channel in notification.channels:
             handler = self._handlers.get(channel)
             if handler:
-                send_tasks.append(self._send_to_channel_safe(notification, channel, handler))
+                send_tasks.append(
+                    self._send_to_channel_safe(notification, channel, handler)
+                )
             else:
                 _LOGGER.warning("No handler for channel %s", channel.value)
                 notification.failed_channels.append(channel)
-        
+
         if send_tasks:
             # Execute all sends in parallel
             results = await asyncio.gather(*send_tasks, return_exceptions=True)
-            
+
             # Process results
             for i, result in enumerate(results):
                 if isinstance(result, Exception):
                     channel = notification.channels[i]
                     _LOGGER.error(
                         "Failed to send notification %s to channel %s: %s",
-                        notification.id, channel.value, result
+                        notification.id,
+                        channel.value,
+                        result,
                     )
 
     async def _send_to_channel_safe(
@@ -918,7 +963,7 @@ class PawControlNotificationManager:
         handler: Callable,
     ) -> None:
         """Send to a single channel with error handling.
-        
+
         Args:
             notification: Notification to send
             channel: Target channel
@@ -927,27 +972,33 @@ class PawControlNotificationManager:
         try:
             await handler(notification)
             notification.sent_to.append(channel)
-            
+
             # Track send attempts
             channel_key = channel.value
-            notification.send_attempts[channel_key] = notification.send_attempts.get(channel_key, 0) + 1
-            
+            notification.send_attempts[channel_key] = (
+                notification.send_attempts.get(channel_key, 0) + 1
+            )
+
         except Exception as err:
             notification.failed_channels.append(channel)
             _LOGGER.error(
                 "Failed to send notification %s to channel %s: %s",
-                notification.id, channel.value, err
+                notification.id,
+                channel.value,
+                err,
             )
 
     # OPTIMIZE: Enhanced notification handlers with better error handling and features
-    async def _send_persistent_notification(self, notification: NotificationEvent) -> None:
+    async def _send_persistent_notification(
+        self, notification: NotificationEvent
+    ) -> None:
         """Send persistent notification in Home Assistant."""
         service_data = {
             "notification_id": f"{self._entry_id}_{notification.id}",
             "title": notification.title,
             "message": notification.message,
         }
-        
+
         await self._hass.services.async_call(
             "persistent_notification",
             "create",
@@ -958,9 +1009,9 @@ class PawControlNotificationManager:
         """Send mobile app notification with enhanced features."""
         config_key = notification.dog_id if notification.dog_id else "system"
         config = await self._get_config_cached(config_key)
-        
+
         mobile_service = config.custom_settings.get("mobile_service", "mobile_app")
-        
+
         service_data = {
             "title": notification.title,
             "message": notification.message,
@@ -972,7 +1023,7 @@ class PawControlNotificationManager:
                 **notification.data,
             },
         }
-        
+
         # Add actions for interactive notifications
         if notification.notification_type in [
             NotificationType.FEEDING_REMINDER,
@@ -991,7 +1042,7 @@ class PawControlNotificationManager:
                     "icon": "sli:clock",
                 },
             ]
-        
+
         await self._hass.services.async_call(
             "notify",
             mobile_service,
@@ -1002,13 +1053,15 @@ class PawControlNotificationManager:
         """Send text-to-speech notification."""
         config_key = notification.dog_id if notification.dog_id else "system"
         config = await self._get_config_cached(config_key)
-        
+
         tts_service = config.custom_settings.get("tts_service", "google_translate_say")
-        tts_entity = config.custom_settings.get("tts_entity", "media_player.living_room")
-        
+        tts_entity = config.custom_settings.get(
+            "tts_entity", "media_player.living_room"
+        )
+
         # Combine title and message for TTS
         tts_message = f"{notification.title}. {notification.message}"
-        
+
         await self._hass.services.async_call(
             "tts",
             tts_service,
@@ -1018,17 +1071,19 @@ class PawControlNotificationManager:
             },
         )
 
-    async def _send_media_player_notification(self, notification: NotificationEvent) -> None:
+    async def _send_media_player_notification(
+        self, notification: NotificationEvent
+    ) -> None:
         """Send notification via media player."""
         config_key = notification.dog_id if notification.dog_id else "system"
         config = await self._get_config_cached(config_key)
-        
+
         media_player = config.custom_settings.get("media_player_entity")
         if not media_player:
             raise ValueError("No media player entity configured")
-        
+
         announcement = f"PawControl Alert: {notification.title}. {notification.message}"
-        
+
         await self._hass.services.async_call(
             "media_player",
             "play_media",
@@ -1041,14 +1096,14 @@ class PawControlNotificationManager:
 
     async def _send_slack_notification(self, notification: NotificationEvent) -> None:
         """Send Slack notification.
-        
+
         OPTIMIZE: New Slack integration for team notifications.
         """
         config_key = notification.dog_id if notification.dog_id else "system"
         config = await self._get_config_cached(config_key)
-        
+
         slack_service = config.custom_settings.get("slack_service", "slack")
-        
+
         service_data = {
             "title": notification.title,
             "message": notification.message,
@@ -1058,7 +1113,7 @@ class PawControlNotificationManager:
                 "username": "PawControl",
             },
         }
-        
+
         await self._hass.services.async_call(
             "notify",
             slack_service,
@@ -1067,14 +1122,14 @@ class PawControlNotificationManager:
 
     async def _send_discord_notification(self, notification: NotificationEvent) -> None:
         """Send Discord notification.
-        
+
         OPTIMIZE: New Discord integration for community notifications.
         """
         config_key = notification.dog_id if notification.dog_id else "system"
         config = await self._get_config_cached(config_key)
-        
+
         discord_service = config.custom_settings.get("discord_service", "discord")
-        
+
         service_data = {
             "title": notification.title,
             "message": notification.message,
@@ -1089,7 +1144,7 @@ class PawControlNotificationManager:
                 },
             },
         }
-        
+
         await self._hass.services.async_call(
             "notify",
             discord_service,
@@ -1098,20 +1153,20 @@ class PawControlNotificationManager:
 
     def _get_color_for_priority(self, priority: NotificationPriority) -> int:
         """Get Discord embed color for priority.
-        
+
         Args:
             priority: Notification priority
-            
+
         Returns:
             Discord color code
         """
         colors = {
-            NotificationPriority.LOW: 0x95a5a6,      # Gray
-            NotificationPriority.NORMAL: 0x3498db,   # Blue
-            NotificationPriority.HIGH: 0xf39c12,     # Orange
-            NotificationPriority.URGENT: 0xe74c3c,   # Red
+            NotificationPriority.LOW: 0x95A5A6,  # Gray
+            NotificationPriority.NORMAL: 0x3498DB,  # Blue
+            NotificationPriority.HIGH: 0xF39C12,  # Orange
+            NotificationPriority.URGENT: 0xE74C3C,  # Red
         }
-        return colors.get(priority, 0x3498db)
+        return colors.get(priority, 0x3498DB)
 
     # OPTIMIZE: Enhanced cleanup and maintenance
     async def _cleanup_expired_notifications(self) -> None:
@@ -1119,20 +1174,21 @@ class PawControlNotificationManager:
         while True:
             try:
                 await asyncio.sleep(CACHE_CLEANUP_INTERVAL)
-                
+
                 async with self._lock:
                     # Clean expired notifications
                     expired_count = await self.async_cleanup_expired_notifications()
-                    
+
                     # Clean cache
                     cache_cleaned = self._cache.cleanup_expired()
-                    
+
                     if expired_count > 0 or cache_cleaned > 0:
                         _LOGGER.debug(
                             "Cleanup: %d expired notifications, %d cache entries",
-                            expired_count, cache_cleaned
+                            expired_count,
+                            cache_cleaned,
                         )
-            
+
             except asyncio.CancelledError:
                 break
             except Exception as err:
@@ -1140,30 +1196,29 @@ class PawControlNotificationManager:
 
     async def async_cleanup_expired_notifications(self) -> int:
         """Clean up expired notifications with enhanced logic.
-        
+
         Returns:
             Number of notifications cleaned up
         """
         now = dt_util.now()
         expired_ids = []
-        
+
         for notification_id, notification in self._notifications.items():
             # Remove if expired or very old acknowledged notifications
-            if (
-                (notification.expires_at and notification.expires_at < now)
-                or (notification.acknowledged and 
-                    notification.acknowledged_at and
-                    (now - notification.acknowledged_at).days > 7)
+            if (notification.expires_at and notification.expires_at < now) or (
+                notification.acknowledged
+                and notification.acknowledged_at
+                and (now - notification.acknowledged_at).days > 7
             ):
                 expired_ids.append(notification_id)
-        
+
         # Batch remove expired notifications
         for notification_id in expired_ids:
             del self._notifications[notification_id]
-        
+
         if expired_ids:
             _LOGGER.debug("Cleaned up %d expired notifications", len(expired_ids))
-        
+
         return len(expired_ids)
 
     # Keep existing public interface methods with optimizations
@@ -1173,10 +1228,10 @@ class PawControlNotificationManager:
             notification = self._notifications.get(notification_id)
             if not notification:
                 return False
-            
+
             notification.acknowledged = True
             notification.acknowledged_at = dt_util.now()
-            
+
             # Dismiss persistent notification if it exists
             if NotificationChannel.PERSISTENT in notification.sent_to:
                 try:
@@ -1186,55 +1241,57 @@ class PawControlNotificationManager:
                         {"notification_id": f"{self._entry_id}_{notification_id}"},
                     )
                 except Exception as err:
-                    _LOGGER.warning("Failed to dismiss persistent notification: %s", err)
-            
+                    _LOGGER.warning(
+                        "Failed to dismiss persistent notification: %s", err
+                    )
+
             _LOGGER.info("Acknowledged notification %s", notification_id)
             return True
 
     async def async_get_performance_statistics(self) -> dict[str, Any]:
         """Get comprehensive performance statistics.
-        
+
         OPTIMIZE: New method for monitoring system performance.
-        
+
         Returns:
             Performance statistics
         """
         async with self._lock:
             total_notifications = len(self._notifications)
-            active_notifications = len([
-                n for n in self._notifications.values()
-                if not n.acknowledged and (
-                    not n.expires_at or n.expires_at > dt_util.now()
-                )
-            ])
-            
+            active_notifications = len(
+                [
+                    n
+                    for n in self._notifications.values()
+                    if not n.acknowledged
+                    and (not n.expires_at or n.expires_at > dt_util.now())
+                ]
+            )
+
             # Calculate type and priority distribution
             type_counts = {}
             priority_counts = {}
-            
+
             for notification in self._notifications.values():
                 ntype = notification.notification_type.value
                 type_counts[ntype] = type_counts.get(ntype, 0) + 1
-                
+
                 priority = notification.priority.value
                 priority_counts[priority] = priority_counts.get(priority, 0) + 1
-            
+
             return {
                 # Basic stats
                 "total_notifications": total_notifications,
                 "active_notifications": active_notifications,
-                "configured_dogs": len([k for k in self._configs.keys() if k != "system"]),
+                "configured_dogs": len([k for k in self._configs if k != "system"]),
                 "type_distribution": type_counts,
                 "priority_distribution": priority_counts,
-                
                 # Performance metrics
                 "performance_metrics": self._performance_metrics.copy(),
                 "cache_stats": self._cache.get_stats(),
                 "batch_queue_size": len(self._batch_queue),
                 "pending_batches": len(self._pending_batches),
-                
                 # Handler stats
-                "available_channels": [channel.value for channel in self._handlers.keys()],
+                "available_channels": [channel.value for channel in self._handlers],
                 "handlers_registered": len(self._handlers),
             }
 
@@ -1246,20 +1303,20 @@ class PawControlNotificationManager:
             self._cleanup_task,
             self._batch_task,
         ]
-        
+
         for task in tasks_to_cancel:
             if task and not task.done():
                 task.cancel()
-        
+
         # Wait for tasks to complete
         await asyncio.gather(*[t for t in tasks_to_cancel if t], return_exceptions=True)
-        
+
         # Process any remaining batches
         async with self._lock:
             for notifications in self._pending_batches.values():
                 for notification in notifications:
                     await self._send_to_channels(notification)
-        
+
         # Clear all data
         self._notifications.clear()
         self._configs.clear()
@@ -1273,11 +1330,11 @@ class PawControlNotificationManager:
         while True:
             try:
                 await asyncio.sleep(RETRY_DELAY_SECONDS)
-                
+
                 async with self._lock:
                     now = dt_util.now()
                     retry_notifications = []
-                    
+
                     for notification in self._notifications.values():
                         if (
                             (notification.expires_at and notification.expires_at < now)
@@ -1286,11 +1343,11 @@ class PawControlNotificationManager:
                             or notification.retry_count >= MAX_RETRY_ATTEMPTS
                         ):
                             continue
-                        
+
                         time_since_creation = now - notification.created_at
                         if time_since_creation.total_seconds() > RETRY_DELAY_SECONDS:
                             retry_notifications.append(notification)
-                    
+
                     for notification in retry_notifications:
                         if notification.failed_channels:
                             _LOGGER.info(
@@ -1298,14 +1355,14 @@ class PawControlNotificationManager:
                                 notification.id,
                                 notification.retry_count + 1,
                             )
-                            
+
                             failed_channels = notification.failed_channels.copy()
                             notification.failed_channels.clear()
                             notification.channels = failed_channels
                             notification.retry_count += 1
-                            
+
                             await self._send_to_channels(notification)
-            
+
             except asyncio.CancelledError:
                 break
             except Exception as err:
@@ -1313,16 +1370,20 @@ class PawControlNotificationManager:
 
     # Additional convenience methods for specific notification types
     async def async_send_feeding_reminder(
-        self, dog_id: str, meal_type: str, scheduled_time: str, portion_size: float | None = None
+        self,
+        dog_id: str,
+        meal_type: str,
+        scheduled_time: str,
+        portion_size: float | None = None,
     ) -> str:
         """Send feeding reminder notification."""
         title = f"🍽️ {meal_type.title()} Time for {dog_id.title()}"
         message = f"It's time for {dog_id}'s {meal_type}"
-        
+
         if portion_size:
             message += f" ({portion_size}g)"
         message += f" scheduled for {scheduled_time}."
-        
+
         return await self.async_send_notification(
             notification_type=NotificationType.FEEDING_REMINDER,
             title=title,
@@ -1341,12 +1402,12 @@ class PawControlNotificationManager:
     ) -> str:
         """Send walk reminder notification."""
         title = f"🚶 Walk Time for {dog_id.title()}"
-        
+
         if last_walk_hours:
             message = f"{dog_id} hasn't been walked in {last_walk_hours:.1f} hours. Time for a walk!"
         else:
             message = f"It's time to take {dog_id} for a walk!"
-        
+
         return await self.async_send_notification(
             notification_type=NotificationType.WALK_REMINDER,
             title=title,
@@ -1357,16 +1418,16 @@ class PawControlNotificationManager:
         )
 
     async def async_send_health_alert(
-        self, 
-        dog_id: str, 
-        alert_type: str, 
+        self,
+        dog_id: str,
+        alert_type: str,
         details: str,
         priority: NotificationPriority = NotificationPriority.HIGH,
     ) -> str:
         """Send health alert notification."""
         title = f"⚕️ Health Alert: {dog_id.title()}"
         message = f"{alert_type}: {details}"
-        
+
         return await self.async_send_notification(
             notification_type=NotificationType.HEALTH_ALERT,
             title=title,

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -849,7 +849,7 @@ class PawControlNotificationManager:
                                 del self._pending_batches[batch_key]
 
                     # Send batches
-                    for batch_key, notifications in batches_to_send.items():
+                    for notifications in batches_to_send.values():
                         await self._send_batch(notifications)
                         self._performance_metrics["batch_operations"] += 1
 
@@ -872,9 +872,7 @@ class PawControlNotificationManager:
         dog_name = dog_id.replace("_", " ").title() if dog_id else "System"
 
         # Create summary
-        summary_lines = []
-        for notification in notifications:
-            summary_lines.append(f"• {notification.title}")
+        summary_lines = [f"• {notification.title}" for notification in notifications]
 
         # Create batch notification
         batch_title = f"📋 {len(notifications)} notifications for {dog_name}"

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -15,6 +15,7 @@ Python: 3.13+
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from typing import Any
 
@@ -211,7 +212,10 @@ class PawControlOptionsFlow(OptionsFlow):
 
         current_dogs = self._config_entry.data.get(CONF_DOGS, [])
         current_profile = self._config_entry.options.get("entity_profile", "standard")
-        cache_key = f"{current_profile}_{len(current_dogs)}_{hash(str(current_dogs))}"
+        cache_key = (
+            f"{current_profile}_{len(current_dogs)}_"
+            f"{hash(json.dumps(current_dogs, sort_keys=True))}"
+        )
 
         cached = self._profile_cache.get(cache_key)
         if cached:
@@ -285,7 +289,10 @@ class PawControlOptionsFlow(OptionsFlow):
         """Calculate profile preview with optimized performance."""
 
         current_dogs = self._config_entry.data.get(CONF_DOGS, [])
-        cache_key = f"{profile}_{len(current_dogs)}_{hash(json.dumps(current_dogs, sort_keys=True))}"
+        cache_key = (
+            f"{profile}_{len(current_dogs)}_"
+            f"{hash(json.dumps(current_dogs, sort_keys=True))}"
+        )
 
         cached_preview = self._entity_estimates_cache.get(cache_key)
         if cached_preview:

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -307,9 +307,7 @@ class PawControlOptionsFlow(OptionsFlow):
             total_entities += estimate
 
             enabled_modules = [module for module, enabled in modules.items() if enabled]
-            utilization = (
-                (estimate / max_entities) * 100 if max_entities > 0 else 0
-            )
+            utilization = (estimate / max_entities) * 100 if max_entities > 0 else 0
 
             entity_breakdown.append(
                 {

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -285,7 +285,7 @@ class PawControlOptionsFlow(OptionsFlow):
         """Calculate profile preview with optimized performance."""
 
         current_dogs = self._config_entry.data.get(CONF_DOGS, [])
-        cache_key = f"{profile}_{len(current_dogs)}_{hash(str(current_dogs))}"
+        cache_key = f"{profile}_{len(current_dogs)}_{hash(json.dumps(current_dogs, sort_keys=True))}"
 
         cached_preview = self._entity_estimates_cache.get(cache_key)
         if cached_preview:

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -12,13 +12,10 @@ from __future__ import annotations
 
 import logging
 from datetime import timedelta
-from typing import Any
 
 import voluptuous as vol
-
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers import config_validation as cv
-from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 
@@ -38,119 +35,169 @@ SERVICE_ANALYZE_PATTERNS = "analyze_patterns"
 SERVICE_GENERATE_REPORT = "generate_report"
 
 # Service schemas
-SERVICE_ADD_FEEDING_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("amount"): vol.Coerce(float),
-    vol.Optional("meal_type"): cv.string,
-    vol.Optional("notes"): cv.string,
-    vol.Optional("feeder"): cv.string,
-    vol.Optional("scheduled", default=False): cv.boolean,
-    vol.Optional("with_medication", default=False): cv.boolean,
-    vol.Optional("medication_data"): vol.Schema({
-        vol.Optional("name"): cv.string,
-        vol.Optional("dose"): cv.string,
-        vol.Optional("time"): cv.string,
-    }),
-})
+SERVICE_ADD_FEEDING_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("amount"): vol.Coerce(float),
+        vol.Optional("meal_type"): cv.string,
+        vol.Optional("notes"): cv.string,
+        vol.Optional("feeder"): cv.string,
+        vol.Optional("scheduled", default=False): cv.boolean,
+        vol.Optional("with_medication", default=False): cv.boolean,
+        vol.Optional("medication_data"): vol.Schema(
+            {
+                vol.Optional("name"): cv.string,
+                vol.Optional("dose"): cv.string,
+                vol.Optional("time"): cv.string,
+            }
+        ),
+    }
+)
 
-SERVICE_START_WALK_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Optional("walker"): cv.string,
-    vol.Optional("weather"): vol.In([
-        "sunny", "cloudy", "rainy", "snowy", "windy", "hot", "cold"
-    ]),
-    vol.Optional("leash_used", default=True): cv.boolean,
-})
+SERVICE_START_WALK_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Optional("walker"): cv.string,
+        vol.Optional("weather"): vol.In(
+            ["sunny", "cloudy", "rainy", "snowy", "windy", "hot", "cold"]
+        ),
+        vol.Optional("leash_used", default=True): cv.boolean,
+    }
+)
 
-SERVICE_END_WALK_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Optional("notes"): cv.string,
-    vol.Optional("dog_weight_kg"): vol.Coerce(float),
-})
+SERVICE_END_WALK_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Optional("notes"): cv.string,
+        vol.Optional("dog_weight_kg"): vol.Coerce(float),
+    }
+)
 
-SERVICE_ADD_GPS_POINT_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("latitude"): vol.Coerce(float),
-    vol.Required("longitude"): vol.Coerce(float),
-    vol.Optional("altitude"): vol.Coerce(float),
-    vol.Optional("accuracy"): vol.Coerce(float),
-})
+SERVICE_ADD_GPS_POINT_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("latitude"): vol.Coerce(float),
+        vol.Required("longitude"): vol.Coerce(float),
+        vol.Optional("altitude"): vol.Coerce(float),
+        vol.Optional("accuracy"): vol.Coerce(float),
+    }
+)
 
-SERVICE_UPDATE_HEALTH_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Optional("weight"): vol.Coerce(float),
-    vol.Optional("ideal_weight"): vol.Coerce(float),
-    vol.Optional("age_months"): vol.Coerce(int),
-    vol.Optional("activity_level"): vol.In([
-        "very_low", "low", "moderate", "high", "very_high"
-    ]),
-    vol.Optional("body_condition_score"): vol.Range(min=1, max=9),
-    vol.Optional("health_conditions"): [cv.string],
-    vol.Optional("weight_goal"): vol.In(["maintain", "lose", "gain"]),
-})
-
-SERVICE_SEND_NOTIFICATION_SCHEMA = vol.Schema({
-    vol.Required("title"): cv.string,
-    vol.Required("message"): cv.string,
-    vol.Optional("dog_id"): cv.string,
-    vol.Optional("notification_type"): vol.In([
-        "feeding_reminder", "feeding_overdue", "walk_reminder", "walk_overdue",
-        "health_alert", "medication_reminder", "veterinary_appointment",
-        "weight_check", "system_info", "system_warning", "system_error"
-    ]),
-    vol.Optional("priority"): vol.In(["low", "normal", "high", "urgent"]),
-    vol.Optional("channels"): [vol.In([
-        "persistent", "mobile", "email", "sms", "webhook", "tts", "media_player"
-    ])],
-    vol.Optional("expires_in_hours"): vol.Coerce(int),
-})
-
-SERVICE_ACKNOWLEDGE_NOTIFICATION_SCHEMA = vol.Schema({
-    vol.Required("notification_id"): cv.string,
-})
-
-SERVICE_CALCULATE_PORTION_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("meal_type"): cv.string,
-    vol.Optional("override_health_data"): vol.Schema({
+SERVICE_UPDATE_HEALTH_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
         vol.Optional("weight"): vol.Coerce(float),
-        vol.Optional("activity_level"): cv.string,
+        vol.Optional("ideal_weight"): vol.Coerce(float),
+        vol.Optional("age_months"): vol.Coerce(int),
+        vol.Optional("activity_level"): vol.In(
+            ["very_low", "low", "moderate", "high", "very_high"]
+        ),
+        vol.Optional("body_condition_score"): vol.Range(min=1, max=9),
         vol.Optional("health_conditions"): [cv.string],
-    }),
-})
+        vol.Optional("weight_goal"): vol.In(["maintain", "lose", "gain"]),
+    }
+)
 
-SERVICE_EXPORT_DATA_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("data_type"): vol.In(["feeding", "walks", "health", "all"]),
-    vol.Optional("format"): vol.In(["json", "csv", "gpx"]),
-    vol.Optional("days"): vol.Coerce(int),
-})
+SERVICE_SEND_NOTIFICATION_SCHEMA = vol.Schema(
+    {
+        vol.Required("title"): cv.string,
+        vol.Required("message"): cv.string,
+        vol.Optional("dog_id"): cv.string,
+        vol.Optional("notification_type"): vol.In(
+            [
+                "feeding_reminder",
+                "feeding_overdue",
+                "walk_reminder",
+                "walk_overdue",
+                "health_alert",
+                "medication_reminder",
+                "veterinary_appointment",
+                "weight_check",
+                "system_info",
+                "system_warning",
+                "system_error",
+            ]
+        ),
+        vol.Optional("priority"): vol.In(["low", "normal", "high", "urgent"]),
+        vol.Optional("channels"): [
+            vol.In(
+                [
+                    "persistent",
+                    "mobile",
+                    "email",
+                    "sms",
+                    "webhook",
+                    "tts",
+                    "media_player",
+                ]
+            )
+        ],
+        vol.Optional("expires_in_hours"): vol.Coerce(int),
+    }
+)
 
-SERVICE_ANALYZE_PATTERNS_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("analysis_type"): vol.In(["feeding", "walking", "health", "comprehensive"]),
-    vol.Optional("days", default=30): vol.Coerce(int),
-})
+SERVICE_ACKNOWLEDGE_NOTIFICATION_SCHEMA = vol.Schema(
+    {
+        vol.Required("notification_id"): cv.string,
+    }
+)
 
-SERVICE_GENERATE_REPORT_SCHEMA = vol.Schema({
-    vol.Required("dog_id"): cv.string,
-    vol.Required("report_type"): vol.In(["health", "activity", "nutrition", "comprehensive"]),
-    vol.Optional("include_recommendations", default=True): cv.boolean,
-    vol.Optional("days", default=30): vol.Coerce(int),
-})
+SERVICE_CALCULATE_PORTION_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("meal_type"): cv.string,
+        vol.Optional("override_health_data"): vol.Schema(
+            {
+                vol.Optional("weight"): vol.Coerce(float),
+                vol.Optional("activity_level"): cv.string,
+                vol.Optional("health_conditions"): [cv.string],
+            }
+        ),
+    }
+)
+
+SERVICE_EXPORT_DATA_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("data_type"): vol.In(["feeding", "walks", "health", "all"]),
+        vol.Optional("format"): vol.In(["json", "csv", "gpx"]),
+        vol.Optional("days"): vol.Coerce(int),
+    }
+)
+
+SERVICE_ANALYZE_PATTERNS_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("analysis_type"): vol.In(
+            ["feeding", "walking", "health", "comprehensive"]
+        ),
+        vol.Optional("days", default=30): vol.Coerce(int),
+    }
+)
+
+SERVICE_GENERATE_REPORT_SCHEMA = vol.Schema(
+    {
+        vol.Required("dog_id"): cv.string,
+        vol.Required("report_type"): vol.In(
+            ["health", "activity", "nutrition", "comprehensive"]
+        ),
+        vol.Optional("include_recommendations", default=True): cv.boolean,
+        vol.Optional("days", default=30): vol.Coerce(int),
+    }
+)
 
 
 async def async_setup_services(hass: HomeAssistant) -> None:
     """Set up PawControl services.
-    
+
     Args:
         hass: Home Assistant instance
     """
-    
+
     async def add_feeding_service(call: ServiceCall) -> None:
         """Handle add feeding service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         dog_id = call.data["dog_id"]
         amount = call.data["amount"]
         meal_type = call.data.get("meal_type")
@@ -159,10 +206,10 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         scheduled = call.data.get("scheduled", False)
         with_medication = call.data.get("with_medication", False)
         medication_data = call.data.get("medication_data")
-        
+
         try:
             if with_medication and medication_data:
-                event = await coordinator.feeding_manager.async_add_feeding_with_medication(
+                await coordinator.feeding_manager.async_add_feeding_with_medication(
                     dog_id=dog_id,
                     amount=amount,
                     meal_type=meal_type,
@@ -171,7 +218,7 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     feeder=feeder,
                 )
             else:
-                event = await coordinator.feeding_manager.async_add_feeding(
+                await coordinator.feeding_manager.async_add_feeding(
                     dog_id=dog_id,
                     amount=amount,
                     meal_type=meal_type,
@@ -179,69 +226,67 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                     feeder=feeder,
                     scheduled=scheduled,
                 )
-            
+
             # Trigger coordinator update
             await coordinator.async_request_refresh()
-            
+
             _LOGGER.info(
-                "Added feeding for %s: %.1fg %s", 
-                dog_id, 
-                amount, 
-                meal_type or "unknown"
+                "Added feeding for %s: %.1fg %s", dog_id, amount, meal_type or "unknown"
             )
-            
+
         except Exception as e:
             _LOGGER.error("Failed to add feeding for %s: %s", dog_id, e)
             raise
-    
+
     async def start_walk_service(call: ServiceCall) -> None:
         """Handle start walk service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         dog_id = call.data["dog_id"]
         walker = call.data.get("walker")
         weather = call.data.get("weather")
         leash_used = call.data.get("leash_used", True)
-        
+
         try:
             # Convert weather string to enum if provided
             weather_enum = None
             if weather:
                 from .walk_manager import WeatherCondition
+
                 weather_enum = WeatherCondition(weather)
-            
+
             session_id = await coordinator.walk_manager.async_start_walk(
                 dog_id=dog_id,
                 walker=walker,
                 weather=weather_enum,
                 leash_used=leash_used,
             )
-            
+
             _LOGGER.info("Started walk for %s (session: %s)", dog_id, session_id)
-            
+
         except Exception as e:
             _LOGGER.error("Failed to start walk for %s: %s", dog_id, e)
             raise
-    
+
     async def end_walk_service(call: ServiceCall) -> None:
         """Handle end walk service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         dog_id = call.data["dog_id"]
         notes = call.data.get("notes")
         dog_weight_kg = call.data.get("dog_weight_kg")
-        
+
         try:
             walk_event = await coordinator.walk_manager.async_end_walk(
                 dog_id=dog_id,
                 notes=notes,
                 dog_weight_kg=dog_weight_kg,
             )
-            
+
             if walk_event:
                 # Trigger coordinator update
                 await coordinator.async_request_refresh()
-                
+
                 _LOGGER.info(
                     "Ended walk for %s: %.1f km in %d minutes",
                     dog_id,
@@ -250,21 +295,21 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 )
             else:
                 _LOGGER.warning("No active walk found for %s", dog_id)
-            
+
         except Exception as e:
             _LOGGER.error("Failed to end walk for %s: %s", dog_id, e)
             raise
-    
+
     async def add_gps_point_service(call: ServiceCall) -> None:
         """Handle add GPS point service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         dog_id = call.data["dog_id"]
         latitude = call.data["latitude"]
         longitude = call.data["longitude"]
         altitude = call.data.get("altitude")
         accuracy = call.data.get("accuracy")
-        
+
         try:
             success = await coordinator.walk_manager.async_add_gps_point(
                 dog_id=dog_id,
@@ -273,43 +318,45 @@ async def async_setup_services(hass: HomeAssistant) -> None:
                 altitude=altitude,
                 accuracy=accuracy,
             )
-            
+
             if not success:
                 _LOGGER.warning("Failed to add GPS point for %s", dog_id)
-            
+
         except Exception as e:
             _LOGGER.error("Failed to add GPS point for %s: %s", dog_id, e)
             raise
-    
+
     async def update_health_service(call: ServiceCall) -> None:
         """Handle update health service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         dog_id = call.data["dog_id"]
-        health_data = {k: v for k, v in call.data.items() if k != "dog_id" and v is not None}
-        
+        health_data = {
+            k: v for k, v in call.data.items() if k != "dog_id" and v is not None
+        }
+
         try:
             success = await coordinator.feeding_manager.async_update_health_data(
                 dog_id=dog_id,
                 health_data=health_data,
             )
-            
+
             if success:
                 # Trigger coordinator update
                 await coordinator.async_request_refresh()
-                
+
                 _LOGGER.info("Updated health data for %s: %s", dog_id, health_data)
             else:
                 _LOGGER.warning("Failed to update health data for %s", dog_id)
-            
+
         except Exception as e:
             _LOGGER.error("Failed to update health data for %s: %s", dog_id, e)
             raise
-    
+
     async def send_notification_service(call: ServiceCall) -> None:
         """Handle send notification service call."""
         coordinator = hass.data[DOMAIN]["coordinator"]
-        
+
         title = call.data["title"]
         message = call.data["message"]
         dog_id = call.data.get("dog_id")
@@ -317,38 +364,44 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         priority = call.data.get("priority", "normal")
         channels = call.data.get("channels")
         expires_in_hours = call.data.get("expires_in_hours")
-        
+
         try:
             # Convert string enums
-            from .notifications import NotificationChannel, NotificationPriority, NotificationType
-            
+            from .notifications import (
+                NotificationChannel,
+                NotificationPriority,
+                NotificationType,
+            )
+
             notification_type_enum = NotificationType(notification_type)
             priority_enum = NotificationPriority(priority)
-            
+
             channel_enums = None
             if channels:
                 channel_enums = [NotificationChannel(channel) for channel in channels]
-            
+
             expires_in = None
             if expires_in_hours:
                 expires_in = timedelta(hours=expires_in_hours)
-            
-            notification_id = await coordinator.notification_manager.async_send_notification(
-                notification_type=notification_type_enum,
-                title=title,
-                message=message,
-                dog_id=dog_id,
-                priority=priority_enum,
-                expires_in=expires_in,
-                force_channels=channel_enums,
+
+            notification_id = (
+                await coordinator.notification_manager.async_send_notification(
+                    notification_type=notification_type_enum,
+                    title=title,
+                    message=message,
+                    dog_id=dog_id,
+                    priority=priority_enum,
+                    expires_in=expires_in,
+                    force_channels=channel_enums,
+                )
             )
-            
+
             _LOGGER.info("Sent notification %s: %s", notification_id, title)
-            
+
         except Exception as e:
             _LOGGER.error("Failed to send notification: %s", e)
             raise
-    
+
     # Register all services
     hass.services.async_register(
         DOMAIN,
@@ -356,48 +409,48 @@ async def async_setup_services(hass: HomeAssistant) -> None:
         add_feeding_service,
         schema=SERVICE_ADD_FEEDING_SCHEMA,
     )
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_START_WALK,
         start_walk_service,
         schema=SERVICE_START_WALK_SCHEMA,
     )
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_END_WALK,
         end_walk_service,
         schema=SERVICE_END_WALK_SCHEMA,
     )
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_ADD_GPS_POINT,
         add_gps_point_service,
         schema=SERVICE_ADD_GPS_POINT_SCHEMA,
     )
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_UPDATE_HEALTH,
         update_health_service,
         schema=SERVICE_UPDATE_HEALTH_SCHEMA,
     )
-    
+
     hass.services.async_register(
         DOMAIN,
         SERVICE_SEND_NOTIFICATION,
         send_notification_service,
         schema=SERVICE_SEND_NOTIFICATION_SCHEMA,
     )
-    
+
     _LOGGER.info("Registered PawControl services")
 
 
 async def async_unload_services(hass: HomeAssistant) -> None:
     """Unload PawControl services.
-    
+
     Args:
         hass: Home Assistant instance
     """
@@ -414,8 +467,8 @@ async def async_unload_services(hass: HomeAssistant) -> None:
         SERVICE_ANALYZE_PATTERNS,
         SERVICE_GENERATE_REPORT,
     ]
-    
+
     for service in services_to_remove:
         hass.services.async_remove(DOMAIN, service)
-    
+
     _LOGGER.info("Unloaded PawControl services")

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -555,20 +555,17 @@ def is_dog_config_valid(config: Any) -> bool:
             return False
 
     # Validate optional fields with frozenset lookups for performance
-    if "dog_age" in config:
-        if (
-            not isinstance(config["dog_age"], int)
-            or config["dog_age"] < 0
-            or config["dog_age"] > 30
-        ):
-            return False
+    if "dog_age" in config and (
+        not isinstance(config["dog_age"], int)
+        or config["dog_age"] < 0
+        or config["dog_age"] > 30
+    ):
+        return False
 
-    if "dog_weight" in config:
-        if (
-            not isinstance(config["dog_weight"], int | float)
-            or config["dog_weight"] <= 0
-        ):
-            return False
+    if "dog_weight" in config and (
+        not isinstance(config["dog_weight"], int | float) or config["dog_weight"] <= 0
+    ):
+        return False
 
     if "dog_size" in config and config["dog_size"] not in VALID_DOG_SIZES:
         return False
@@ -600,12 +597,10 @@ def is_gps_location_valid(location: Any) -> bool:
             return False
 
     # Validate optional fields
-    if "accuracy" in location:
-        if (
-            not isinstance(location["accuracy"], int | float)
-            or location["accuracy"] < 0
-        ):
-            return False
+    if "accuracy" in location and (
+        not isinstance(location["accuracy"], int | float) or location["accuracy"] < 0
+    ):
+        return False
 
     if "battery_level" in location:
         battery = location["battery_level"]

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -546,11 +546,11 @@ def is_dog_config_valid(config: Any) -> bool:
 
     # Check required fields
     required_fields = ["dog_id", "dog_name"]
-    for field in required_fields:
+    for required_field in required_fields:
         if (
-            field not in config
-            or not isinstance(config[field], str)
-            or not config[field].strip()
+            required_field not in config
+            or not isinstance(config[required_field], str)
+            or not config[required_field].strip()
         ):
             return False
 
@@ -710,11 +710,11 @@ def is_notification_data_valid(data: Any) -> bool:
         return False
 
     required_fields = ["title", "message"]
-    for field in required_fields:
+    for required_field in required_fields:
         if (
-            field not in data
-            or not isinstance(data[field], str)
-            or not data[field].strip()
+            required_field not in data
+            or not isinstance(data[required_field], str)
+            or not data[required_field].strip()
         ):
             return False
 

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -24,15 +24,41 @@ if TYPE_CHECKING:
 
 # OPTIMIZE: Use literal constants instead of runtime imports to avoid circular dependencies
 VALID_MEAL_TYPES: frozenset[str] = frozenset(["breakfast", "lunch", "dinner", "snack"])
-VALID_FOOD_TYPES: frozenset[str] = frozenset(["dry_food", "wet_food", "barf", "home_cooked", "mixed"])
-VALID_DOG_SIZES: frozenset[str] = frozenset(["toy", "small", "medium", "large", "giant"])
-VALID_HEALTH_STATUS: frozenset[str] = frozenset(["excellent", "very_good", "good", "normal", "unwell", "sick"])
-VALID_MOOD_OPTIONS: frozenset[str] = frozenset(["happy", "neutral", "sad", "angry", "anxious", "tired"])
-VALID_ACTIVITY_LEVELS: frozenset[str] = frozenset(["very_low", "low", "normal", "high", "very_high"])
-VALID_GEOFENCE_TYPES: frozenset[str] = frozenset(["safe_zone", "restricted_area", "point_of_interest"])
-VALID_GPS_SOURCES: frozenset[str] = frozenset(["manual", "device_tracker", "person_entity", "smartphone", "tractive", "webhook", "mqtt"])
-VALID_NOTIFICATION_PRIORITIES: frozenset[str] = frozenset(["low", "normal", "high", "urgent"])
-VALID_NOTIFICATION_CHANNELS: frozenset[str] = frozenset(["mobile", "persistent", "email", "slack"])
+VALID_FOOD_TYPES: frozenset[str] = frozenset(
+    ["dry_food", "wet_food", "barf", "home_cooked", "mixed"]
+)
+VALID_DOG_SIZES: frozenset[str] = frozenset(
+    ["toy", "small", "medium", "large", "giant"]
+)
+VALID_HEALTH_STATUS: frozenset[str] = frozenset(
+    ["excellent", "very_good", "good", "normal", "unwell", "sick"]
+)
+VALID_MOOD_OPTIONS: frozenset[str] = frozenset(
+    ["happy", "neutral", "sad", "angry", "anxious", "tired"]
+)
+VALID_ACTIVITY_LEVELS: frozenset[str] = frozenset(
+    ["very_low", "low", "normal", "high", "very_high"]
+)
+VALID_GEOFENCE_TYPES: frozenset[str] = frozenset(
+    ["safe_zone", "restricted_area", "point_of_interest"]
+)
+VALID_GPS_SOURCES: frozenset[str] = frozenset(
+    [
+        "manual",
+        "device_tracker",
+        "person_entity",
+        "smartphone",
+        "tractive",
+        "webhook",
+        "mqtt",
+    ]
+)
+VALID_NOTIFICATION_PRIORITIES: frozenset[str] = frozenset(
+    ["low", "normal", "high", "urgent"]
+)
+VALID_NOTIFICATION_CHANNELS: frozenset[str] = frozenset(
+    ["mobile", "persistent", "email", "slack"]
+)
 
 # Type aliases for better readability and performance
 DogId = str
@@ -45,15 +71,15 @@ ConfigData = dict[str, Any]
 
 class DogConfigData(TypedDict):
     """Type definition for dog configuration data.
-    
+
     OPTIMIZE: Uses Required[] for mandatory fields and optional for others.
     Added discovery_info field support for device discovery integration.
     """
-    
+
     # Required fields
     dog_id: Required[str]
     dog_name: Required[str]
-    
+
     # Optional fields with defaults
     dog_breed: str | None
     dog_age: int | None
@@ -183,7 +209,7 @@ class FeedingData:
     logged_by: str = ""
     calories: float | None = None
     automatic: bool = False  # OPTIMIZE: Track automatic vs manual feeding
-    
+
     def __post_init__(self) -> None:
         """Validate data after initialization."""
         if self.meal_type not in VALID_MEAL_TYPES:
@@ -213,7 +239,7 @@ class WalkData:
     ended_by: str = ""
     weather: str = ""  # OPTIMIZE: Added weather tracking
     temperature: float | None = None  # OPTIMIZE: Added temperature tracking
-    
+
     def __post_init__(self) -> None:
         """Validate data after initialization."""
         if self.rating < 0 or self.rating > 10:
@@ -242,7 +268,7 @@ class HealthData:
     logged_by: str = ""
     heart_rate: int | None = None  # OPTIMIZE: Added heart rate tracking
     respiratory_rate: int | None = None  # OPTIMIZE: Added respiratory rate
-    
+
     def __post_init__(self) -> None:
         """Validate data after initialization."""
         if self.mood and self.mood not in VALID_MOOD_OPTIONS:
@@ -253,9 +279,13 @@ class HealthData:
             raise ValueError(f"Invalid health status: {self.health_status}")
         if self.weight is not None and (self.weight <= 0 or self.weight > 200):
             raise ValueError("Weight must be between 0 and 200 kg")
-        if self.temperature is not None and (self.temperature < 35 or self.temperature > 45):
+        if self.temperature is not None and (
+            self.temperature < 35 or self.temperature > 45
+        ):
             raise ValueError("Temperature must be between 35 and 45 degrees Celsius")
-        if self.heart_rate is not None and (self.heart_rate < 50 or self.heart_rate > 250):
+        if self.heart_rate is not None and (
+            self.heart_rate < 50 or self.heart_rate > 250
+        ):
             raise ValueError("Heart rate must be between 50 and 250 bpm")
 
 
@@ -271,7 +301,7 @@ class GPSLocation:
     source: str = ""
     battery_level: int | None = None  # OPTIMIZE: Added battery level for GPS devices
     signal_strength: int | None = None  # OPTIMIZE: Added signal strength
-    
+
     def __post_init__(self) -> None:
         """Validate GPS coordinates."""
         if not (-90 <= self.latitude <= 90):
@@ -298,7 +328,7 @@ class GeofenceZone:
     notifications: bool = True
     auto_actions: list[str] = field(default_factory=list)
     priority: int = 1  # OPTIMIZE: Added priority for zone overlaps
-    
+
     def __post_init__(self) -> None:
         """Validate geofence parameters."""
         if not (-90 <= self.latitude <= 90):
@@ -326,7 +356,7 @@ class NotificationData:
     actions: list[dict[str, str]] = field(default_factory=list)
     dog_id: str = ""  # OPTIMIZE: Added dog association
     module: str = ""  # OPTIMIZE: Added source module tracking
-    
+
     def __post_init__(self) -> None:
         """Validate notification data."""
         if self.priority not in VALID_NOTIFICATION_PRIORITIES:
@@ -342,7 +372,7 @@ class NotificationData:
 @dataclass
 class MedicationData:
     """Data structure for medication information.
-    
+
     OPTIMIZE: New comprehensive medication tracking structure.
     """
 
@@ -355,7 +385,7 @@ class MedicationData:
     notes: str = ""
     side_effects: list[str] = field(default_factory=list)
     effectiveness_rating: int | None = None  # 1-10 scale
-    
+
     def __post_init__(self) -> None:
         """Validate medication data."""
         if not self.name.strip():
@@ -366,7 +396,9 @@ class MedicationData:
             raise ValueError("Frequency cannot be empty")
         if self.end_date and self.end_date < self.start_date:
             raise ValueError("End date cannot be before start date")
-        if self.effectiveness_rating is not None and not (1 <= self.effectiveness_rating <= 10):
+        if self.effectiveness_rating is not None and not (
+            1 <= self.effectiveness_rating <= 10
+        ):
             raise ValueError("Effectiveness rating must be between 1 and 10")
 
 
@@ -385,7 +417,7 @@ class DailyStats:
     last_walk_time: datetime | None = None
     medication_doses: int = 0  # OPTIMIZE: Added medication tracking
     grooming_sessions: int = 0  # OPTIMIZE: Added grooming tracking
-    
+
     def __post_init__(self) -> None:
         """Validate statistics data."""
         if self.feedings_count < 0:
@@ -415,8 +447,10 @@ class DogProfile:
     current_walk: WalkData | None = None
     last_location: GPSLocation | None = None
     is_visitor_mode: bool = False
-    health_alerts: list[str] = field(default_factory=list)  # OPTIMIZE: Added health alerts
-    
+    health_alerts: list[str] = field(
+        default_factory=list
+    )  # OPTIMIZE: Added health alerts
+
     def __post_init__(self) -> None:
         """Validate dog profile."""
         if not self.dog_id.strip():
@@ -442,7 +476,7 @@ class PawControlRuntimeData:
     entity_factory: EntityFactory
     entity_profile: str
     dogs: list[DogConfigData]
-    
+
     # OPTIMIZE: Added performance and error tracking
     performance_stats: dict[str, Any] = field(default_factory=dict)
     error_history: list[dict[str, Any]] = field(default_factory=list)
@@ -498,174 +532,203 @@ class RepairIssueData(TypedDict):
 # OPTIMIZE: Enhanced type guards for runtime type checking with better performance
 def is_dog_config_valid(config: Any) -> bool:
     """Type guard to validate dog configuration.
-    
+
     OPTIMIZE: Uses frozenset membership for O(1) validation performance.
-    
+
     Args:
         config: Configuration to validate
-        
+
     Returns:
         True if configuration is valid
     """
     if not isinstance(config, dict):
         return False
-        
+
     # Check required fields
     required_fields = ["dog_id", "dog_name"]
     for field in required_fields:
-        if field not in config or not isinstance(config[field], str) or not config[field].strip():
+        if (
+            field not in config
+            or not isinstance(config[field], str)
+            or not config[field].strip()
+        ):
             return False
-    
+
     # Validate optional fields with frozenset lookups for performance
     if "dog_age" in config:
-        if not isinstance(config["dog_age"], int) or config["dog_age"] < 0 or config["dog_age"] > 30:
+        if (
+            not isinstance(config["dog_age"], int)
+            or config["dog_age"] < 0
+            or config["dog_age"] > 30
+        ):
             return False
-            
+
     if "dog_weight" in config:
-        if not isinstance(config["dog_weight"], (int, float)) or config["dog_weight"] <= 0:
+        if (
+            not isinstance(config["dog_weight"], int | float)
+            or config["dog_weight"] <= 0
+        ):
             return False
-            
-    if "dog_size" in config:
-        if config["dog_size"] not in VALID_DOG_SIZES:
-            return False
-    
-    # Validate modules if present
-    if "modules" in config and not isinstance(config["modules"], dict):
+
+    if "dog_size" in config and config["dog_size"] not in VALID_DOG_SIZES:
         return False
-    
-    return True
+
+    # Validate modules if present
+    return not ("modules" in config and not isinstance(config["modules"], dict))
 
 
 def is_gps_location_valid(location: Any) -> bool:
     """Type guard to validate GPS location data.
-    
+
     Args:
         location: Location data to validate
-        
+
     Returns:
         True if location is valid
     """
     if not isinstance(location, dict):
         return False
-        
+
     # Check required coordinates
     for coord, limits in [("latitude", (-90, 90)), ("longitude", (-180, 180))]:
         if coord not in location:
             return False
         value = location[coord]
-        if not isinstance(value, (int, float)):
+        if not isinstance(value, int | float):
             return False
         if not (limits[0] <= value <= limits[1]):
             return False
-    
+
     # Validate optional fields
     if "accuracy" in location:
-        if not isinstance(location["accuracy"], (int, float)) or location["accuracy"] < 0:
+        if (
+            not isinstance(location["accuracy"], int | float)
+            or location["accuracy"] < 0
+        ):
             return False
-            
+
     if "battery_level" in location:
         battery = location["battery_level"]
-        if battery is not None and (not isinstance(battery, int) or not (0 <= battery <= 100)):
+        if battery is not None and (
+            not isinstance(battery, int) or not (0 <= battery <= 100)
+        ):
             return False
-            
+
     return True
 
 
 def is_feeding_data_valid(data: Any) -> bool:
     """Type guard to validate feeding data with frozenset performance optimization.
-    
+
     Args:
         data: Feeding data to validate
-        
+
     Returns:
         True if data is valid
     """
     if not isinstance(data, dict):
         return False
-        
+
     # Check required fields with frozenset lookup
     if "meal_type" not in data or data["meal_type"] not in VALID_MEAL_TYPES:
         return False
-        
+
     if "portion_size" not in data:
         return False
     portion = data["portion_size"]
-    if not isinstance(portion, (int, float)) or portion < 0:
+    if not isinstance(portion, int | float) or portion < 0:
         return False
-        
+
     # Validate optional fields with frozenset lookup
     if "food_type" in data and data["food_type"] not in VALID_FOOD_TYPES:
         return False
-        
+
     if "calories" in data:
         calories = data["calories"]
-        if calories is not None and (not isinstance(calories, (int, float)) or calories < 0):
+        if calories is not None and (
+            not isinstance(calories, int | float) or calories < 0
+        ):
             return False
-        
+
     return True
 
 
 def is_health_data_valid(data: Any) -> bool:
     """Type guard to validate health data with frozenset performance optimization.
-    
+
     Args:
         data: Health data to validate
-        
+
     Returns:
         True if data is valid
     """
     if not isinstance(data, dict):
         return False
-        
+
     # Validate optional fields with frozenset lookups
     if "mood" in data and data["mood"] and data["mood"] not in VALID_MOOD_OPTIONS:
         return False
-        
-    if "activity_level" in data and data["activity_level"] and data["activity_level"] not in VALID_ACTIVITY_LEVELS:
+
+    if (
+        "activity_level" in data
+        and data["activity_level"]
+        and data["activity_level"] not in VALID_ACTIVITY_LEVELS
+    ):
         return False
-        
-    if "health_status" in data and data["health_status"] and data["health_status"] not in VALID_HEALTH_STATUS:
+
+    if (
+        "health_status" in data
+        and data["health_status"]
+        and data["health_status"] not in VALID_HEALTH_STATUS
+    ):
         return False
-        
+
     if "weight" in data:
         weight = data["weight"]
-        if weight is not None and (not isinstance(weight, (int, float)) or weight <= 0 or weight > 200):
+        if weight is not None and (
+            not isinstance(weight, int | float) or weight <= 0 or weight > 200
+        ):
             return False
-    
+
     if "temperature" in data:
         temp = data["temperature"]
-        if temp is not None and (not isinstance(temp, (int, float)) or temp < 35 or temp > 45):
+        if temp is not None and (
+            not isinstance(temp, int | float) or temp < 35 or temp > 45
+        ):
             return False
-            
+
     return True
 
 
 def is_notification_data_valid(data: Any) -> bool:
     """Type guard to validate notification data.
-    
+
     OPTIMIZE: New validation function with frozenset performance.
-    
+
     Args:
         data: Notification data to validate
-        
+
     Returns:
         True if data is valid
     """
     if not isinstance(data, dict):
         return False
-        
+
     required_fields = ["title", "message"]
     for field in required_fields:
-        if field not in data or not isinstance(data[field], str) or not data[field].strip():
+        if (
+            field not in data
+            or not isinstance(data[field], str)
+            or not data[field].strip()
+        ):
             return False
-    
+
     if "priority" in data and data["priority"] not in VALID_NOTIFICATION_PRIORITIES:
         return False
-        
-    if "channel" in data and data["channel"] not in VALID_NOTIFICATION_CHANNELS:
-        return False
-        
-    return True
+
+    return not (
+        "channel" in data and data["channel"] not in VALID_NOTIFICATION_CHANNELS
+    )
 
 
 # Performance optimization types
@@ -700,7 +763,7 @@ class PawControlError:
     timestamp: datetime = field(default_factory=datetime.now)
     context: dict[str, Any] = field(default_factory=dict)
     severity: str = "error"  # OPTIMIZE: Added severity levels
-    
+
     def __post_init__(self) -> None:
         """Validate error data."""
         valid_severities = {"debug", "info", "warning", "error", "critical"}
@@ -748,7 +811,7 @@ class NotificationError(PawControlError):
 @dataclass
 class HealthMetrics:
     """Health metrics for monitoring integration performance."""
-    
+
     uptime_seconds: int
     total_entities: int
     active_dogs: int
@@ -756,7 +819,7 @@ class HealthMetrics:
     error_rate: float
     memory_usage_mb: float
     api_response_time_ms: float
-    
+
     def __post_init__(self) -> None:
         """Validate health metrics."""
         if self.uptime_seconds < 0:
@@ -770,12 +833,12 @@ class HealthMetrics:
 # OPTIMIZE: Add utility functions for common operations
 def create_entity_id(dog_id: str, entity_type: str, module: str) -> str:
     """Create standardized entity ID.
-    
+
     Args:
         dog_id: Dog identifier
         entity_type: Type of entity
         module: Module name
-        
+
     Returns:
         Formatted entity ID
     """
@@ -784,11 +847,11 @@ def create_entity_id(dog_id: str, entity_type: str, module: str) -> str:
 
 def validate_dog_weight_for_size(weight: float, size: str) -> bool:
     """Validate if weight is appropriate for dog size.
-    
+
     Args:
         weight: Dog weight in kg
         size: Dog size category
-        
+
     Returns:
         True if weight is appropriate for size
     """
@@ -799,31 +862,32 @@ def validate_dog_weight_for_size(weight: float, size: str) -> bool:
         "large": (22.0, 50.0),
         "giant": (35.0, 90.0),
     }
-    
+
     if size not in size_ranges:
         return True  # Unknown size, skip validation
-        
+
     min_weight, max_weight = size_ranges[size]
     return min_weight <= weight <= max_weight
 
 
 def calculate_daily_calories(weight: float, activity_level: str, age: int) -> int:
     """Calculate recommended daily calories for a dog.
-    
+
     OPTIMIZE: New utility function for feeding management.
-    
+
     Args:
         weight: Dog weight in kg
         activity_level: Activity level string
         age: Dog age in years
-        
+
     Returns:
         Recommended daily calories
     """
     # Base calories = 70 * (weight in kg)^0.75
     import math
+
     base_calories = 70 * math.pow(weight, 0.75)
-    
+
     # Activity multipliers
     activity_multipliers = {
         "very_low": 1.2,
@@ -832,13 +896,13 @@ def calculate_daily_calories(weight: float, activity_level: str, age: int) -> in
         "high": 1.8,
         "very_high": 2.0,
     }
-    
+
     multiplier = activity_multipliers.get(activity_level, 1.6)
-    
+
     # Age adjustment (puppies and seniors need different amounts)
     if age < 1:
         multiplier *= 2.0  # Puppies need more calories
     elif age > 7:
         multiplier *= 0.9  # Seniors need fewer calories
-    
+
     return int(base_calories * multiplier)

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -29,87 +29,77 @@ V = TypeVar("V")
 
 def deep_merge_dicts(base: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
     """Recursively merge two dictionaries.
-    
+
     Args:
         base: Base dictionary to merge into
         updates: Updates to apply
-        
+
     Returns:
         New dictionary with merged values
     """
     result = base.copy()
-    
+
     for key, value in updates.items():
-        if (
-            key in result
-            and isinstance(result[key], dict)
-            and isinstance(value, dict)
-        ):
+        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
             result[key] = deep_merge_dicts(result[key], value)
         else:
             result[key] = value
-    
+
     return result
 
 
 def safe_get_nested(
-    data: dict[str, Any], 
-    path: str, 
-    default: Any = None, 
-    separator: str = "."
+    data: dict[str, Any], path: str, default: Any = None, separator: str = "."
 ) -> Any:
     """Safely get nested dictionary value using dot notation.
-    
+
     Args:
         data: Dictionary to search
         path: Dot-separated path (e.g., "dog.health.weight")
         default: Default value if path not found
         separator: Path separator character
-        
+
     Returns:
         Value at path or default
     """
     try:
         keys = path.split(separator)
         current = data
-        
+
         for key in keys:
             if isinstance(current, dict) and key in current:
                 current = current[key]
             else:
                 return default
-                
+
         return current
     except (AttributeError, KeyError, TypeError):
         return default
 
 
 def safe_set_nested(
-    data: dict[str, Any], 
-    path: str, 
-    value: Any, 
-    separator: str = "."
+    data: dict[str, Any], path: str, value: Any, separator: str = "."
 ) -> dict[str, Any]:
     """Safely set nested dictionary value using dot notation.
-    
+
     Args:
         data: Dictionary to update
         path: Dot-separated path
         value: Value to set
         separator: Path separator character
-        
+
     Returns:
         Updated dictionary
     """
     keys = path.split(separator)
     current = data
-    
+
     # Navigate to parent of target key
     for key in keys[:-1]:
         if key not in current or not isinstance(current[key], dict):
             current[key] = {}
         current = current[key]
-    
+
     # Set the final value
     current[keys[-1]] = value
     return data
@@ -117,16 +107,16 @@ def safe_set_nested(
 
 def validate_time_string(time_str: str | None) -> time | None:
     """Validate and parse time string.
-    
+
     Args:
         time_str: Time string in HH:MM or HH:MM:SS format
-        
+
     Returns:
         Parsed time object or None if invalid
     """
     if not time_str:
         return None
-        
+
     try:
         # Support both HH:MM and HH:MM:SS formats
         if re.match(r"^\d{1,2}:\d{2}$", time_str):
@@ -137,22 +127,22 @@ def validate_time_string(time_str: str | None) -> time | None:
             return time(hour, minute, second)
     except (ValueError, AttributeError):
         pass
-        
+
     return None
 
 
 def validate_email(email: str | None) -> bool:
     """Validate email address format.
-    
+
     Args:
         email: Email address to validate
-        
+
     Returns:
         True if valid email format
     """
     if not email:
         return False
-        
+
     # Simple but effective email regex
     pattern = r"^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$"
     return bool(re.match(pattern, email))
@@ -160,33 +150,33 @@ def validate_email(email: str | None) -> bool:
 
 def sanitize_dog_id(dog_id: str) -> str:
     """Sanitize dog ID for use as entity identifier.
-    
+
     Args:
         dog_id: Raw dog ID
-        
+
     Returns:
         Sanitized dog ID suitable for entity IDs
     """
     # Convert to lowercase and replace invalid characters
     sanitized = re.sub(r"[^a-z0-9_]", "_", dog_id.lower())
-    
+
     # Ensure it starts with a letter
     if sanitized and not sanitized[0].isalpha():
         sanitized = f"dog_{sanitized}"
-    
+
     # Remove consecutive underscores
     sanitized = re.sub(r"_+", "_", sanitized)
-    
+
     # Remove leading/trailing underscores
     return sanitized.strip("_")
 
 
 def format_duration(seconds: int | float) -> str:
     """Format duration in seconds to human-readable string.
-    
+
     Args:
         seconds: Duration in seconds
-        
+
     Returns:
         Formatted duration string
     """
@@ -208,11 +198,11 @@ def format_duration(seconds: int | float) -> str:
 
 def format_distance(meters: float, unit: str = "metric") -> str:
     """Format distance with appropriate units.
-    
+
     Args:
         meters: Distance in meters
         unit: Unit system ("metric" or "imperial")
-        
+
     Returns:
         Formatted distance string
     """
@@ -233,16 +223,16 @@ def format_distance(meters: float, unit: str = "metric") -> str:
 
 def calculate_age_from_months(age_months: int) -> dict[str, int]:
     """Calculate years and months from total months.
-    
+
     Args:
         age_months: Total age in months
-        
+
     Returns:
         Dictionary with years and months
     """
     years = age_months // 12
     months = age_months % 12
-    
+
     return {
         "years": years,
         "months": months,
@@ -252,22 +242,22 @@ def calculate_age_from_months(age_months: int) -> dict[str, int]:
 
 def parse_weight(weight_input: str | float | int) -> float | None:
     """Parse weight input in various formats.
-    
+
     Args:
         weight_input: Weight as string, float, or int
-        
+
     Returns:
         Weight in kilograms or None if invalid
     """
-    if isinstance(weight_input, (int, float)):
+    if isinstance(weight_input, int | float):
         return float(weight_input) if weight_input > 0 else None
-    
+
     if not isinstance(weight_input, str):
         return None
-    
+
     # Remove whitespace and convert to lowercase
     weight_str = weight_input.strip().lower()
-    
+
     # Handle common weight formats
     if "kg" in weight_str:
         try:
@@ -287,34 +277,34 @@ def parse_weight(weight_input: str | float | int) -> float | None:
             return float(weight_str)
         except ValueError:
             pass
-    
+
     return None
 
 
 def generate_entity_id(domain: str, dog_id: str, entity_type: str) -> str:
     """Generate entity ID following Home Assistant conventions.
-    
+
     Args:
         domain: Integration domain
         dog_id: Dog identifier
         entity_type: Type of entity
-        
+
     Returns:
         Generated entity ID
     """
     sanitized_dog_id = sanitize_dog_id(dog_id)
     sanitized_type = re.sub(r"[^a-z0-9_]", "_", entity_type.lower())
-    
+
     return f"{domain}.{sanitized_dog_id}_{sanitized_type}"
 
 
 def calculate_bmi_equivalent(weight_kg: float, breed_size: str) -> float | None:
     """Calculate BMI equivalent for dogs based on breed size.
-    
+
     Args:
         weight_kg: Weight in kilograms
         breed_size: Size category ("toy", "small", "medium", "large", "giant")
-        
+
     Returns:
         BMI equivalent or None if invalid
     """
@@ -326,12 +316,12 @@ def calculate_bmi_equivalent(weight_kg: float, breed_size: str) -> float | None:
         "large": (22.0, 50.0),
         "giant": (35.0, 90.0),
     }
-    
+
     if breed_size not in size_ranges:
         return None
-    
+
     min_weight, max_weight = size_ranges[breed_size]
-    
+
     # Calculate relative position within breed size range
     if weight_kg <= min_weight:
         return 15.0  # Underweight
@@ -344,17 +334,15 @@ def calculate_bmi_equivalent(weight_kg: float, breed_size: str) -> float | None:
 
 
 def validate_portion_size(
-    portion: float, 
-    daily_amount: float, 
-    meals_per_day: int = 2
+    portion: float, daily_amount: float, meals_per_day: int = 2
 ) -> dict[str, Any]:
     """Validate portion size against daily requirements.
-    
+
     Args:
         portion: Portion size in grams
         daily_amount: Total daily food amount
         meals_per_day: Number of meals per day
-        
+
     Returns:
         Validation result with warnings and recommendations
     """
@@ -364,57 +352,60 @@ def validate_portion_size(
         "recommendations": [],
         "percentage_of_daily": 0.0,
     }
-    
+
     if daily_amount > 0:
         percentage = (portion / daily_amount) * 100
         result["percentage_of_daily"] = percentage
-        
+
         expected_percentage = 100 / meals_per_day
-        
+
         # Check for extremely large portions
         if percentage > 70:
             result["valid"] = False
             result["warnings"].append("Portion exceeds 70% of daily requirement")
             result["recommendations"].append("Consider reducing portion size")
         elif percentage > expected_percentage * 1.5:
-            result["warnings"].append("Portion is larger than typical for meal frequency")
+            result["warnings"].append(
+                "Portion is larger than typical for meal frequency"
+            )
             result["recommendations"].append("Verify portion calculation")
-        
+
         # Check for extremely small portions
         elif percentage < 5:
-            result["warnings"].append("Portion is very small compared to daily requirement")
-            result["recommendations"].append("Consider increasing portion or meal frequency")
-    
+            result["warnings"].append(
+                "Portion is very small compared to daily requirement"
+            )
+            result["recommendations"].append(
+                "Consider increasing portion or meal frequency"
+            )
+
     return result
 
 
-def chunk_list(items: Sequence[T], chunk_size: int) -> list[list[T]]:
+def chunk_list[T](items: Sequence[T], chunk_size: int) -> list[list[T]]:
     """Split a list into chunks of specified size.
-    
+
     Args:
         items: List to chunk
         chunk_size: Maximum size of each chunk
-        
+
     Returns:
         List of chunks
     """
     if chunk_size <= 0:
         raise ValueError("Chunk size must be positive")
-    
-    return [
-        list(items[i:i + chunk_size]) 
-        for i in range(0, len(items), chunk_size)
-    ]
+
+    return [list(items[i : i + chunk_size]) for i in range(0, len(items), chunk_size)]
 
 
 def safe_divide(numerator: float, denominator: float, default: float = 0.0) -> float:
     """Safely divide two numbers with default for division by zero.
-    
+
     Args:
         numerator: Number to divide
         denominator: Number to divide by
         default: Default value if denominator is zero
-        
+
     Returns:
         Division result or default
     """
@@ -426,12 +417,12 @@ def safe_divide(numerator: float, denominator: float, default: float = 0.0) -> f
 
 def clamp(value: float, min_value: float, max_value: float) -> float:
     """Clamp value between minimum and maximum.
-    
+
     Args:
         value: Value to clamp
         min_value: Minimum allowed value
         max_value: Maximum allowed value
-        
+
     Returns:
         Clamped value
     """
@@ -440,84 +431,78 @@ def clamp(value: float, min_value: float, max_value: float) -> float:
 
 def is_dict_subset(subset: Mapping[K, V], superset: Mapping[K, V]) -> bool:
     """Check if one dictionary is a subset of another.
-    
+
     Args:
         subset: Dictionary to check if it's a subset
         superset: Dictionary to check against
-        
+
     Returns:
         True if subset is contained in superset
     """
     try:
         return all(
-            key in superset and superset[key] == value
-            for key, value in subset.items()
+            key in superset and superset[key] == value for key, value in subset.items()
         )
     except (AttributeError, TypeError):
         return False
 
 
 def flatten_dict(
-    data: dict[str, Any], 
-    separator: str = ".", 
-    prefix: str = ""
+    data: dict[str, Any], separator: str = ".", prefix: str = ""
 ) -> dict[str, Any]:
     """Flatten nested dictionary using dot notation.
-    
+
     Args:
         data: Dictionary to flatten
         separator: Separator for keys
         prefix: Prefix for keys
-        
+
     Returns:
         Flattened dictionary
     """
     flattened = {}
-    
+
     for key, value in data.items():
         new_key = f"{prefix}{separator}{key}" if prefix else key
-        
+
         if isinstance(value, dict):
             flattened.update(flatten_dict(value, separator, new_key))
         else:
             flattened[new_key] = value
-    
+
     return flattened
 
 
-def unflatten_dict(
-    data: dict[str, Any], 
-    separator: str = "."
-) -> dict[str, Any]:
+def unflatten_dict(data: dict[str, Any], separator: str = ".") -> dict[str, Any]:
     """Unflatten dictionary from dot notation.
-    
+
     Args:
         data: Flattened dictionary
         separator: Key separator
-        
+
     Returns:
         Nested dictionary
     """
     result = {}
-    
+
     for key, value in data.items():
         safe_set_nested(result, key, value, separator)
-    
+
     return result
 
 
 def extract_numbers(text: str) -> list[float]:
     """Extract all numbers from text string.
-    
+
     Args:
         text: Text to extract numbers from
-        
+
     Returns:
         List of extracted numbers
     """
     pattern = r"-?\d+(?:\.\d+)?"
     matches = re.findall(pattern, text)
-    
+
     try:
         return [float(match) for match in matches]
     except ValueError:
@@ -526,10 +511,10 @@ def extract_numbers(text: str) -> list[float]:
 
 def generate_unique_id(*parts: str) -> str:
     """Generate unique ID from multiple parts.
-    
+
     Args:
         *parts: Parts to combine into unique ID
-        
+
     Returns:
         Generated unique ID
     """
@@ -541,7 +526,7 @@ def generate_unique_id(*parts: str) -> str:
             sanitized = re.sub(r"_+", "_", sanitized).strip("_")
             if sanitized:
                 sanitized_parts.append(sanitized.lower())
-    
+
     return "_".join(sanitized_parts) if sanitized_parts else "unknown"
 
 
@@ -549,24 +534,25 @@ def retry_on_exception(
     max_retries: int = 3,
     delay: float = 1.0,
     backoff_factor: float = 2.0,
-    exceptions: tuple[type[Exception], ...] = (Exception,)
+    exceptions: tuple[type[Exception], ...] = (Exception,),
 ):
     """Decorator for retrying functions on exception.
-    
+
     Args:
         max_retries: Maximum number of retries
         delay: Initial delay between retries
         backoff_factor: Factor to multiply delay by each retry
         exceptions: Exception types to retry on
-        
+
     Returns:
         Decorator function
     """
+
     def decorator(func):
         async def async_wrapper(*args, **kwargs):
             last_exception = None
             current_delay = delay
-            
+
             for attempt in range(max_retries + 1):
                 try:
                     return await func(*args, **kwargs)
@@ -588,13 +574,13 @@ def retry_on_exception(
                             max_retries + 1,
                             func.__name__,
                         )
-            
+
             raise last_exception
-        
+
         def sync_wrapper(*args, **kwargs):
             last_exception = None
             current_delay = delay
-            
+
             for attempt in range(max_retries + 1):
                 try:
                     return func(*args, **kwargs)
@@ -609,6 +595,7 @@ def retry_on_exception(
                             current_delay,
                         )
                         import time
+
                         time.sleep(current_delay)
                         current_delay *= backoff_factor
                     else:
@@ -617,30 +604,30 @@ def retry_on_exception(
                             max_retries + 1,
                             func.__name__,
                         )
-            
+
             raise last_exception
-        
+
         return async_wrapper if asyncio.iscoroutinefunction(func) else sync_wrapper
-    
+
     return decorator
 
 
 def calculate_time_until(target_time: time) -> timedelta:
     """Calculate time until next occurrence of target time.
-    
+
     Args:
         target_time: Target time of day
-        
+
     Returns:
         Time delta until next occurrence
     """
     now = dt_util.now()
     today = now.date()
-    
+
     # Try today first
     target_datetime = datetime.combine(today, target_time)
     target_datetime = dt_util.as_local(target_datetime)
-    
+
     if target_datetime > now:
         return target_datetime - now
     else:
@@ -653,23 +640,23 @@ def calculate_time_until(target_time: time) -> timedelta:
 
 def format_relative_time(dt: datetime) -> str:
     """Format datetime as relative time string.
-    
+
     Args:
         dt: Datetime to format
-        
+
     Returns:
         Relative time string
     """
     now = dt_util.now()
-    
+
     # Make both timezone-aware for comparison
     if dt.tzinfo is None:
         dt = dt_util.as_local(dt)
     if now.tzinfo is None:
         now = dt_util.as_local(now)
-    
+
     delta = now - dt
-    
+
     if delta.total_seconds() < 60:
         return "just now"
     elif delta.total_seconds() < 3600:
@@ -693,63 +680,55 @@ def format_relative_time(dt: datetime) -> str:
 def merge_configurations(
     base_config: dict[str, Any],
     user_config: dict[str, Any],
-    protected_keys: set[str] | None = None
+    protected_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Merge user configuration with base configuration.
-    
+
     Args:
         base_config: Base configuration with defaults
         user_config: User-provided configuration
         protected_keys: Keys that cannot be overridden
-        
+
     Returns:
         Merged configuration
     """
     protected_keys = protected_keys or set()
     merged = base_config.copy()
-    
+
     for key, value in user_config.items():
         if key in protected_keys:
             _LOGGER.warning("Ignoring protected configuration key: %s", key)
             continue
-            
-        if (
-            key in merged
-            and isinstance(merged[key], dict)
-            and isinstance(value, dict)
-        ):
-            merged[key] = merge_configurations(
-                merged[key], 
-                value, 
-                protected_keys
-            )
+
+        if key in merged and isinstance(merged[key], dict) and isinstance(value, dict):
+            merged[key] = merge_configurations(merged[key], value, protected_keys)
         else:
             merged[key] = value
-    
+
     return merged
 
 
 def validate_configuration_schema(
     config: dict[str, Any],
     required_keys: set[str],
-    optional_keys: set[str] | None = None
+    optional_keys: set[str] | None = None,
 ) -> dict[str, Any]:
     """Validate configuration against schema.
-    
+
     Args:
         config: Configuration to validate
         required_keys: Required configuration keys
         optional_keys: Optional configuration keys
-        
+
     Returns:
         Validation result with missing/unknown keys
     """
     optional_keys = optional_keys or set()
     all_valid_keys = required_keys | optional_keys
-    
+
     missing_keys = required_keys - config.keys()
     unknown_keys = config.keys() - all_valid_keys
-    
+
     return {
         "valid": len(missing_keys) == 0,
         "missing_keys": list(missing_keys),
@@ -759,21 +738,17 @@ def validate_configuration_schema(
     }
 
 
-def convert_units(
-    value: float,
-    from_unit: str,
-    to_unit: str
-) -> float:
+def convert_units(value: float, from_unit: str, to_unit: str) -> float:
     """Convert between different units.
-    
+
     Args:
         value: Value to convert
         from_unit: Source unit
         to_unit: Target unit
-        
+
     Returns:
         Converted value
-        
+
     Raises:
         ValueError: If unit conversion not supported
     """
@@ -786,7 +761,7 @@ def convert_units(
         ("oz", "g"): lambda x: x * 28.3495,
         ("g", "oz"): lambda x: x / 28.3495,
     }
-    
+
     # Distance conversions
     distance_conversions = {
         ("m", "ft"): lambda x: x * 3.28084,
@@ -796,31 +771,31 @@ def convert_units(
         ("m", "km"): lambda x: x / 1000,
         ("km", "m"): lambda x: x * 1000,
     }
-    
+
     # Temperature conversions
     temp_conversions = {
-        ("c", "f"): lambda x: (x * 9/5) + 32,
-        ("f", "c"): lambda x: (x - 32) * 5/9,
+        ("c", "f"): lambda x: (x * 9 / 5) + 32,
+        ("f", "c"): lambda x: (x - 32) * 5 / 9,
     }
-    
+
     # Combine all conversions
     all_conversions = {
         **weight_conversions,
         **distance_conversions,
         **temp_conversions,
     }
-    
+
     # Normalize unit names
     from_unit = from_unit.lower().strip()
     to_unit = to_unit.lower().strip()
-    
+
     # Handle same unit
     if from_unit == to_unit:
         return value
-    
+
     # Look up conversion
     conversion_key = (from_unit, to_unit)
     if conversion_key in all_conversions:
         return all_conversions[conversion_key](value)
-    
+
     raise ValueError(f"Conversion from {from_unit} to {to_unit} not supported")

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -576,8 +576,7 @@ class WalkManager:
 
         # Sample points at regular intervals
         interval = len(path) // (PATH_POINT_LIMIT - 2)
-        for i in range(interval, len(path) - 1, interval):
-            optimized.append(path[i])
+        optimized.extend(path[i] for i in range(interval, len(path) - 1, interval))
 
         # Always keep end point
         optimized.append(path[-1])

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -11,11 +11,12 @@ Python: 3.13+
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import logging
 import math
+from collections import deque
 from datetime import datetime, timedelta
 from typing import Any
-from collections import deque
 
 from homeassistant.util import dt as dt_util
 
@@ -34,7 +35,7 @@ class GPSCache:
 
     def __init__(self, max_size: int = GPS_CACHE_SIZE_LIMIT) -> None:
         """Initialize GPS cache.
-        
+
         Args:
             max_size: Maximum cache entries
         """
@@ -45,10 +46,10 @@ class GPSCache:
 
     def get_location(self, dog_id: str) -> tuple[float, float, datetime] | None:
         """Get cached location with LRU update.
-        
+
         Args:
             dog_id: Dog identifier
-            
+
         Returns:
             Location tuple or None
         """
@@ -59,9 +60,11 @@ class GPSCache:
             return self._cache[dog_id]
         return None
 
-    def set_location(self, dog_id: str, latitude: float, longitude: float, timestamp: datetime) -> None:
+    def set_location(
+        self, dog_id: str, latitude: float, longitude: float, timestamp: datetime
+    ) -> None:
         """Set location with LRU eviction.
-        
+
         Args:
             dog_id: Dog identifier
             latitude: Latitude coordinate
@@ -74,50 +77,54 @@ class GPSCache:
             del self._cache[oldest]
 
         self._cache[dog_id] = (latitude, longitude, timestamp)
-        
+
         # Update access order
         if dog_id in self._access_order:
             self._access_order.remove(dog_id)
         self._access_order.append(dog_id)
 
-    def calculate_distance_cached(self, point1: tuple[float, float], point2: tuple[float, float]) -> float:
+    def calculate_distance_cached(
+        self, point1: tuple[float, float], point2: tuple[float, float]
+    ) -> float:
         """Calculate distance with caching for frequently used points.
-        
+
         Args:
             point1: First GPS coordinate (lat, lon)
             point2: Second GPS coordinate (lat, lon)
-            
+
         Returns:
             Distance in meters
         """
         # Create cache key (order independent)
         cache_key = tuple(sorted([point1, point2]))
-        
+
         if cache_key in self._distance_cache:
             return self._distance_cache[cache_key]
-        
+
         # Calculate distance using Haversine formula
         distance = self._haversine_distance(point1, point2)
-        
+
         # Cache result with size limit
         if len(self._distance_cache) >= DISTANCE_CALCULATION_CACHE_SIZE:
             # Remove oldest entry
             oldest_key = next(iter(self._distance_cache))
             del self._distance_cache[oldest_key]
-        
+
         self._distance_cache[cache_key] = distance
         return distance
 
     @staticmethod
-    def _haversine_distance(point1: tuple[float, float], point2: tuple[float, float]) -> float:
+    def _haversine_distance(
+        point1: tuple[float, float], point2: tuple[float, float]
+    ) -> float:
         """Calculate Haversine distance between two points.
-        
+
         OPTIMIZE: Static method for better performance, no self access needed.
-        
+
         Args:
             point1: First GPS coordinate (lat, lon)
             point2: Second GPS coordinate (lat, lon)
-            
+
         Returns:
             Distance in meters
         """
@@ -188,7 +195,9 @@ class WalkManager:
         }
 
         # OPTIMIZE: Batch processing for location analysis
-        self._location_analysis_queue: dict[str, list[tuple[float, float, datetime]]] = {}
+        self._location_analysis_queue: dict[
+            str, list[tuple[float, float, datetime]]
+        ] = {}
         self._batch_analysis_task: asyncio.Task | None = None
 
         _LOGGER.debug("WalkManager initialized with optimizations")
@@ -232,7 +241,7 @@ class WalkManager:
                     "zone": "unknown",
                     "distance_from_home": None,
                     "signal_strength": None,  # OPTIMIZE: Added signal strength
-                    "battery_level": None,    # OPTIMIZE: Added battery tracking
+                    "battery_level": None,  # OPTIMIZE: Added battery tracking
                 }
 
                 self._walk_history[dog_id] = []
@@ -240,9 +249,13 @@ class WalkManager:
 
             # Start batch analysis task
             if self._batch_analysis_task is None:
-                self._batch_analysis_task = asyncio.create_task(self._batch_location_analysis())
+                self._batch_analysis_task = asyncio.create_task(
+                    self._batch_location_analysis()
+                )
 
-        _LOGGER.info("WalkManager initialized for %d dogs with optimizations", len(dog_ids))
+        _LOGGER.info(
+            "WalkManager initialized for %d dogs with optimizations", len(dog_ids)
+        )
 
     async def async_update_gps_data(
         self,
@@ -337,13 +350,17 @@ class WalkManager:
 
             _LOGGER.debug(
                 "Updated GPS data for %s: %f, %f (accuracy: %s, battery: %s%%)",
-                dog_id, latitude, longitude, accuracy, battery_level,
+                dog_id,
+                latitude,
+                longitude,
+                accuracy,
+                battery_level,
             )
             return True
 
     async def _batch_location_analysis(self) -> None:
         """Background task for batch location analysis.
-        
+
         OPTIMIZE: Process location analysis in batches for better performance.
         """
         while True:
@@ -505,7 +522,9 @@ class WalkManager:
                 )
                 walk_data["average_speed"] = self._calculate_average_speed(walk_data)
                 walk_data["max_speed"] = self._calculate_max_speed(walk_data["path"])
-                walk_data["elevation_gain"] = self._calculate_elevation_gain(walk_data["path"])
+                walk_data["elevation_gain"] = self._calculate_elevation_gain(
+                    walk_data["path"]
+                )
                 walk_data["calories_burned"] = self._estimate_calories_burned(
                     dog_id, walk_data
                 )
@@ -540,12 +559,12 @@ class WalkManager:
 
     def _optimize_path(self, path: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Optimize walk path by removing redundant points.
-        
+
         OPTIMIZE: Reduce memory usage by removing points that don't add significant value.
-        
+
         Args:
             path: Original path points
-            
+
         Returns:
             Optimized path
         """
@@ -554,20 +573,17 @@ class WalkManager:
 
         # Keep start and end points
         optimized = [path[0]]
-        
+
         # Sample points at regular intervals
         interval = len(path) // (PATH_POINT_LIMIT - 2)
         for i in range(interval, len(path) - 1, interval):
             optimized.append(path[i])
-        
+
         # Always keep end point
         optimized.append(path[-1])
-        
-        _LOGGER.debug(
-            "Optimized path: %d -> %d points", 
-            len(path), len(optimized)
-        )
-        
+
+        _LOGGER.debug("Optimized path: %d -> %d points", len(path), len(optimized))
+
         return optimized
 
     async def _process_walk_detection_optimized(
@@ -601,13 +617,15 @@ class WalkManager:
             await self.async_start_walk(dog_id, "auto_detected")
             _LOGGER.debug(
                 "Auto-detected walk start for %s: distance=%.1fm, speed=%.1fkm/h",
-                dog_id, distance, speed or 0
+                dog_id,
+                distance,
+                speed or 0,
             )
 
         # OPTIMIZE: Add to walk path if walk in progress with point limits
         if dog_id in self._current_walks:
             current_walk = self._current_walks[dog_id]
-            
+
             # Only add point if it's significant (distance > 5m or time > 30s since last point)
             should_add_point = True
             if current_walk["path"]:
@@ -616,12 +634,12 @@ class WalkManager:
                 last_distance = self._gps_cache.calculate_distance_cached(
                     last_location, new_location
                 )
-                
+
                 # Only add if moved significantly or time passed
                 now = dt_util.now()
                 last_time = dt_util.parse_datetime(last_point["timestamp"])
                 time_diff = (now - last_time).total_seconds()
-                
+
                 should_add_point = last_distance > 5.0 or time_diff > 30
 
             if should_add_point and len(current_walk["path"]) < PATH_POINT_LIMIT:
@@ -635,7 +653,9 @@ class WalkManager:
                 }
                 current_walk["path"].append(path_point)
 
-    async def _calculate_total_distance_optimized(self, path: list[dict[str, Any]]) -> float:
+    async def _calculate_total_distance_optimized(
+        self, path: list[dict[str, Any]]
+    ) -> float:
         """Calculate total distance with caching optimization.
 
         OPTIMIZE: Batch distance calculations for better performance.
@@ -650,7 +670,7 @@ class WalkManager:
             return 0.0
 
         total_distance = 0.0
-        
+
         # OPTIMIZE: Batch process distance calculations
         for i in range(1, len(path)):
             point1 = (path[i - 1]["latitude"], path[i - 1]["longitude"])
@@ -682,13 +702,21 @@ class WalkManager:
         # OPTIMIZE: Batch calculate averages from recent walks
         recent_walks = await self.async_get_walk_history(dog_id, 7)
         if recent_walks:
-            durations = [w.get("duration", 0) for w in recent_walks if w.get("duration")]
-            distances = [w.get("distance", 0) for w in recent_walks if w.get("distance")]
-            
+            durations = [
+                w.get("duration", 0) for w in recent_walks if w.get("duration")
+            ]
+            distances = [
+                w.get("distance", 0) for w in recent_walks if w.get("distance")
+            ]
+
             if durations:
-                self._walk_data[dog_id]["average_duration"] = sum(durations) / len(durations)
+                self._walk_data[dog_id]["average_duration"] = sum(durations) / len(
+                    durations
+                )
             if distances:
-                self._walk_data[dog_id]["average_distance"] = sum(distances) / len(distances)
+                self._walk_data[dog_id]["average_distance"] = sum(distances) / len(
+                    distances
+                )
 
         # OPTIMIZE: Update weekly stats in single pass
         week_walks = await self.async_get_walk_history(dog_id, 7)
@@ -698,19 +726,21 @@ class WalkManager:
         )
 
         # OPTIMIZE: Calculate walk streak efficiently
-        self._walk_data[dog_id]["walk_streak"] = await self._calculate_walk_streak_optimized(dog_id)
+        self._walk_data[dog_id][
+            "walk_streak"
+        ] = await self._calculate_walk_streak_optimized(dog_id)
 
         # Update energy level based on recent activity
         self._update_energy_level(dog_id, walk_data)
 
     async def _calculate_walk_streak_optimized(self, dog_id: str) -> int:
         """Calculate walk streak with optimized algorithm.
-        
+
         OPTIMIZE: More efficient streak calculation using binary search approach.
-        
+
         Args:
             dog_id: Dog identifier
-            
+
         Returns:
             Current walk streak in days
         """
@@ -731,7 +761,7 @@ class WalkManager:
         # Calculate streak
         streak = 0
         current_date = dt_util.now().date()
-        
+
         for _ in range(30):  # Check last 30 days
             date_str = current_date.isoformat()
             if date_str in walks_by_date:
@@ -744,7 +774,7 @@ class WalkManager:
 
     def _update_energy_level(self, dog_id: str, walk_data: dict[str, Any]) -> None:
         """Update dog's energy level based on walk activity.
-        
+
         Args:
             dog_id: Dog identifier
             walk_data: Recent walk data
@@ -752,24 +782,24 @@ class WalkManager:
         # Simple energy level calculation based on walk distance and duration
         distance = walk_data.get("distance", 0)
         duration = walk_data.get("duration", 0)
-        
+
         if distance > 2000 or duration > 3600:  # Long walk (>2km or >1h)
             energy_level = "low"
         elif distance > 1000 or duration > 1800:  # Moderate walk (>1km or >30min)
             energy_level = "medium"
         else:
             energy_level = "high"
-            
+
         self._walk_data[dog_id]["energy_level"] = energy_level
 
     def _calculate_elevation_gain(self, path: list[dict[str, Any]]) -> float:
         """Calculate total elevation gain from path.
-        
+
         OPTIMIZE: New feature for comprehensive walk analysis.
-        
+
         Args:
             path: List of GPS path points with altitude data
-            
+
         Returns:
             Total elevation gain in meters
         """
@@ -817,16 +847,20 @@ class WalkManager:
             # Add current walk if in progress
             if dog_id in self._current_walks:
                 current_walk = self._current_walks[dog_id].copy()
-                
+
                 # Calculate current walk duration and distance
                 if current_walk["path"]:
-                    current_walk["current_distance"] = await self._calculate_total_distance_optimized(
+                    current_walk[
+                        "current_distance"
+                    ] = await self._calculate_total_distance_optimized(
                         current_walk["path"]
                     )
-                    
+
                 start_time = dt_util.parse_datetime(current_walk["start_time"])
-                current_walk["current_duration"] = (dt_util.now() - start_time).total_seconds()
-                
+                current_walk["current_duration"] = (
+                    dt_util.now() - start_time
+                ).total_seconds()
+
                 data["current_walk"] = current_walk
                 data["walk_in_progress"] = True
             else:
@@ -839,7 +873,7 @@ class WalkManager:
 
     def _invalidate_statistics_cache(self, dog_id: str) -> None:
         """Invalidate statistics cache for a dog.
-        
+
         Args:
             dog_id: Dog identifier
         """
@@ -848,9 +882,9 @@ class WalkManager:
 
     async def async_get_performance_statistics(self) -> dict[str, Any]:
         """Get performance statistics for the walk manager.
-        
+
         OPTIMIZE: New method for monitoring performance and optimization effectiveness.
-        
+
         Returns:
             Performance statistics
         """
@@ -879,7 +913,6 @@ class WalkManager:
                 "total_walks_today": total_walks_today,
                 "total_distance_today": round(total_distance_today, 1),
                 "walk_detection_enabled": self._walk_detection_enabled,
-                
                 # Performance metrics
                 "performance_metrics": self._performance_metrics.copy(),
                 "cache_stats": cache_stats,
@@ -887,12 +920,11 @@ class WalkManager:
                 "location_analysis_queue_size": sum(
                     len(queue) for queue in self._location_analysis_queue.values()
                 ),
-                
                 # Memory usage
                 "average_path_length": sum(
-                    len(walk.get("path", []))
-                    for walk in self._current_walks.values()
-                ) / max(len(self._current_walks), 1),
+                    len(walk.get("path", [])) for walk in self._current_walks.values()
+                )
+                / max(len(self._current_walks), 1),
             }
 
     # OPTIMIZE: Keep existing methods for compatibility but optimize internal calls
@@ -943,9 +975,9 @@ class WalkManager:
         self, dog_id: str, latitude: float, longitude: float
     ) -> None:
         """Update location-based analysis with caching.
-        
+
         OPTIMIZE: Enhanced with zone caching and reduced calculations.
-        
+
         Args:
             dog_id: Dog identifier
             latitude: Current latitude
@@ -1021,10 +1053,8 @@ class WalkManager:
         # Cancel batch analysis task
         if self._batch_analysis_task:
             self._batch_analysis_task.cancel()
-            try:
+            with contextlib.suppress(asyncio.CancelledError):
                 await self._batch_analysis_task
-            except asyncio.CancelledError:
-                pass
 
         async with self._data_lock:
             self._walk_data.clear()
@@ -1033,7 +1063,7 @@ class WalkManager:
             self._walk_history.clear()
             self._location_analysis_queue.clear()
             self._statistics_cache.clear()
-            
+
             # Clear caches
             self._gps_cache.clear()
             self._zone_cache.clear()


### PR DESCRIPTION
## Summary
- add a reusable performance monitor and timed operation helper to the config flow and cache repeated dog validation and entity estimation results
- enhance import validation with detailed warnings and profile checks while reusing cached entity counts throughout the flow
- cache profile descriptions and preview calculations in the options flow with richer recommendations and warnings

## Testing
- pytest *(fails: missing dependency pytest_homeassistant_custom_component)*

------
https://chatgpt.com/codex/tasks/task_e_68c958165fec83319623acb54a27e34a