### PR TITLE
Fix performance monitor decorator import and usage

### DIFF
--- a/custom_components/pawcontrol/date.py
+++ b/custom_components/pawcontrol/date.py
@@ -40,7 +40,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .exceptions import PawControlError, ValidationError
-from .utils import performance_monitor
+from .helpers import performance_monitor
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary
- make the performance monitor callable so it can be used as a decorator for both async and sync integration helpers
- add timeout-aware logging and execution tracking to the decorator implementation
- fix the date platform to import the performance monitor from the helpers module

## Testing
- ruff check custom_components/pawcontrol/helpers.py custom_components/pawcontrol/date.py
- ruff format --check custom_components/pawcontrol/helpers.py custom_components/pawcontrol/date.py
- pytest *(fails: ModuleNotFoundError: No module named 'pytest_homeassistant_custom_component')*

------
https://chatgpt.com/codex/tasks/task_e_68cae0ea709c8331bee26398586d0910