### PR TITLE
Ensure timezone-aware timestamps

### DIFF
--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -18,6 +18,7 @@ from enum import Enum
 from typing import Any, Final
 
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.util import dt as dt_util
 
 from .types import GPSLocation
 
@@ -88,7 +89,7 @@ class PawControlError(HomeAssistantError):
         self.recovery_suggestions = recovery_suggestions or []
         self.user_message = user_message or message
         self.technical_details = technical_details
-        self.timestamp = timestamp or datetime.now()
+        self.timestamp = timestamp or dt_util.utcnow()
         self.stack_trace = traceback.format_stack()
 
     def to_dict(self) -> dict[str, Any]:
@@ -963,7 +964,7 @@ def create_error_context(
         Structured error context dictionary
     """
     context = {
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": dt_util.utcnow().isoformat(),
         "dog_id": dog_id,
         "operation": operation,
     }

--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -108,7 +108,7 @@ class MealSchedule:
         if self.days_of_week is None:
             return True
 
-        today = datetime.now().weekday()
+        today = dt_util.now().weekday()
         return today in self.days_of_week
 
     def get_next_feeding_time(self) -> datetime:

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import TYPE_CHECKING, Any, Required, TypedDict
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.util import dt as dt_util
 
 # OPTIMIZE: Resolve circular imports with proper conditional imports
 if TYPE_CHECKING:
@@ -297,7 +298,7 @@ class GPSLocation:
     longitude: float
     accuracy: float | None = None
     altitude: float | None = None
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=dt_util.utcnow)
     source: str = ""
     battery_level: int | None = None  # OPTIMIZE: Added battery level for GPS devices
     signal_strength: int | None = None  # OPTIMIZE: Added signal strength
@@ -351,7 +352,7 @@ class NotificationData:
     message: str
     priority: str = "normal"
     channel: str = "mobile"
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=dt_util.utcnow)
     persistent: bool = False
     actions: list[dict[str, str]] = field(default_factory=list)
     dog_id: str = ""  # OPTIMIZE: Added dog association
@@ -783,7 +784,7 @@ class PawControlError:
 
     code: str
     message: str
-    timestamp: datetime = field(default_factory=datetime.now)
+    timestamp: datetime = field(default_factory=dt_util.utcnow)
     context: dict[str, Any] = field(default_factory=dict)
     severity: str = "error"  # OPTIMIZE: Added severity levels
 


### PR DESCRIPTION
## Summary
- ensure meal schedule calculations rely on Home Assistant's timezone utilities
- store PawControl exception timestamps and contexts with timezone-aware values
- update dataclass timestamp defaults to use Home Assistant UTC helpers for consistency

## Testing
- `pytest tests/components/pawcontrol -q`
- `ruff check custom_components/pawcontrol/exceptions.py custom_components/pawcontrol/feeding_manager.py custom_components/pawcontrol/types.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9bf9f52ec83319273a76d8768c82d