### PR TITLE
Fix coordinator update failure handling

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -19,10 +19,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.event import async_track_time_interval
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorUpdateFailed,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
 from .const import (
@@ -184,7 +181,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             Dictionary mapping dog_id to dog data
 
         Raises:
-            CoordinatorUpdateFailed: If critical errors occur or all dogs fail
+            UpdateFailed: If critical errors occur or all dogs fail
         """
         # OPTIMIZE: Handle empty dogs list edge case efficiently
         if not self.dogs:
@@ -266,7 +263,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if errors == len(self.dogs) and len(self.dogs) > 0:
             self._performance_metrics["error_count"] += 1
             error_summary = "; ".join(error_details[:3])  # Limit error message length
-            raise CoordinatorUpdateFailed(f"All dogs failed to update: {error_summary}")
+            raise UpdateFailed(f"All dogs failed to update: {error_summary}")
 
         # Log partial failures for monitoring
         if errors > 0:


### PR DESCRIPTION
## Summary
- replace the deprecated `CoordinatorUpdateFailed` import with the supported `UpdateFailed`
- update coordinator documentation to reflect the new exception type

## Testing
- pytest
- ruff check custom_components/pawcontrol


------
https://chatgpt.com/codex/tasks/task_e_68cae653b87c83318435a4e12f1274c4