### PR TITLE
Fix platform helper signature and tighten typing

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -1,15 +1,11 @@
-"""Core setup and platform initialization for the PawControl integration.
-
-Optimized setup with enhanced error handling, performance monitoring,
-and Platinum-level compliance for Home Assistant 2025.9.3+.
-"""
+"""Set up and manage the PawControl integration lifecycle."""
 
 from __future__ import annotations
 
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Mapping
-from typing import Any, Final
+from typing import Any, Final, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
@@ -17,7 +13,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.typing import ConfigType
-from homeassistant.loader import bind_hass
 
 from .const import (
     CONF_DOG_ID,
@@ -32,7 +27,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .data_manager import PawControlDataManager
-from .entity_factory import EntityFactory
+from .entity_factory import ENTITY_PROFILES, EntityFactory
 from .exceptions import PawControlSetupError
 from .feeding_manager import FeedingManager
 from .health_calculator import HealthCalculator
@@ -55,9 +50,8 @@ MANAGER_INIT_TIMEOUT = 30.0  # seconds
 MAX_MANAGER_RETRIES = 2
 
 
-@bind_hass
 def get_platforms_for_profile_and_modules(
-    dogs_config: list[dict[str, Any]], profile: str
+    dogs_config: list[DogConfigData], profile: str
 ) -> tuple[Platform, ...]:
     """Determine required platforms based on dogs, modules and profile.
 
@@ -90,8 +84,6 @@ def get_platforms_for_profile_and_modules(
         signature_source.append((dog.get(CONF_DOG_ID, ""), module_items))
 
     dogs_signature = hash(str(sorted(signature_source)))
-
-    from .entity_factory import ENTITY_PROFILES
 
     normalized_profile = profile
     if normalized_profile not in ENTITY_PROFILES:
@@ -181,7 +173,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
     _LOGGER.debug("Setting up Paw Control integration entry: %s", entry.entry_id)
 
     # Validate dogs configuration early with enhanced validation
-    dogs_config: list[DogConfigData] = entry.data.get(CONF_DOGS, [])
+    dogs_config = cast(list[DogConfigData], entry.data.get(CONF_DOGS, []))
     if not dogs_config:
         raise ConfigEntryNotReady("No dogs configured")
 
@@ -197,8 +189,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
 
     # Determine and validate profile
     profile = entry.options.get("entity_profile", "standard")
-    from .entity_factory import ENTITY_PROFILES, EntityFactory
-
     if profile not in ENTITY_PROFILES:
         _LOGGER.warning("Unknown profile '%s', using 'standard'", profile)
         profile = "standard"


### PR DESCRIPTION
## Summary
- streamline the module header and remove the unnecessary `bind_hass` decorator while updating the platform helper to work directly with typed dog configurations
- reuse the shared `ENTITY_PROFILES` constant and cast stored configuration data during setup for clearer typing

## Testing
- ruff check custom_components/pawcontrol/__init__.py
- pytest tests/components/pawcontrol/test_platforms.py::test_get_platforms_for_profile_and_modules[advanced--expected_platforms0] *(fails: missing pytest_homeassistant_custom_component)*

------
https://chatgpt.com/codex/tasks/task_e_68c9f12f090c8331876ac8ef45591270