### PR TITLE
Add unit test for platform sorting determinism

### DIFF
--- a/tests/components/pawcontrol/test_platforms.py
+++ b/tests/components/pawcontrol/test_platforms.py
@@ -1,0 +1,63 @@
+"""Tests for platform resolution logic in the PawControl integration."""
+
+from __future__ import annotations
+
+import importlib
+
+import custom_components.pawcontrol as pawcontrol_module
+from custom_components.pawcontrol.const import (
+    CONF_DOG_ID,
+    MODULE_FEEDING,
+    MODULE_GPS,
+    MODULE_HEALTH,
+    MODULE_NOTIFICATIONS,
+    MODULE_WALK,
+)
+from homeassistant.const import Platform
+
+
+def test_get_platforms_sorted_deterministically() -> None:
+    """Ensure the helper returns platforms in deterministic sorted order."""
+    importlib.reload(pawcontrol_module)
+    pawcontrol_module._PLATFORM_CACHE.clear()
+
+    dogs_config = [
+        {
+            CONF_DOG_ID: "alpha",
+            "modules": {
+                MODULE_NOTIFICATIONS: True,
+                MODULE_GPS: True,
+                MODULE_WALK: True,
+                MODULE_FEEDING: True,
+                MODULE_HEALTH: True,
+            },
+        },
+        {
+            CONF_DOG_ID: "beta",
+            "modules": {
+                MODULE_WALK: True,
+                MODULE_GPS: True,
+                MODULE_HEALTH: True,
+            },
+        },
+    ]
+
+    result = pawcontrol_module.get_platforms_for_profile_and_modules(
+        dogs_config, "advanced"
+    )
+
+    expected_platforms = {
+        Platform.BUTTON,
+        Platform.SENSOR,
+        Platform.BINARY_SENSOR,
+        Platform.SWITCH,
+        Platform.SELECT,
+        Platform.DEVICE_TRACKER,
+        Platform.NUMBER,
+        Platform.DATE,
+        Platform.DATETIME,
+        Platform.TEXT,
+    }
+    expected_order = tuple(sorted(expected_platforms, key=lambda platform: platform.value))
+
+    assert result == expected_order

--- a/tests/components/pawcontrol/test_platforms.py
+++ b/tests/components/pawcontrol/test_platforms.py
@@ -6,9 +6,8 @@ import importlib
 from collections.abc import Iterable
 from typing import Any
 
-import pytest
-
 import custom_components.pawcontrol as pawcontrol_module
+import pytest
 from custom_components.pawcontrol.const import (
     CONF_DOG_ID,
     MODULE_FEEDING,
@@ -20,7 +19,9 @@ from custom_components.pawcontrol.const import (
 from homeassistant.const import Platform
 
 
-def _build_dogs_config(modules_per_dog: Iterable[Iterable[str]]) -> list[dict[str, Any]]:
+def _build_dogs_config(
+    modules_per_dog: Iterable[Iterable[str]],
+) -> list[dict[str, Any]]:
     """Create a dogs configuration payload from enabled module sets."""
     return [
         {
@@ -125,12 +126,16 @@ def reload_and_clear_platform_cache() -> None:
     ],
 )
 def test_get_platforms_for_profile_and_modules(
-    profile: str, modules_per_dog: Iterable[Iterable[str]], expected_platforms: set[Platform]
+    profile: str,
+    modules_per_dog: Iterable[Iterable[str]],
+    expected_platforms: set[Platform],
 ) -> None:
     """Ensure the helper returns deterministically sorted platforms per scenario."""
     dogs_config = _build_dogs_config(modules_per_dog)
 
-    result = pawcontrol_module.get_platforms_for_profile_and_modules(dogs_config, profile)
+    result = pawcontrol_module.get_platforms_for_profile_and_modules(
+        dogs_config, profile
+    )
 
     expected_order = tuple(
         sorted(expected_platforms, key=lambda platform: platform.value)

--- a/tests/components/pawcontrol/test_platforms.py
+++ b/tests/components/pawcontrol/test_platforms.py
@@ -58,6 +58,8 @@ def test_get_platforms_sorted_deterministically() -> None:
         Platform.DATETIME,
         Platform.TEXT,
     }
-    expected_order = tuple(sorted(expected_platforms, key=lambda platform: platform.value))
+    expected_order = tuple(
+        sorted(expected_platforms, key=lambda platform: platform.value)
+    )
 
     assert result == expected_order


### PR DESCRIPTION
## Summary
- add a focused test for `get_platforms_for_profile_and_modules`
- verify the helper clears its cache and returns a deterministically sorted platform tuple

## Testing
- `pytest tests/components/pawcontrol/test_platforms.py`


------
https://chatgpt.com/codex/tasks/task_e_68c9c552469c8331b7664d57e838e07a