### PR TITLE
Improve config flow validation and adjust dependencies

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -79,6 +79,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         # OPTIMIZE: Initialize external API flag BEFORE super().__init__() to prevent AttributeError
         self._use_external_api = False
 
+        # OPTIMIZE: Prepare caches before calculating interval
+        self._interval_cache: dict[str, int] = {}
+
         # Calculate optimized update interval
         update_interval = self._calculate_optimized_update_interval()
 
@@ -107,9 +110,6 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
         # Track maintenance task unsubscriber
         self._unsub_maintenance: Callable[[], None] | None = None
-
-        # OPTIMIZE: Add interval cache with size limit
-        self._interval_cache: dict[str, int] = {}
 
         _LOGGER.info(
             "Coordinator initialized: %d dogs, %ds interval, session=%s",

--- a/custom_components/pawcontrol/manifest.json
+++ b/custom_components/pawcontrol/manifest.json
@@ -18,7 +18,6 @@
     "@BigDaddy1990"
   ],
   "config_flow": true,
-  "dependencies": ["bluetooth_adapters"],
   "dhcp": [
     {
       "hostname": "tractive-*",


### PR DESCRIPTION
## Summary
- add a dedicated `DogValidationError` to capture field-specific validation issues and surface them on the config flow form
- normalize timestamp handling and entry titling in the config flow and drop the hard dependency on `bluetooth_adapters`
- initialize the coordinator interval cache before computing update intervals to avoid attribute errors during setup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c97eeec8348331982bfb9696fa7b85