### PR TITLE
Fix dashboard renderer batch edge cases

### DIFF
--- a/custom_components/pawcontrol/dashboard_renderer.py
+++ b/custom_components/pawcontrol/dashboard_renderer.py
@@ -340,11 +340,16 @@ class DashboardRenderer:
         Returns:
             List of dog view configurations
         """
-        views = []
+        if not dogs_config:
+            # Nothing to render; avoid zero batch size that would break range.
+            return []
+
+        views: list[dict[str, Any]] = []
 
         # Process dogs in batches to prevent memory issues
+        estimated_cards_per_dog = max(1, MAX_CARDS_PER_BATCH // 10)
         batch_size = min(
-            MAX_CARDS_PER_BATCH // 10, len(dogs_config)
+            estimated_cards_per_dog, len(dogs_config)
         )  # Estimate cards per dog
 
         for i in range(0, len(dogs_config), batch_size):

--- a/tests/components/pawcontrol/test_dashboard_renderer.py
+++ b/tests/components/pawcontrol/test_dashboard_renderer.py
@@ -1,0 +1,48 @@
+"""Tests for the dashboard renderer batching safeguards."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from custom_components.pawcontrol.dashboard_renderer import DashboardRenderer
+
+
+@pytest.mark.asyncio
+async def test_render_dog_views_batch_returns_empty_for_no_dogs() -> None:
+    """Ensure no views are generated when there are no dog configurations."""
+
+    hass = MagicMock()
+    hass.states = MagicMock()
+    renderer = DashboardRenderer(hass)
+
+    result = await renderer._render_dog_views_batch([], {})
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_render_dog_views_batch_enforces_minimum_batch_size(monkeypatch) -> None:
+    """Ensure the renderer never calculates an invalid zero batch size."""
+
+    hass = MagicMock()
+    hass.states = MagicMock()
+    renderer = DashboardRenderer(hass)
+
+    monkeypatch.setattr(
+        "custom_components.pawcontrol.dashboard_renderer.MAX_CARDS_PER_BATCH",
+        5,
+        raising=False,
+    )
+
+    renderer._render_single_dog_view = AsyncMock(
+        return_value={"title": "Dog", "cards": []}
+    )
+
+    dogs = [{"dog_id": "doggo", "dog_name": "Doggo"}]
+
+    result = await renderer._render_dog_views_batch(dogs, {})
+
+    assert result == [{"title": "Dog", "cards": []}]
+    renderer._render_single_dog_view.assert_awaited_once_with(dogs[0], 0, {})

--- a/tests/components/pawcontrol/test_dashboard_renderer.py
+++ b/tests/components/pawcontrol/test_dashboard_renderer.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-
 from custom_components.pawcontrol.dashboard_renderer import DashboardRenderer
 
 


### PR DESCRIPTION
## Summary
- guard the dashboard renderer batch logic so empty dog lists return immediately
- ensure the batch size never drops to zero when global limits change
- add regression tests covering empty lists and minimum batch sizing

## Testing
- `pytest tests/components/pawcontrol/test_dashboard_renderer.py` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68c9f13ebd448331850d5a9a966c98fc