### PR TITLE
Use CoordinatorUpdateFailed in coordinator

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -19,7 +19,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.helpers.update_coordinator import (
+    CoordinatorUpdateFailed,
+    DataUpdateCoordinator,
+)
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -181,7 +184,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             Dictionary mapping dog_id to dog data
 
         Raises:
-            UpdateFailed: If critical errors occur or all dogs fail
+            CoordinatorUpdateFailed: If critical errors occur or all dogs fail
         """
         # OPTIMIZE: Handle empty dogs list edge case efficiently
         if not self.dogs:
@@ -263,7 +266,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if errors == len(self.dogs) and len(self.dogs) > 0:
             self._performance_metrics["error_count"] += 1
             error_summary = "; ".join(error_details[:3])  # Limit error message length
-            raise UpdateFailed(f"All dogs failed to update: {error_summary}")
+            raise CoordinatorUpdateFailed(
+                f"All dogs failed to update: {error_summary}"
+            )
 
         # Log partial failures for monitoring
         if errors > 0:

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -266,9 +266,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if errors == len(self.dogs) and len(self.dogs) > 0:
             self._performance_metrics["error_count"] += 1
             error_summary = "; ".join(error_details[:3])  # Limit error message length
-            raise CoordinatorUpdateFailed(
-                f"All dogs failed to update: {error_summary}"
-            )
+            raise CoordinatorUpdateFailed(f"All dogs failed to update: {error_summary}")
 
         # Log partial failures for monitoring
         if errors > 0:


### PR DESCRIPTION
## Summary
- switch the coordinator to import `CoordinatorUpdateFailed`
- raise the new exception when all dog updates fail and update the docstring accordingly

## Testing
- `pytest tests/components/pawcontrol/test_platforms.py -k nothing` *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*
- `ruff check custom_components/pawcontrol/coordinator.py`


------
https://chatgpt.com/codex/tasks/task_e_68caddf6104c8331845197e34288c17f