### PR TITLE
Ensure deterministic platform setup ordering

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -47,7 +47,7 @@ _LOGGER = logging.getLogger(__name__)
 ALL_PLATFORMS: Final[tuple[Platform, ...]] = PLATFORMS
 
 # OPTIMIZE: Platform cache with size limits and better management
-_PLATFORM_CACHE: dict[str, list[Platform]] = {}
+_PLATFORM_CACHE: dict[str, tuple[Platform, ...]] = {}
 _CACHE_SIZE_LIMIT = 100
 
 # OPTIMIZE: Manager initialization timeout and retry settings
@@ -58,7 +58,7 @@ MAX_MANAGER_RETRIES = 2
 @bind_hass
 def get_platforms_for_profile_and_modules(
     dogs_config: list[dict[str, Any]], profile: str
-) -> list[Platform]:
+) -> tuple[Platform, ...]:
     """Determine required platforms based on dogs, modules and profile.
 
     OPTIMIZE: Enhanced with caching, single-pass iteration, and early validation.
@@ -68,10 +68,10 @@ def get_platforms_for_profile_and_modules(
         profile: Entity profile name
 
     Returns:
-        List of required platforms
+        Tuple of required platforms sorted for deterministic setup ordering
     """
     if not dogs_config:
-        return [Platform.SENSOR, Platform.BUTTON]
+        return (Platform.SENSOR, Platform.BUTTON)
 
     # OPTIMIZE: Generate cache key with better performance using hash
     dogs_signature = hash(
@@ -145,7 +145,7 @@ def get_platforms_for_profile_and_modules(
         elif profile == "health_focus":
             platforms.update({Platform.DATE, Platform.NUMBER, Platform.TEXT})
 
-    result_platforms = list(platforms)
+    result_platforms = tuple(sorted(platforms, key=lambda item: item.value))
     _PLATFORM_CACHE[cache_key] = result_platforms
     return result_platforms
 


### PR DESCRIPTION
## Summary
- ensure the cached platform list uses tuples and a deterministic sort order so setup and unload run with predictable sequences

## Testing
- ruff check
- pytest -q *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_68c9c1f99b6c8331add2a5fe139a1b4c