### PR TITLE
Fix cached data retrieval for empty payloads

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -211,7 +211,7 @@ class PawControlDataStorage:
             # Check cache first
             cache_key = "all_data"
             cached_data = await self._cache.get(cache_key)
-            if cached_data:
+            if cached_data is not None:
                 return cached_data
 
             # Load all data stores concurrently

--- a/tests/components/pawcontrol/test_helpers.py
+++ b/tests/components/pawcontrol/test_helpers.py
@@ -1,0 +1,51 @@
+"""Tests for helper utilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from custom_components.pawcontrol.helpers import PawControlDataStorage
+
+
+class _DummyCache:
+    """Simple in-memory cache stand-in for tests."""
+
+    def __init__(self) -> None:
+        self.values: dict[str, Any] = {}
+
+    async def get(self, key: str, default: Any = None) -> Any:
+        """Return a cached value if present."""
+
+        return self.values.get(key, default)
+
+    async def set(self, key: str, value: Any, ttl_seconds: int = 300) -> None:
+        """Store a value in the cache."""
+
+        self.values[key] = value
+
+
+@pytest.mark.asyncio
+async def test_async_load_all_data_uses_cached_empty_payload() -> None:
+    """An empty payload stored in the cache should be returned without reload."""
+
+    storage = object.__new__(PawControlDataStorage)
+    storage._cache = _DummyCache()  # type: ignore[attr-defined]
+    storage._stores = {"test": object()}  # type: ignore[attr-defined]
+
+    called = False
+
+    async def fake_loader(store_key: str) -> dict[str, Any]:
+        nonlocal called
+        called = True
+        return {store_key: "loaded"}
+
+    storage._load_store_data_cached = fake_loader  # type: ignore[attr-defined]
+
+    await storage._cache.set("all_data", {})
+
+    result = await PawControlDataStorage.async_load_all_data(storage)
+
+    assert result == {}
+    assert called is False


### PR DESCRIPTION
## Summary
- ensure the PawControl data storage returns cached payloads even when empty so reads are not repeated unnecessarily
- add a regression test that exercises the cache path when an empty payload is stored

## Testing
- pytest tests/components/pawcontrol/test_helpers.py *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68c9d52cd22c8331b8b0b843b9284c42