### PR TITLE
Fix cache truthiness handling

### DIFF
--- a/custom_components/pawcontrol/config_flow.py
+++ b/custom_components/pawcontrol/config_flow.py
@@ -644,7 +644,7 @@ class PawControlConfigFlow(ConfigFlow, domain=DOMAIN):
         cached_entry = self._validation_cache.get(cache_key)
         now = dt_util.utcnow()
 
-        if cached_entry:
+        if cached_entry is not None:
             cached_result, cache_time, cached_state = cached_entry
             if (
                 cached_state == state_signature

--- a/custom_components/pawcontrol/config_flow_dogs.py
+++ b/custom_components/pawcontrol/config_flow_dogs.py
@@ -976,7 +976,7 @@ class DogManagementMixin:
 
             # Check cache first for performance
             cache_key = self._create_cache_key(dog_id, dog_name, user_input)
-            if cached := self._get_cached_validation(cache_key):
+            if (cached := self._get_cached_validation(cache_key)) is not None:
                 return cached
 
             # Enhanced dog ID validation
@@ -1027,9 +1027,8 @@ class DogManagementMixin:
 
     def _get_cached_validation(self, cache_key: str) -> dict[str, Any] | None:
         cached = self._validation_cache.get(cache_key)
-        if (
-            cached
-            and cached.get("timestamp", 0) > asyncio.get_running_loop().time() - 5
+        if cached is not None and (
+            cached.get("timestamp", 0) > asyncio.get_running_loop().time() - 5
         ):
             return cached["result"]
         return None

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -249,8 +249,7 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     async def _get_feeding_data(self, dog_id: str) -> dict[str, Any]:
         """Get feeding data for dog."""
         cache_key = f"feeding_{dog_id}"
-        cached = self._get_cache(cache_key)
-        if cached:
+        if (cached := self._get_cache(cache_key)) is not None:
             return cached
 
         try:

--- a/custom_components/pawcontrol/dashboard_templates.py
+++ b/custom_components/pawcontrol/dashboard_templates.py
@@ -374,7 +374,7 @@ class DashboardTemplates:
 
         # Try cache first
         cached = await self._cache.get(cache_key)
-        if cached:
+        if cached is not None:
             return cached
 
         # Generate template
@@ -497,7 +497,7 @@ class DashboardTemplates:
         cache_key = f"action_buttons_{dog_id}_{hash(frozenset(modules.items()))}_{theme}_{layout}"
 
         cached = await self._cache.get(cache_key)
-        if cached:
+        if cached is not None:
             return cached.get("buttons", [])
 
         base_button = self._get_base_card_template("button")

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -1293,7 +1293,7 @@ class PawControlNotificationManager:
         cache_key = f"quiet_hours_{priority}"
 
         cached = self._quiet_hours_cache.get(cache_key)
-        if cached:
+        if cached is not None:
             cached_result, cache_time = cached
             if (dt_util.utcnow() - cache_time).total_seconds() < 60:
                 return cached_result

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -662,7 +662,7 @@ class PawControlNotificationManager:
         """
         # Check cache first
         cached_config = self._cache.get_config(config_key)
-        if cached_config:
+        if cached_config is not None:
             self._performance_metrics["cache_hits"] += 1
             return cached_config
 

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -226,7 +226,7 @@ class PawControlOptionsFlow(OptionsFlow):
         )
 
         cached = self._profile_cache.get(cache_key)
-        if cached:
+        if cached is not None:
             return cached
 
         total_estimate = 0
@@ -305,7 +305,7 @@ class PawControlOptionsFlow(OptionsFlow):
         )
 
         cached_preview = self._entity_estimates_cache.get(cache_key)
-        if cached_preview:
+        if cached_preview is not None:
             return cached_preview
 
         entity_breakdown: list[dict[str, Any]] = []

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -318,7 +318,7 @@ class WalkManager:
 
             # OPTIMIZE: Get previous location from cache for better performance
             cached_location = self._gps_cache.get_location(dog_id)
-            if cached_location:
+            if cached_location is not None:
                 old_location = (cached_location[0], cached_location[1])
                 self._performance_metrics["cache_hits"] += 1
             elif (
@@ -450,7 +450,7 @@ class WalkManager:
             # OPTIMIZE: Get current location from cache first
             start_location = None
             cached_location = self._gps_cache.get_location(dog_id)
-            if cached_location:
+            if cached_location is not None:
                 start_location = {
                     "latitude": cached_location[0],
                     "longitude": cached_location[1],
@@ -540,7 +540,7 @@ class WalkManager:
             # OPTIMIZE: Get end location from cache if available
             end_location = None
             cached_location = self._gps_cache.get_location(dog_id)
-            if cached_location:
+            if cached_location is not None:
                 end_location = {
                     "latitude": cached_location[0],
                     "longitude": cached_location[1],


### PR DESCRIPTION
## Summary
- ensure cached data handling uses explicit None checks so empty payloads are preserved across coordinator, dashboard templates, options flow, config flows, notifications, and walk manager
- keep notification quiet-hour cache lookups consistent when suppressing alerts

## Type of change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Docs/CI only

## Checklist
- [ ] Tests added/updated
- [ ] Docs updated (README/QUALITY_CHECKLIST)
- [ ] CI green
- [ ] Linked issue

## Related
Repo: https://github.com/Bigdaddy1990/pawcontrol

------
https://chatgpt.com/codex/tasks/task_e_68cb6357624c83319d8248209181d96c