### PR TITLE
Fix notification channel alignment for async send results

### DIFF
--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -11,7 +11,7 @@ import logging
 from collections import deque
 from contextlib import suppress
 from datetime import datetime, timedelta
-from typing import Any, Deque
+from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -496,7 +496,7 @@ class PawControlData:
         self._dogs: list[dict[str, Any]] = config_entry.data.get(CONF_DOGS, [])
 
         # OPTIMIZATION: Event queue for batch processing
-        self._event_queue: Deque[dict[str, Any]] = deque(maxlen=1000)
+        self._event_queue: deque[dict[str, Any]] = deque(maxlen=1000)
         self._event_task: asyncio.Task | None = None
         self._valid_dog_ids: set[str] | None = None
 
@@ -723,10 +723,10 @@ class PawControlNotificationManager:
         self.config_entry = config_entry
 
         # OPTIMIZATION: Use deque for efficient queue operations
-        self._notification_queue: Deque[dict[str, Any]] = deque(
+        self._notification_queue: deque[dict[str, Any]] = deque(
             maxlen=MAX_NOTIFICATION_QUEUE
         )
-        self._high_priority_queue: Deque[dict[str, Any]] = deque(
+        self._high_priority_queue: deque[dict[str, Any]] = deque(
             maxlen=50
         )  # Separate urgent queue
 
@@ -950,7 +950,7 @@ class PerformanceMonitor:
             "avg_operation_time": 0.0,
             "last_cleanup": None,
         }
-        self._operation_times: Deque[float] = deque(maxlen=100)
+        self._operation_times: deque[float] = deque(maxlen=100)
 
     def record_operation(self, operation_time: float, success: bool = True) -> None:
         """Record an operation."""

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -9,10 +9,9 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from collections.abc import Deque
 from contextlib import suppress
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, Deque
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -946,7 +946,7 @@ class PawControlNotificationManager:
             results = await asyncio.gather(*send_tasks, return_exceptions=True)
 
             # Process results
-            for channel, result in zip(task_channels, results, strict=False):
+            for channel, result in zip(task_channels, results, strict=True):
                 if isinstance(result, Exception):
                     _LOGGER.error(
                         "Failed to send notification %s to channel %s: %s",

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
@@ -928,10 +928,12 @@ class PawControlNotificationManager:
             notification: Notification to send
         """
         # Send to all channels in parallel
-        send_tasks = []
+        send_tasks: list[Awaitable[None]] = []
+        task_channels: list[NotificationChannel] = []
         for channel in notification.channels:
             handler = self._handlers.get(channel)
             if handler:
+                task_channels.append(channel)
                 send_tasks.append(
                     self._send_to_channel_safe(notification, channel, handler)
                 )
@@ -944,9 +946,8 @@ class PawControlNotificationManager:
             results = await asyncio.gather(*send_tasks, return_exceptions=True)
 
             # Process results
-            for i, result in enumerate(results):
+            for channel, result in zip(task_channels, results, strict=False):
                 if isinstance(result, Exception):
-                    channel = notification.channels[i]
                     _LOGGER.error(
                         "Failed to send notification %s to channel %s: %s",
                         notification.id,

--- a/tests/components/pawcontrol/test_helpers.py
+++ b/tests/components/pawcontrol/test_helpers.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-
 from custom_components.pawcontrol.helpers import PawControlDataStorage
 
 


### PR DESCRIPTION
## Summary
- keep track of channel order when building notification send tasks so gathered results map back to the correct destination

## Testing
- ruff check custom_components/pawcontrol/notifications.py
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68c9d52cd22c8331b8b0b843b9284c42