### PR TITLE
Ensure PawControl event processor starts after load failures

### DIFF
--- a/tests/components/pawcontrol/test_helpers.py
+++ b/tests/components/pawcontrol/test_helpers.py
@@ -7,12 +7,10 @@ from collections.abc import Coroutine
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-
-
 import pytest
 from custom_components.pawcontrol.helpers import PawControlDataStorage
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 
 
 class _DummyCache:

--- a/tests/components/pawcontrol/test_helpers.py
+++ b/tests/components/pawcontrol/test_helpers.py
@@ -7,6 +7,9 @@ from collections.abc import Coroutine
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
 
 import pytest
 from custom_components.pawcontrol.helpers import PawControlDataStorage

--- a/tests/components/pawcontrol/test_helpers.py
+++ b/tests/components/pawcontrol/test_helpers.py
@@ -61,8 +61,8 @@ async def test_async_load_all_data_uses_cached_empty_payload() -> None:
 async def test_async_load_data_starts_event_processor_on_failure(monkeypatch) -> None:
     """Ensure the event processor starts even when initial loading fails."""
 
-    hass = MagicMock()
-    config_entry = MagicMock()
+    hass = MagicMock(spec=HomeAssistant)
+    config_entry = MagicMock(spec=ConfigEntry)
     config_entry.data = {}
 
     storage = MagicMock()


### PR DESCRIPTION
## Summary
- ensure `PawControlData.async_load_data` always (re)starts the background event processor even when initial storage loading fails
- add a regression test covering the failure path and fallback data initialisation
- refactor the load failure regression test to instantiate `PawControlData` through a patched `PawControlDataStorage`, avoiding brittle manual attribute setup

## Testing
- pytest tests/components/pawcontrol/test_helpers.py::test_async_load_data_starts_event_processor_on_failure *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68c9edc666a08331bc02f135f318dd4c