### PR TITLE
Refine entity profile utilities for PawControl flows

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -22,6 +22,11 @@ from homeassistant.core import callback
 from homeassistant.helpers import config_validation as cv
 from homeassistant.util import dt as dt_util
 
+from .config_flow_profile import (
+    PROFILE_SCHEMA,
+    build_profile_summary_text,
+    validate_profile_selection,
+)
 from .const import (
     CONF_DOG_AGE,
     CONF_DOG_BREED,
@@ -44,11 +49,6 @@ from .const import (
     MODULE_HEALTH,
     MODULE_NOTIFICATIONS,
     MODULE_WALK,
-)
-from .config_flow_profile import (
-    PROFILE_SCHEMA,
-    build_profile_summary_text,
-    validate_profile_selection,
 )
 from .entity_factory import ENTITY_PROFILES, EntityFactory
 from .options_flow import PawControlOptionsFlow
@@ -152,6 +152,7 @@ MODULES_SCHEMA = vol.Schema(
         vol.Optional(MODULE_NOTIFICATIONS, default=True): cv.boolean,
     }
 )
+
 
 class DogValidationError(Exception):
     """Raised when validating a dog configuration fails."""

--- a/custom_components/pawcontrol/config_flow_profile.py
+++ b/custom_components/pawcontrol/config_flow_profile.py
@@ -1,40 +1,106 @@
-"""Profile configuration integration for PawControl config flow.
+"""Helpers for the entity profile selection step in the config flow.
 
