### PR TITLE
Fix coordinator interval scaling

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -609,7 +609,8 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # OPTIMIZE: Determine update frequency based on complexity with performance consideration
             if total_modules > 15:  # High complexity
-                interval = UPDATE_INTERVALS["balanced"]
+                # Use the most aggressive refresh rate to keep data in sync
+                interval = UPDATE_INTERVALS["real_time"]
             elif total_modules > 8:  # Medium complexity
                 interval = UPDATE_INTERVALS["frequent"]
             else:  # Low complexity


### PR DESCRIPTION
## Summary
- ensure the coordinator chooses the real-time refresh interval for high-complexity setups so data stays responsive

## Testing
- pytest tests/components/pawcontrol -q *(fails: missing pytest_homeassistant_custom_component)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0b2776d48331970df1f681866a36