### PR TITLE
Fix profile selector label formatting and add missing translations

### DIFF
--- a/custom_components/pawcontrol/config_flow_profile.py
+++ b/custom_components/pawcontrol/config_flow_profile.py
@@ -77,7 +77,7 @@ def get_profile_selector_options() -> list[dict[str, str]]:
             # Use second-person tone to match the global writing guidance.
             label_parts.append(description)
 
-        options.append({"value": profile, "label": " – ".join(label_parts)})
+        options.append({"value": profile, "label": " - ".join(label_parts)})
 
     return options
 

--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -198,6 +198,7 @@
       "door_sensor_not_found": "The selected door sensor entity was not found",
       "notification_service_not_found": "The selected notification service was not found",
       "invalid_notification_service": "The notification service format is invalid",
+      "invalid_profile": "You need to select a valid profile",
       "external_entity_validation_failed": "External entity validation failed",
       "reauth_unsuccessful": "Reauthentication was not successful",
       "wrong_account": "Wrong account - unique ID mismatch",

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -199,6 +199,7 @@
       "door_sensor_not_found": "Die ausgewählte Türsensor-Entität wurde nicht gefunden",
       "notification_service_not_found": "Der ausgewählte Benachrichtigungsdienst wurde nicht gefunden",
       "invalid_notification_service": "Das Format des Benachrichtigungsdienstes ist ungültig",
+      "invalid_profile": "Du musst ein gültiges Profil auswählen",
       "external_entity_validation_failed": "Validierung externer Entitäten fehlgeschlagen"
     },
     "abort": {

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -199,6 +199,7 @@
       "door_sensor_not_found": "The selected door sensor entity was not found",
       "notification_service_not_found": "The selected notification service was not found",
       "invalid_notification_service": "The notification service format is invalid",
+      "invalid_profile": "You need to select a valid profile",
       "external_entity_validation_failed": "External entity validation failed"
     },
     "abort": {


### PR DESCRIPTION
## Summary
- replace the en dash used in profile selector labels with a standard hyphen to satisfy the lint configuration
- add the missing `invalid_profile` error message to the base strings file and synchronize the English and German translations

## Testing
- ruff check
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*


------
https://chatgpt.com/codex/tasks/task_e_68ca022e905c8331a5ddcafa1e0f7a91