### PR TITLE
Fix device tracker state attribute overrides

### DIFF
--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -864,27 +864,3 @@ class PawControlDeviceTracker(
 
         return total_distance
 
-    @property
-    def state_attributes(self) -> AttributeDict:
-        """Return state attributes for the device tracker.
-
-        Combines base tracker attributes with custom Paw Control attributes
-        for comprehensive tracking information.
-
-        Returns:
-            Complete state attributes dictionary
-        """
-        attrs = super().extra_state_attributes or {}
-
-        # Add coordinate information
-        if self.latitude is not None:
-            attrs[ATTR_LATITUDE] = self.latitude
-        if self.longitude is not None:
-            attrs[ATTR_LONGITUDE] = self.longitude
-        if self.location_accuracy:
-            attrs[ATTR_GPS_ACCURACY] = self.location_accuracy
-
-        # Add source type
-        attrs["source_type"] = self.source_type
-
-        return attrs


### PR DESCRIPTION
## Summary
- remove the custom `state_attributes` override from the GPS tracker entity so Home Assistant's `TrackerEntity` base class can supply the canonical attributes
- rely on the existing `extra_state_attributes` implementation for PawControl-specific metadata while the base class contributes latitude/longitude/source fields

## Testing
- `pytest -q` *(fails: missing pytest_homeassistant_custom_component dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce34f16e3c8331a0e103540c736f82