### PR TITLE
Use hass-managed session and running loop timing

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -487,12 +487,13 @@ class PawControlData:
 
     async def async_load_data(self) -> None:
         """Load data with performance monitoring."""
-        start_time = asyncio.get_event_loop().time()
+        loop = asyncio.get_running_loop()
+        start_time = loop.time()
 
         try:
             self._data = await self.storage.async_load_all_data()
 
-            load_time = asyncio.get_event_loop().time() - start_time
+            load_time = loop.time() - start_time
             _LOGGER.debug(
                 "Data manager initialized with %d data types in %.2fs",
                 len(self._data),

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -898,7 +898,7 @@ class PawControlOptionsFlow(OptionsFlow):
                         "medication": False,
                         "training": False,
                     },
-                    "created_at": asyncio.get_event_loop().time(),
+                    "created_at": asyncio.get_running_loop().time(),
                 }
 
                 # Add to existing dogs


### PR DESCRIPTION
## Summary
- reuse Home Assistant's managed aiohttp session when constructing the coordinator
- measure monotonic timings with `asyncio.get_running_loop().time()` across coordinator, helpers, and options flow
- simplify coordinator shutdown to clear cached state while relying on Home Assistant for session lifecycle management

## Testing
- ruff check
- pytest *(fails: missing dependency `pytest_homeassistant_custom_component`)*
- python -m script.hassfest --integration-path custom_components/pawcontrol *(fails: module `script` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9988afcb4833190801169a6c9589c