### PR TITLE
Fix coordinator last_update timestamp format

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -20,6 +20,7 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
 from .const import (
     CONF_DOG_ID,
@@ -355,7 +356,8 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         data: dict[str, Any] = {
             "dog_info": dog_config,
             "status": "online",
-            "last_update": asyncio.get_running_loop().time(),
+            # Use wall-clock time to ensure other components can parse the timestamp.
+            "last_update": dt_util.utcnow().isoformat(),
         }
         modules = dog_config.get("modules", {})
 


### PR DESCRIPTION
## Summary
- store coordinator `last_update` timestamps using wall-clock UTC ISO strings so downstream components can parse them reliably
- import Home Assistant's datetime utility to provide timezone-aware timestamps

## Testing
- `pytest tests/components/pawcontrol/test_helpers.py -k online --maxfail=1` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68cac26ee810833181633da7af11ecd0