-Updates config_flow.py to include entity profile selection.
-Reduces entity count from 54+ to 8-18 per dog based on user needs.
+The Home Assistant quality scale requires strict typing and centralized
+validation. The original helper bundled a dynamic method without any type
+annotations, which made reuse from both the configuration flow and the
+options flow difficult.  This module now provides reusable, fully typed
+utilities that standardize how entity profiles are presented and validated.
 """
 
 from __future__ import annotations
 
+from collections.abc import Mapping
+from typing import Any, Final
+
 import voluptuous as vol
 
-# Add to config_flow.py - Profile selection step
+from .entity_factory import ENTITY_PROFILES
 
-ENTITY_PROFILES = {
-    "basic": "Essential monitoring only (8 entities)",
-    "standard": "Balanced monitoring with GPS (12 entities)",
-    "advanced": "Comprehensive monitoring (18 entities)",
-    "gps_focus": "GPS tracking focused (10 entities)",
-    "health_focus": "Health monitoring focused (10 entities)",
+#: Default profile used when the user has not made a choice yet.
+DEFAULT_PROFILE: Final[str] = "standard"
+
+# Mapping used by voluptuous to offer friendly names in the dropdown.
+PROFILE_TITLES: Final[dict[str, str]] = {
+    profile: config.get("name", profile.title())
+    for profile, config in ENTITY_PROFILES.items()
 }
 
+# Schema reused by the config flow and options flow when asking for a profile.
+PROFILE_SCHEMA: Final[vol.Schema] = vol.Schema(
+    {
+        vol.Required("entity_profile", default=DEFAULT_PROFILE): vol.In(
+            PROFILE_TITLES
+        )
+    }
+)
 
-async def async_step_entity_profile(self, user_input=None):
-    """Handle entity profile selection."""
-    if user_input is not None:
-        self._config_data["entity_profile"] = user_input["entity_profile"]
-        return await self.async_step_final()
 
-    return self.async_show_form(
-        step_id="entity_profile",
-        data_schema=vol.Schema(
-            {
-                vol.Required("entity_profile", default="standard"): vol.In(
-                    ENTITY_PROFILES
-                )
-            }
-        ),
-        description_placeholders={
-            "profile_info": "Choose entity profile to optimize performance",
-        },
-    )
+def validate_profile_selection(user_input: Mapping[str, Any]) -> str:
+    """Validate and return the selected profile.
+
+    Args:
+        user_input: Mapping containing the submitted form values.
+
+    Returns:
+        The validated profile key.
+
+    Raises:
+        vol.Invalid: If the provided profile is not part of the supported set.
+    """
+
+    try:
+        # ``PROFILE_SCHEMA`` already restricts the value to supported profiles,
+        # but we still run it here to benefit from voluptuous error reporting.
+        profile_data = PROFILE_SCHEMA(dict(user_input))
+    except vol.Invalid as err:  # pragma: no cover - exercised by HA UI
+        raise vol.Invalid("invalid_profile") from err
+
+    profile = profile_data["entity_profile"]
+
+    if profile not in ENTITY_PROFILES:
+        # This should never happen because of the schema, but keeping this
+        # guard makes mypy and future refactors happier.
+        raise vol.Invalid("invalid_profile")
+
+    return profile
+
+
+def get_profile_selector_options() -> list[dict[str, str]]:
+    """Return selector options with descriptive labels for each profile."""
+
+    options: list[dict[str, str]] = []
+    for profile, config in ENTITY_PROFILES.items():
+        name = config.get("name", profile.title())
+        description = config.get("description", "")
+        max_entities = config.get("max_entities")
+
+        label_parts = [name]
+        if isinstance(max_entities, int):
+            label_parts.append(f"{max_entities} entities per dog")
+        if description:
+            # Use second-person tone to match the global writing guidance.
+            label_parts.append(description)
+
+        options.append({"value": profile, "label": " – ".join(label_parts)})
+
+    return options
+
+
+def build_profile_summary_text() -> str:
+    """Create a human readable summary of all profiles for UI hints."""
+
+    summaries: list[str] = []
+    for profile, config in ENTITY_PROFILES.items():
+        name = config.get("name", profile.title())
+        description = config.get("description", "")
+        recommended_for = config.get("recommended_for")
+
+        summary_parts = [f"{name}: {description}".rstrip()]
+        if isinstance(recommended_for, str) and recommended_for:
+            summary_parts.append(
+                f"You should pick this when you want {recommended_for.lower()}."
+            )
+
+        summaries.append(" ".join(summary_parts).strip())
+
+    return "\n".join(summaries)

--- a/custom_components/pawcontrol/config_flow_profile.py
+++ b/custom_components/pawcontrol/config_flow_profile.py
@@ -27,11 +27,7 @@ PROFILE_TITLES: Final[dict[str, str]] = {
 
 # Schema reused by the config flow and options flow when asking for a profile.
 PROFILE_SCHEMA: Final[vol.Schema] = vol.Schema(
-    {
-        vol.Required("entity_profile", default=DEFAULT_PROFILE): vol.In(
-            PROFILE_TITLES
-        )
-    }
+    {vol.Required("entity_profile", default=DEFAULT_PROFILE): vol.In(PROFILE_TITLES)}
 )
 
 

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -23,6 +23,11 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlowResult, OptionsFlow
 from homeassistant.helpers import selector
 
+from .config_flow_profile import (
+    DEFAULT_PROFILE,
+    get_profile_selector_options,
+    validate_profile_selection,
+)
 from .const import (
     CONF_DASHBOARD_MODE,
     CONF_DOG_AGE,
@@ -53,11 +58,6 @@ from .const import (
     MODULE_GPS,
     MODULE_HEALTH,
     MODULE_WALK,
-)
-from .config_flow_profile import (
-    DEFAULT_PROFILE,
-    get_profile_selector_options,
-    validate_profile_selection,
 )
 from .entity_factory import ENTITY_PROFILES, EntityFactory
 from .types import DogConfigData


### PR DESCRIPTION
## Summary
- centralize the entity profile schema, validation, and selector labels in `config_flow_profile`
- switch the config flow to the shared helpers and add richer profile guidance strings
- reuse the same helpers in the options flow so the dropdown and defaults stay consistent

## Testing
- pytest *(fails: missing dependency `pytest_homeassistant_custom_component`)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f12f090c8331876ac8ef45591270