### PR TITLE
Fix system health backend reporting

### DIFF
--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from homeassistant.config_entries import ConfigEntry
+
 from homeassistant.components import system_health
 from homeassistant.core import HomeAssistant, callback
 
@@ -22,18 +24,61 @@ def async_register(
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Return basic system health information."""
 
-    entry = next(iter(hass.config_entries.async_entries(DOMAIN)), None)
-    runtime = getattr(entry, "runtime_data", None) if entry else None
-    api = getattr(runtime, "api", None) if runtime else None
-    remaining_quota = getattr(runtime, "remaining_quota", "unknown")
+    entry = _async_get_first_entry(hass)
+    if entry is None:
+        return {"can_reach_backend": False, "remaining_quota": "unknown"}
 
-    if not api or not getattr(api, "base_url", None):
-        return {"can_reach_backend": False, "remaining_quota": remaining_quota}
+    coordinator = _async_resolve_coordinator(hass, entry)
+    if coordinator is None:
+        return {"can_reach_backend": False, "remaining_quota": "unknown"}
 
-    can_reach_backend = await system_health.async_check_can_reach_url(
-        hass, api.base_url
-    )
+    stats = coordinator.get_update_statistics()
+    api_calls = stats["performance_metrics"].get("api_calls", 0)
+
+    if coordinator.use_external_api:
+        quota = entry.options.get("external_api_quota")
+        remaining_quota: int | str
+        if isinstance(quota, int) and quota >= 0:
+            remaining_quota = max(quota - api_calls, 0)
+        else:
+            remaining_quota = "untracked"
+    else:
+        remaining_quota = "unlimited"
+
     return {
-        "can_reach_backend": can_reach_backend,
+        "can_reach_backend": coordinator.last_update_success,
         "remaining_quota": remaining_quota,
     }
+
+
+def _async_get_first_entry(hass: HomeAssistant) -> ConfigEntry | None:
+    """Return the first loaded PawControl config entry."""
+
+    return next(iter(hass.config_entries.async_entries(DOMAIN)), None)
+
+
+def _async_resolve_coordinator(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> Any | None:
+    """Resolve the coordinator for system health lookups."""
+
+    runtime = getattr(entry, "runtime_data", None)
+    if runtime and getattr(runtime, "coordinator", None) is not None:
+        return runtime.coordinator
+
+    domain_data = hass.data.get(DOMAIN)
+    if not domain_data:
+        return None
+
+    if (entry_store := domain_data.get(entry.entry_id)) and isinstance(
+        entry_store, dict
+    ):
+        coordinator = entry_store.get("coordinator")
+        if coordinator is not None:
+            return coordinator
+
+        runtime = entry_store.get("runtime_data")
+        if runtime and getattr(runtime, "coordinator", None) is not None:
+            return runtime.coordinator
+
+    return domain_data.get("coordinator")

--- a/custom_components/pawcontrol/system_health.py
+++ b/custom_components/pawcontrol/system_health.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.config_entries import ConfigEntry
-
 from homeassistant.components import system_health
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
@@ -57,9 +56,7 @@ def _async_get_first_entry(hass: HomeAssistant) -> ConfigEntry | None:
     return next(iter(hass.config_entries.async_entries(DOMAIN)), None)
 
 
-def _async_resolve_coordinator(
-    hass: HomeAssistant, entry: ConfigEntry
-) -> Any | None:
+def _async_resolve_coordinator(hass: HomeAssistant, entry: ConfigEntry) -> Any | None:
     """Resolve the coordinator for system health lookups."""
 
     runtime = getattr(entry, "runtime_data", None)

--- a/tests/components/pawcontrol/test_system_health.py
+++ b/tests/components/pawcontrol/test_system_health.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
 
 import pytest
 from custom_components.pawcontrol import system_health as system_health_module
@@ -26,3 +27,57 @@ async def test_system_health_no_api(hass: HomeAssistant) -> None:
     assert info["can_reach_backend"] is False
     assert info["remaining_quota"] == "unknown"
     mock_check.assert_not_called()
+
+
+async def test_system_health_reports_coordinator_status(
+    hass: HomeAssistant,
+) -> None:
+    """Use coordinator statistics when runtime data is available."""
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.use_external_api = False
+    coordinator.get_update_statistics.return_value = {
+        "performance_metrics": {"api_calls": 3}
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Paw Control", "dogs": []},
+        unique_id="coordinator-entry",
+    )
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+    entry.add_to_hass(hass)
+
+    info = await system_health_module.system_health_info(hass)
+
+    assert info["can_reach_backend"] is True
+    assert info["remaining_quota"] == "unlimited"
+    coordinator.get_update_statistics.assert_called_once()
+
+
+async def test_system_health_reports_external_quota(
+    hass: HomeAssistant,
+) -> None:
+    """Report remaining quota when external API tracking is enabled."""
+
+    coordinator = MagicMock()
+    coordinator.last_update_success = True
+    coordinator.use_external_api = True
+    coordinator.get_update_statistics.return_value = {
+        "performance_metrics": {"api_calls": 7}
+    }
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"name": "Paw Control", "dogs": []},
+        options={"external_api_quota": 10},
+        unique_id="quota-entry",
+    )
+    entry.runtime_data = SimpleNamespace(coordinator=coordinator)
+    entry.add_to_hass(hass)
+
+    info = await system_health_module.system_health_info(hass)
+
+    assert info["can_reach_backend"] is True
+    assert info["remaining_quota"] == 3


### PR DESCRIPTION
## Summary
- derive PawControl system health metrics from the active coordinator instead of an undefined API client
- surface whether the backend is reachable and expose quota details when external API tracking is enabled
- extend system health tests to cover coordinator driven reporting and quota calculations

## Testing
- `pytest tests/components/pawcontrol/test_system_health.py -q`
- `pytest tests/components/pawcontrol -q`


------
https://chatgpt.com/codex/tasks/task_e_68cad99def748331862e5c4d6ecd4436