### PR TITLE
Fix platform ordering and add pytest compatibility shims

### DIFF
--- a/pytest_homeassistant_custom_component/__init__.py
+++ b/pytest_homeassistant_custom_component/__init__.py
@@ -21,6 +21,7 @@ def _ensure_uuid_compatibility() -> None:
     """Provide the private UUID helpers expected by older dependencies."""
 
     if not hasattr(uuid, "_uuid_generate_time"):
+
         def _uuid_generate_time() -> bytes:
             generated = uuid._generate_time_safe()  # type: ignore[attr-defined]
             return generated[0]
@@ -28,6 +29,7 @@ def _ensure_uuid_compatibility() -> None:
         uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
 
     if not hasattr(uuid, "_load_system_functions"):
+
         def _load_system_functions() -> None:
             if not hasattr(uuid, "_uuid_generate_time"):
                 uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]

--- a/pytest_homeassistant_custom_component/__init__.py
+++ b/pytest_homeassistant_custom_component/__init__.py
@@ -1,0 +1,73 @@
+"""Compatibility shim for pytest-homeassistant-custom-component on Python 3.13.
+
+The upstream package depends on `freezegun`, which still reaches into
+private CPython UUID helpers that were removed in Python 3.13.  Importing
+the real package would fail before our tests run.  We patch the `uuid`
+module first and then load the actual distribution from site-packages.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+import types
+import uuid
+
+_PACKAGE_NAME = __name__
+
+
+def _ensure_uuid_compatibility() -> None:
+    """Provide the private UUID helpers expected by older dependencies."""
+
+    if not hasattr(uuid, "_uuid_generate_time"):
+        def _uuid_generate_time() -> bytes:
+            generated = uuid._generate_time_safe()  # type: ignore[attr-defined]
+            return generated[0]
+
+        uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
+
+    if not hasattr(uuid, "_load_system_functions"):
+        def _load_system_functions() -> None:
+            if not hasattr(uuid, "_uuid_generate_time"):
+                uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
+
+        uuid._load_system_functions = _load_system_functions  # type: ignore[attr-defined]
+
+    if not hasattr(uuid, "_UuidCreate"):
+        uuid._UuidCreate = types.SimpleNamespace  # type: ignore[attr-defined]
+
+
+def _load_real_package() -> types.ModuleType:
+    """Load the real distribution from site-packages.
+
+    We temporarily skip the project root (the first entry on ``sys.path``)
+    so that the import machinery can locate the installed package instead
+    of this shim module.
+    """
+
+    for base in sys.path[1:]:
+        candidate = pathlib.Path(base) / _PACKAGE_NAME / "__init__.py"
+        if candidate.exists():
+            spec = importlib.util.spec_from_file_location(
+                f"{_PACKAGE_NAME}.__real__",
+                candidate,
+                submodule_search_locations=[str(candidate.parent)],
+            )
+            if spec and spec.loader:
+                module = importlib.util.module_from_spec(spec)
+                sys.modules.setdefault(spec.name, module)
+                spec.loader.exec_module(module)
+                return module
+    raise ModuleNotFoundError(
+        f"Could not locate the real {_PACKAGE_NAME} distribution for compatibility shim"
+    )
+
+
+_ensure_uuid_compatibility()
+_real_module = _load_real_package()
+
+globals().update({key: getattr(_real_module, key) for key in dir(_real_module)})
+__all__ = getattr(_real_module, "__all__", [])
+__path__ = getattr(_real_module, "__path__", [])
+sys.modules[_PACKAGE_NAME] = _real_module

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,58 @@
+"""Runtime patches for compatibility with third-party dependencies.
+
+This project runs on Python 3.13 during testing, but some third-party
+packages that ship with the test suite still expect private helpers from
+`uuid` that were removed in Python 3.13.  The Home Assistant test helper
+`pytest-homeassistant-custom-component` depends on `freezegun`, which
+tries to import ``uuid._uuid_generate_time`` and ``uuid._load_system_functions``.
+Without shims the import fails before our tests even start.  We provide a
+minimal, well-documented compatibility layer so that those modules can be
+imported safely on modern Python versions.  The helpers delegate to the
+public ``uuid._generate_time_safe`` implementation available since Python
+3.8, keeping behaviour consistent with CPython's previous private APIs.
+"""
+
+from __future__ import annotations
+
+import types
+import uuid
+
+if not hasattr(uuid, "_uuid_generate_time"):
+    def _uuid_generate_time() -> bytes:
+        """Return a time-based UUID byte sequence.
+
+        This mirrors the return type of the legacy private CPython helper
+        that `freezegun` expects.  ``uuid._generate_time_safe`` returns a
+        tuple of ``(bytes, clock_seq)`` so we only expose the first element
+        to match the historical API.
+        """
+
+        generated = uuid._generate_time_safe()  # type: ignore[attr-defined]
+        # `_generate_time_safe` returns ``(bytes, clock_seq)``; the legacy
+        # helper only returned the raw bytes payload used to build UUID1
+        # instances.
+        return generated[0]
+
+    uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
+
+if not hasattr(uuid, "_load_system_functions"):
+    def _load_system_functions() -> None:
+        """Compatibility no-op for removed CPython internals.
+
+        Older versions of ``freezegun`` call this helper during import to
+        populate the private ``_uuid_generate_time`` attribute.  Our shim
+        ensures that attribute is available above, so the function simply
+        verifies it exists.
+        """
+
+        if not hasattr(uuid, "_uuid_generate_time"):
+            uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
+
+    uuid._load_system_functions = _load_system_functions  # type: ignore[attr-defined]
+
+# ``freezegun`` also checks for ``uuid._UuidCreate`` on Windows.  That
+# attribute still exists on Python 3.13 when running on Windows, but the
+# tests execute on Linux where it is missing.  The import only needs the
+# attribute to exist so we provide a stub matching the old behaviour.
+if not hasattr(uuid, "_UuidCreate"):
+    uuid._UuidCreate = types.SimpleNamespace  # type: ignore[attr-defined]

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -18,6 +18,7 @@ import types
 import uuid
 
 if not hasattr(uuid, "_uuid_generate_time"):
+
     def _uuid_generate_time() -> bytes:
         """Return a time-based UUID byte sequence.
 
@@ -36,6 +37,7 @@ if not hasattr(uuid, "_uuid_generate_time"):
     uuid._uuid_generate_time = _uuid_generate_time  # type: ignore[attr-defined]
 
 if not hasattr(uuid, "_load_system_functions"):
+
     def _load_system_functions() -> None:
         """Compatibility no-op for removed CPython internals.
 


### PR DESCRIPTION
## Summary
- return a deterministic tuple of platforms from `get_platforms_for_profile_and_modules`
- add compatibility shims so `pytest-homeassistant-custom-component` can run on Python 3.13

## Testing
- not run (dependency constraints for pytest-homeassistant-custom-component on Python 3.13)


------
https://chatgpt.com/codex/tasks/task_e_68cb7c445e4c8331852068c2d7f7e9ff