### PR TITLE
Normalize special diet configuration handling

### DIFF
--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -164,7 +164,7 @@ class FeedingConfigData(TypedDict, total=False):
     daily_food_amount: float | None
     meals_per_day: int
     food_type: str
-    special_diet: str | None
+    special_diet: list[str] | None
     portion_calculation: str
     automatic_feeding: bool  # OPTIMIZE: Added automatic feeding support
 


### PR DESCRIPTION
## Summary
- normalize stored special diet configuration so FeedingManager always works with trimmed string lists
- tighten FeedingConfigData typing to describe list-based special diet values

## Testing
- ruff check custom_components/pawcontrol/feeding_manager.py custom_components/pawcontrol/types.py
- pytest tests/components/pawcontrol/test_platforms.py *(fails: missing dependency pytest_homeassistant_custom_component)*

------
https://chatgpt.com/codex/tasks/task_e_68cacabde17083319de43d4cffb4d412