### PR TITLE
Improve diet safety typing

### DIFF
--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -16,6 +16,7 @@ from homeassistant.util import dt as dt_util
 try:  # pragma: no cover - fallback for direct test execution
     from .health_calculator import (
         ActivityLevel,
+        DietSafetyResult,
         HealthCalculator,
         HealthMetrics,
         LifeStage,
@@ -23,6 +24,7 @@ try:  # pragma: no cover - fallback for direct test execution
 except ImportError:  # pragma: no cover
     from custom_components.pawcontrol.health_calculator import (
         ActivityLevel,
+        DietSafetyResult,
         HealthCalculator,
         HealthMetrics,
         LifeStage,
@@ -1728,6 +1730,7 @@ class FeedingManager:
                     portion = max(portion, 7 * config.dog_weight)
 
                 # Validate portion safety with diet considerations
+                safety_result: DietSafetyResult
                 if config.dog_weight and portion > 0:
                     safety_result = HealthCalculator.validate_portion_safety(
                         calculated_portion=portion,
@@ -1743,6 +1746,7 @@ class FeedingManager:
                         "safe": True,
                         "warnings": [],
                         "recommendations": [],
+                        "portion_per_kg": 0.0,
                     }
 
                 # Include diet validation info

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -17,7 +17,7 @@ import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from datetime import datetime, time, timedelta
 from functools import wraps
-from typing import Any, ParamSpec, TypeVar, cast
+from typing import Any, ParamSpec, TypedDict, TypeVar, cast
 
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.util import dt as dt_util
@@ -32,6 +32,15 @@ K = TypeVar("K")
 V = TypeVar("V")
 P = ParamSpec("P")
 R = TypeVar("R")
+
+
+class PortionValidationResult(TypedDict):
+    """Validation outcome for a single portion size."""
+
+    valid: bool
+    warnings: list[str]
+    recommendations: list[str]
+    percentage_of_daily: float
 
 
 def create_device_info(dog_id: str, dog_name: str, **kwargs: Any) -> DeviceInfo:
@@ -392,7 +401,7 @@ def calculate_bmi_equivalent(weight_kg: float, breed_size: str) -> float | None:
 
 def validate_portion_size(
     portion: float, daily_amount: float, meals_per_day: int = 2
-) -> dict[str, Any]:
+) -> PortionValidationResult:
     """Validate portion size against daily requirements.
 
     Args:
@@ -403,7 +412,7 @@ def validate_portion_size(
     Returns:
         Validation result with warnings and recommendations
     """
-    result = {
+    result: PortionValidationResult = {
         "valid": True,
         "warnings": [],
         "recommendations": [],


### PR DESCRIPTION
## Summary
- introduce structured `DietSafetyResult` and `DietInteractionDetails` TypedDicts to document diet safety and interaction outputs
- reuse the new types in the feeding manager and provide a default diet safety payload when no calculation is possible
- add a `PortionValidationResult` TypedDict for the portion validator helper to keep strict typing consistent

## Testing
- `mypy custom_components/pawcontrol/health_calculator.py custom_components/pawcontrol/utils.py custom_components/pawcontrol/feeding_manager.py` *(fails: mypy surfaces numerous pre-existing type errors in other modules that import these files)*
- `pytest` *(fails: missing pytest_homeassistant_custom_component dependency in the environment)*
- `ruff check custom_components/pawcontrol/health_calculator.py custom_components/pawcontrol/utils.py custom_components/pawcontrol/feeding_manager.py`


------
https://chatgpt.com/codex/tasks/task_e_68cb7c445e4c8331852068c2d7f7e9ff