### PR TITLE
Add aiofiles requirement to manifest

### DIFF
--- a/custom_components/pawcontrol/manifest.json
+++ b/custom_components/pawcontrol/manifest.json
@@ -47,7 +47,9 @@
     "custom_components.pawcontrol"
   ],
   "quality_scale": "platinum",
-  "requirements": [],
+  "requirements": [
+    "aiofiles>=23.1.0"
+  ],
   "usb": [
     {
       "vid": "1234",


### PR DESCRIPTION
## Summary
- declare the aiofiles dependency in the integration manifest so Home Assistant installs it automatically

## Testing
- not run (third-party Home Assistant test dependencies are too heavy for this environment)


------
https://chatgpt.com/codex/tasks/task_e_68cae9864398833184ac2d5e38745212