### PR TITLE
Adapt integration to new HA service info and unit translations

### DIFF
--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -16,6 +16,7 @@ from homeassistant.components.number import NumberDeviceClass, NumberEntity, Num
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfEnergy,
     UnitOfLength,
     UnitOfMass,
     UnitOfSpeed,
@@ -307,6 +308,7 @@ class PawControlNumberBase(
         icon: str | None = None,
         entity_category: EntityCategory | None = None,
         initial_value: float | None = None,
+        translation_key: str | None = None,
     ) -> None:
         """Initialize the number entity.
 
@@ -335,6 +337,7 @@ class PawControlNumberBase(
         # Entity configuration
         self._attr_unique_id = f"pawcontrol_{dog_id}_{number_type}"
         self._attr_name = f"{dog_name} {number_type.replace('_', ' ').title()}"
+        self._attr_translation_key = translation_key
         self._attr_device_class = device_class
         self._attr_mode = mode
         self._attr_native_unit_of_measurement = native_unit_of_measurement
@@ -534,6 +537,7 @@ class PawControlDogWeightNumber(PawControlNumberBase):
             native_step=0.1,
             icon="mdi:scale",
             initial_value=current_weight,
+            translation_key="weight",
         )
 
     async def _async_set_number_value(self, value: float) -> None:
@@ -584,13 +588,14 @@ class PawControlDogAgeNumber(PawControlNumberBase):
             dog_name,
             "age",
             mode=NumberMode.BOX,
-            native_unit_of_measurement="years",
+            native_unit_of_measurement=UnitOfTime.YEARS,
             native_min_value=MIN_DOG_AGE,
             native_max_value=MAX_DOG_AGE,
             native_step=1,
             icon="mdi:calendar",
             entity_category=EntityCategory.CONFIG,
             initial_value=current_age,
+            translation_key="age",
         )
 
     async def _async_set_number_value(self, value: float) -> None:
@@ -657,12 +662,13 @@ class PawControlDailyFoodAmountNumber(PawControlNumberBase):
             dog_name,
             "daily_food_amount",
             mode=NumberMode.BOX,
-            native_unit_of_measurement="g",
+            native_unit_of_measurement=UnitOfMass.GRAMS,
             native_min_value=50,
             native_max_value=2000,
             native_step=10,
             icon="mdi:food",
             initial_value=300,
+            translation_key="daily_food_amount",
         )
 
     async def _async_set_number_value(self, value: float) -> None:
@@ -768,12 +774,13 @@ class PawControlPortionSizeNumber(PawControlNumberBase):
             dog_name,
             "portion_size",
             mode=NumberMode.BOX,
-            native_unit_of_measurement="g",
+            native_unit_of_measurement=UnitOfMass.GRAMS,
             native_min_value=10,
             native_max_value=500,
             native_step=5,
             icon="mdi:food-variant",
             initial_value=150,
+            translation_key="portion_size",
         )
 
     async def _async_set_number_value(self, value: float) -> None:
@@ -795,12 +802,13 @@ class PawControlCalorieTargetNumber(PawControlNumberBase):
             dog_name,
             "calorie_target",
             mode=NumberMode.BOX,
-            native_unit_of_measurement="kcal",
+            native_unit_of_measurement=UnitOfEnergy.KILO_CALORIE,
             native_min_value=200,
             native_max_value=3000,
             native_step=50,
             icon="mdi:fire",
             initial_value=800,
+            translation_key="calorie_target",
         )
 
     async def _async_set_number_value(self, value: float) -> None:
@@ -1179,12 +1187,13 @@ class PawControlVetCheckupIntervalNumber(PawControlNumberBase):
             dog_name,
             "vet_checkup_interval",
             mode=NumberMode.BOX,
-            native_unit_of_measurement="months",
+            native_unit_of_measurement=UnitOfTime.MONTHS,
             native_min_value=3,
             native_max_value=24,
             native_step=3,
             icon="mdi:medical-bag",
             initial_value=12,
+            translation_key="vet_checkup_interval",
         )
 
     async def _async_set_number_value(self, value: float) -> None:

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -14,7 +14,15 @@ from homeassistant.components.sensor import (
     SensorEntity,
     SensorStateClass,
 )
-from homeassistant.const import PERCENTAGE, STATE_UNKNOWN
+from homeassistant.const import (
+    PERCENTAGE,
+    STATE_UNKNOWN,
+    UnitOfEnergy,
+    UnitOfLength,
+    UnitOfMass,
+    UnitOfSpeed,
+    UnitOfTime,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -358,6 +366,7 @@ class PawControlSensorBase(CoordinatorEntity[PawControlCoordinator], SensorEntit
         unit_of_measurement: str | None = None,
         icon: str | None = None,
         entity_category: EntityCategory | None = None,
+        translation_key: str | None = None,
     ) -> None:
         """Initialize base sensor with performance optimizations."""
         super().__init__(coordinator)
@@ -366,6 +375,7 @@ class PawControlSensorBase(CoordinatorEntity[PawControlCoordinator], SensorEntit
         self._sensor_type = sensor_type
         self._attr_unique_id = f"pawcontrol_{dog_id}_{sensor_type}"
         self._attr_name = f"{dog_name} {sensor_type.replace('_', ' ').title()}"
+        self._attr_translation_key = translation_key
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_native_unit_of_measurement = unit_of_measurement
@@ -769,8 +779,9 @@ class PawControlDailyCaloriesSensor(PawControlSensorBase):
             dog_name,
             "daily_calories",
             state_class=SensorStateClass.TOTAL_INCREASING,
-            unit_of_measurement="kcal",
+            unit_of_measurement=UnitOfEnergy.KILO_CALORIE,
             icon="mdi:fire",
+            translation_key="daily_calories",
         )
 
     @property
@@ -858,8 +869,9 @@ class PawControlHealthAwarePortionSensor(PawControlSensorBase):
             dog_name,
             "health_aware_portion",
             state_class=SensorStateClass.MEASUREMENT,
-            unit_of_measurement="g",
+            unit_of_measurement=UnitOfMass.GRAMS,
             icon="mdi:scale",
+            translation_key="health_aware_portion",
         )
 
     @property
@@ -1060,8 +1072,9 @@ class PawControlWalkDistanceTodaySensor(PawControlSensorBase):
             dog_name,
             "walk_distance_today",
             state_class=SensorStateClass.TOTAL_INCREASING,
-            unit_of_measurement="m",
+            unit_of_measurement=UnitOfLength.METERS,
             icon="mdi:map-marker-path",
+            translation_key="walk_distance_today",
         )
 
     @property
@@ -1115,8 +1128,9 @@ class PawControlLastWalkDurationSensor(PawControlSensorBase):
             dog_name,
             "last_walk_duration",
             device_class=SensorDeviceClass.DURATION,
-            unit_of_measurement="min",
+            unit_of_measurement=UnitOfTime.MINUTES,
             icon="mdi:timer",
+            translation_key="last_walk_duration",
         )
 
     @property
@@ -1146,8 +1160,9 @@ class PawControlLastWalkDistanceSensor(PawControlSensorBase):
             dog_name,
             "last_walk_distance",
             state_class=SensorStateClass.MEASUREMENT,
-            unit_of_measurement="m",
+            unit_of_measurement=UnitOfLength.METERS,
             icon="mdi:map-marker-path",
+            translation_key="last_walk_distance",
         )
 
     @property
@@ -1178,8 +1193,9 @@ class PawControlTotalWalkTimeTodaySensor(PawControlSensorBase):
             "total_walk_time_today",
             state_class=SensorStateClass.TOTAL_INCREASING,
             device_class=SensorDeviceClass.DURATION,
-            unit_of_measurement="min",
+            unit_of_measurement=UnitOfTime.MINUTES,
             icon="mdi:timer-sand",
+            translation_key="total_walk_time_today",
         )
 
     @property
@@ -1209,8 +1225,9 @@ class PawControlAverageWalkDurationSensor(PawControlSensorBase):
             "average_walk_duration",
             state_class=SensorStateClass.MEASUREMENT,
             device_class=SensorDeviceClass.DURATION,
-            unit_of_measurement="min",
+            unit_of_measurement=UnitOfTime.MINUTES,
             icon="mdi:timer-outline",
+            translation_key="average_walk_duration",
         )
 
     @property
@@ -1262,8 +1279,9 @@ class PawControlDistanceFromHomeSensor(PawControlSensorBase):
             dog_name,
             "distance_from_home",
             state_class=SensorStateClass.MEASUREMENT,
-            unit_of_measurement="m",
+            unit_of_measurement=UnitOfLength.METERS,
             icon="mdi:map-marker-distance",
+            translation_key="distance_from_home",
         )
 
     @property
@@ -1293,8 +1311,9 @@ class PawControlCurrentSpeedSensor(PawControlSensorBase):
             dog_name,
             "current_speed",
             state_class=SensorStateClass.MEASUREMENT,
-            unit_of_measurement="km/h",
+            unit_of_measurement=UnitOfSpeed.KILOMETERS_PER_HOUR,
             icon="mdi:speedometer",
+            translation_key="current_speed",
         )
 
     @property
@@ -1324,8 +1343,9 @@ class PawControlGPSAccuracySensor(PawControlSensorBase):
             dog_name,
             "gps_accuracy",
             state_class=SensorStateClass.MEASUREMENT,
-            unit_of_measurement="m",
+            unit_of_measurement=UnitOfLength.METERS,
             icon="mdi:crosshairs-gps",
+            translation_key="gps_accuracy",
         )
 
     @property
@@ -1416,8 +1436,9 @@ class PawControlWeightSensor(PawControlSensorBase):
             "weight",
             state_class=SensorStateClass.MEASUREMENT,
             device_class=SensorDeviceClass.WEIGHT,
-            unit_of_measurement="kg",
+            unit_of_measurement=UnitOfMass.KILOGRAMS,
             icon="mdi:scale-bathroom",
+            translation_key="weight",
         )
 
     @property

--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -347,13 +347,16 @@
         "name": "Current Location"
       },
       "distance_from_home": {
-        "name": "Distance from Home"
+        "name": "Distance from Home",
+        "unit_of_measurement": "m"
       },
       "gps_accuracy": {
-        "name": "GPS Accuracy"
+        "name": "GPS Accuracy",
+        "unit_of_measurement": "m"
       },
       "current_speed": {
-        "name": "Current Speed"
+        "name": "Current Speed",
+        "unit_of_measurement": "km/h"
       },
       "current_weight": {
         "name": "Current Weight"
@@ -369,6 +372,38 @@
       },
       "activity_level": {
         "name": "Activity Level"
+      },
+      "daily_calories": {
+        "name": "Daily Calorie Intake",
+        "unit_of_measurement": "kcal"
+      },
+      "health_aware_portion": {
+        "name": "Health-Aware Portion",
+        "unit_of_measurement": "g"
+      },
+      "walk_distance_today": {
+        "name": "Walk Distance Today",
+        "unit_of_measurement": "m"
+      },
+      "last_walk_duration": {
+        "name": "Last Walk Duration",
+        "unit_of_measurement": "min"
+      },
+      "last_walk_distance": {
+        "name": "Last Walk Distance",
+        "unit_of_measurement": "m"
+      },
+      "total_walk_time_today": {
+        "name": "Total Walk Time Today",
+        "unit_of_measurement": "min"
+      },
+      "average_walk_duration": {
+        "name": "Average Walk Duration",
+        "unit_of_measurement": "min"
+      },
+      "weight": {
+        "name": "Weight",
+        "unit_of_measurement": "kg"
       }
     },
     "binary_sensor": {
@@ -598,16 +633,19 @@
     },
     "number": {
       "weight": {
-        "name": "Weight"
+        "name": "Weight",
+        "unit_of_measurement": "kg"
       },
       "age": {
-        "name": "Age"
+        "name": "Age",
+        "unit_of_measurement": "y"
       },
       "activity_goal": {
         "name": "Activity Goal"
       },
       "daily_food_amount": {
-        "name": "Daily Food Amount"
+        "name": "Daily Food Amount",
+        "unit_of_measurement": "g"
       },
       "feeding_reminder_hours": {
         "name": "Feeding Reminder Hours"
@@ -616,10 +654,12 @@
         "name": "Meals Per Day"
       },
       "portion_size": {
-        "name": "Portion Size"
+        "name": "Portion Size",
+        "unit_of_measurement": "g"
       },
       "calorie_target": {
-        "name": "Calorie Target"
+        "name": "Calorie Target",
+        "unit_of_measurement": "kcal"
       },
       "daily_walk_target": {
         "name": "Daily Walk Target"
@@ -661,7 +701,8 @@
         "name": "Grooming Interval"
       },
       "vet_checkup_interval": {
-        "name": "Vet Checkup Interval"
+        "name": "Vet Checkup Interval",
+        "unit_of_measurement": "m"
       },
       "health_score_threshold": {
         "name": "Health Score Threshold"


### PR DESCRIPTION
## Summary
- update the config flow to consume DhcpServiceInfo and ZeroconfServiceInfo from the new helper modules and read their attributes directly
- adjust sensor and number bases and platform entities to use Home Assistant unit enums and provide translation keys for unit localization
- add unit_of_measurement metadata to the corresponding entries in strings.json for the new translation workflow

## Testing
- pytest *(fails: pytest_homeassistant_custom_component is unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce37949394833198ef4fb8e513c96a