### PR TITLE
Ensure timezone-aware date/time handling across integration

### DIFF
--- a/custom_components/pawcontrol/data_manager.py
+++ b/custom_components/pawcontrol/data_manager.py
@@ -24,7 +24,7 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN, STORAGE_VERSION
 from .exceptions import StorageError
-from .utils import deep_merge_dicts
+from .utils import deep_merge_dicts, ensure_utc_datetime
 
 if TYPE_CHECKING:
     pass
@@ -317,9 +317,8 @@ class OptimizedStorage:
                 for entry in entries:
                     try:
                         timestamp = entry.get("timestamp")
-                        if isinstance(timestamp, str):
-                            entry_time = datetime.fromisoformat(timestamp)
-                        else:
+                        entry_time = ensure_utc_datetime(timestamp)
+                        if entry_time is None:
                             new_entries.append(entry)
                             continue
 
@@ -747,11 +746,8 @@ class PawControlDataManager:
                     filtered.append(entry)
                     continue
 
-                if isinstance(timestamp, str):
-                    entry_time = datetime.fromisoformat(timestamp)
-                elif isinstance(timestamp, datetime):
-                    entry_time = timestamp
-                else:
+                entry_time = ensure_utc_datetime(timestamp)
+                if entry_time is None:
                     filtered.append(entry)
                     continue
 

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from contextlib import suppress
 from datetime import datetime
 
 from homeassistant.components.datetime import DateTimeEntity
@@ -27,6 +26,7 @@ from .const import (
     MODULE_WALK,
 )
 from .coordinator import PawControlCoordinator
+from .utils import ensure_utc_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -205,10 +205,7 @@ class PawControlDateTimeBase(
         # Restore previous value
         if (last_state := await self.async_get_last_state()) is not None:  # noqa: SIM102
             if last_state.state not in ("unknown", "unavailable"):
-                try:
-                    self._current_value = dt_util.parse_datetime(last_state.state)
-                except (ValueError, TypeError):
-                    self._current_value = None
+                self._current_value = ensure_utc_datetime(last_state.state)
 
     async def async_set_value(self, value: datetime) -> None:
         """Set new datetime value."""
@@ -321,8 +318,9 @@ class PawControlLastFeedingDateTime(PawControlDateTimeBase):
 
         last_feeding = dog_data["feeding"].get("last_feeding")
         if last_feeding:
-            with suppress(ValueError, TypeError):
-                return dt_util.parse_datetime(last_feeding)
+            timestamp = ensure_utc_datetime(last_feeding)
+            if timestamp is not None:
+                return timestamp
 
         return self._current_value
 
@@ -378,8 +376,9 @@ class PawControlLastVetVisitDateTime(PawControlDateTimeBase):
 
         last_visit = dog_data["health"].get("last_vet_visit")
         if last_visit:
-            with suppress(ValueError, TypeError):
-                return dt_util.parse_datetime(last_visit)
+            timestamp = ensure_utc_datetime(last_visit)
+            if timestamp is not None:
+                return timestamp
 
         return self._current_value
 
@@ -437,8 +436,9 @@ class PawControlLastGroomingDateTime(PawControlDateTimeBase):
 
         last_grooming = dog_data["health"].get("last_grooming")
         if last_grooming:
-            with suppress(ValueError, TypeError):
-                return dt_util.parse_datetime(last_grooming)
+            timestamp = ensure_utc_datetime(last_grooming)
+            if timestamp is not None:
+                return timestamp
 
         return self._current_value
 
@@ -534,8 +534,9 @@ class PawControlLastWalkDateTime(PawControlDateTimeBase):
 
         last_walk = dog_data["walk"].get("last_walk")
         if last_walk:
-            with suppress(ValueError, TypeError):
-                return dt_util.parse_datetime(last_walk)
+            timestamp = ensure_utc_datetime(last_walk)
+            if timestamp is not None:
+                return timestamp
 
         return self._current_value
 

--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -10,7 +10,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from contextlib import suppress
 from datetime import datetime, timedelta
 from typing import Any
 
@@ -41,8 +40,8 @@ from .const import (
     DOMAIN,
     MODULE_GPS,
 )
-from .utils import ensure_utc_datetime
 from .coordinator import PawControlCoordinator
+from .utils import ensure_utc_datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from datetime import datetime, timedelta
+from datetime import timedelta
 from enum import Enum
 from typing import Any, Literal, TypedDict
 

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -14,6 +14,8 @@ from typing import Any, Literal, TypedDict
 
 from homeassistant.util import dt as dt_util
 
+from .utils import ensure_local_datetime
+
 _LOGGER = logging.getLogger(__name__)
 
 
@@ -680,10 +682,7 @@ class HealthCalculator:
         week_ago = now - timedelta(days=7)
 
         for event in feeding_events:
-            event_time = event.get("time")
-            if isinstance(event_time, str):
-                event_time = datetime.fromisoformat(event_time)
-
+            event_time = ensure_local_datetime(event.get("time"))
             if event_time and event_time > week_ago:
                 date_key = event_time.date()
                 if date_key not in recent_days:

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -40,8 +40,8 @@ from .const import (
     EVENT_WALK_ENDED,
     EVENT_WALK_STARTED,
 )
-from .utils import ensure_utc_datetime
 from .types import HealthEvent, WalkEvent
+from .utils import ensure_utc_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -426,9 +426,7 @@ class PawControlDataStorage:
                 for entry in value:
                     if isinstance(entry, dict) and "timestamp" in entry:
                         entry_date = ensure_utc_datetime(entry.get("timestamp"))
-                        if entry_date is None:
-                            cleaned_list.append(entry)
-                        elif entry_date >= cutoff_date:
+                        if entry_date is None or entry_date >= cutoff_date:
                             cleaned_list.append(entry)
                     else:
                         # Keep non-timestamped entries

--- a/custom_components/pawcontrol/optimized_entity_base.py
+++ b/custom_components/pawcontrol/optimized_entity_base.py
@@ -41,6 +41,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DOG_ID, ATTR_DOG_NAME, DOMAIN
+from .utils import ensure_utc_datetime
 from .coordinator import PawControlCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -490,13 +491,12 @@ class OptimizedEntityBase(CoordinatorEntity[PawControlCoordinator], RestoreEntit
 
         # Check for recent updates (within last 10 minutes)
         if last_update := dog_data.get("last_update"):
-            try:
-                last_update_dt = datetime.fromisoformat(last_update)
-                time_since_update = dt_util.utcnow() - last_update_dt
-                if time_since_update > timedelta(minutes=10):
-                    return False
-            except (ValueError, TypeError):
-                # Invalid timestamp format - treat as unavailable
+            last_update_dt = ensure_utc_datetime(last_update)
+            if last_update_dt is None:
+                return False
+
+            time_since_update = dt_util.utcnow() - last_update_dt
+            if time_since_update > timedelta(minutes=10):
                 return False
 
         return True

--- a/custom_components/pawcontrol/optimized_entity_base.py
+++ b/custom_components/pawcontrol/optimized_entity_base.py
@@ -41,8 +41,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DOG_ID, ATTR_DOG_NAME, DOMAIN
-from .utils import ensure_utc_datetime
 from .coordinator import PawControlCoordinator
+from .utils import ensure_utc_datetime
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/pawcontrol/person_entity_manager.py
+++ b/custom_components/pawcontrol/person_entity_manager.py
@@ -24,6 +24,8 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.event import async_track_state_change_event
 from homeassistant.util import dt as dt_util
 
+from .utils import ensure_utc_datetime
+
 _LOGGER = logging.getLogger(__name__)
 
 # Configuration constants
@@ -68,13 +70,17 @@ class PersonEntityInfo:
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> PersonEntityInfo:
         """Create from dictionary."""
+        last_updated = ensure_utc_datetime(data["last_updated"])
+        if last_updated is None:
+            last_updated = dt_util.utcnow()
+
         return cls(
             entity_id=data["entity_id"],
             name=data["name"],
             friendly_name=data["friendly_name"],
             state=data["state"],
             is_home=data["is_home"],
-            last_updated=datetime.fromisoformat(data["last_updated"]),
+            last_updated=last_updated,
             mobile_device_id=data.get("mobile_device_id"),
             notification_service=data.get("notification_service"),
             attributes=data.get("attributes", {}),

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -30,7 +30,7 @@ from .const import (
 from .coordinator import PawControlCoordinator
 from .entity_factory import EntityFactory
 from .types import PawControlConfigEntry
-from .utils import create_device_info
+from .utils import create_device_info, ensure_utc_datetime
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -504,13 +504,11 @@ class PawControlLastActionSensor(PawControlSensorBase):
             timestamp_value = module_data.get(timestamp_key)
 
             if timestamp_value:
-                try:
-                    if isinstance(timestamp_value, str):
-                        timestamps.append(datetime.fromisoformat(timestamp_value))
-                    elif isinstance(timestamp_value, datetime):
-                        timestamps.append(timestamp_value)
-                except (ValueError, TypeError) as err:
-                    _LOGGER.debug("Invalid timestamp in %s: %s", module, err)
+                timestamp = ensure_utc_datetime(timestamp_value)
+                if timestamp is not None:
+                    timestamps.append(timestamp)
+                else:
+                    _LOGGER.debug("Invalid timestamp in %s: %s", module, timestamp_value)
 
         return max(timestamps) if timestamps else None
 
@@ -745,13 +743,11 @@ class PawControlLastFeedingSensor(PawControlSensorBase):
         if not last_feeding:
             return None
 
-        try:
-            if isinstance(last_feeding, str):
-                return datetime.fromisoformat(last_feeding)
-            elif isinstance(last_feeding, datetime):
-                return last_feeding
-        except (ValueError, TypeError) as err:
-            _LOGGER.debug("Invalid last_feeding timestamp: %s", err)
+        timestamp = ensure_utc_datetime(last_feeding)
+        if timestamp is not None:
+            return timestamp
+
+        _LOGGER.debug("Invalid last_feeding timestamp: %s", last_feeding)
 
         return None
 
@@ -1002,13 +998,11 @@ class PawControlLastWalkSensor(PawControlSensorBase):
         if not last_walk:
             return None
 
-        try:
-            if isinstance(last_walk, str):
-                return datetime.fromisoformat(last_walk)
-            elif isinstance(last_walk, datetime):
-                return last_walk
-        except (ValueError, TypeError) as err:
-            _LOGGER.debug("Invalid last_walk timestamp: %s", err)
+        timestamp = ensure_utc_datetime(last_walk)
+        if timestamp is not None:
+            return timestamp
+
+        _LOGGER.debug("Invalid last_walk timestamp: %s", last_walk)
 
         return None
 
@@ -1516,12 +1510,10 @@ class PawControlLastVetVisitSensor(PawControlSensorBase):
         if not last_visit:
             return None
 
-        try:
-            if isinstance(last_visit, str):
-                return datetime.fromisoformat(last_visit)
-            elif isinstance(last_visit, datetime):
-                return last_visit
-        except (ValueError, TypeError) as err:
-            _LOGGER.debug("Invalid last_vet_visit timestamp: %s", err)
+        timestamp = ensure_utc_datetime(last_visit)
+        if timestamp is not None:
+            return timestamp
+
+        _LOGGER.debug("Invalid last_vet_visit timestamp: %s", last_visit)
 
         return None

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -508,7 +508,9 @@ class PawControlLastActionSensor(PawControlSensorBase):
                 if timestamp is not None:
                     timestamps.append(timestamp)
                 else:
-                    _LOGGER.debug("Invalid timestamp in %s: %s", module, timestamp_value)
+                    _LOGGER.debug(
+                        "Invalid timestamp in %s: %s", module, timestamp_value
+                    )
 
         return max(timestamps) if timestamps else None
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -738,6 +738,48 @@ def format_relative_time(dt: datetime) -> str:
         return f"{months} month{'s' if months > 1 else ''} ago"
 
 
+def ensure_utc_datetime(value: datetime | str | None) -> datetime | None:
+    """Return a timezone-aware UTC datetime from various input formats."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        dt_value = value
+    elif isinstance(value, str) and value:
+        dt_value = dt_util.parse_datetime(value)
+        if dt_value is None:
+            date_value = dt_util.parse_date(value)
+            if date_value is None:
+                return None
+            dt_value = datetime.combine(date_value, datetime.min.time())
+    else:
+        return None
+
+    return dt_util.as_utc(dt_value)
+
+
+def ensure_local_datetime(value: datetime | str | None) -> datetime | None:
+    """Return a timezone-aware datetime in the configured local timezone."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, datetime):
+        dt_value = value
+    elif isinstance(value, str) and value:
+        dt_value = dt_util.parse_datetime(value)
+        if dt_value is None:
+            date_value = dt_util.parse_date(value)
+            if date_value is None:
+                return None
+            dt_value = datetime.combine(date_value, datetime.min.time())
+    else:
+        return None
+
+    return dt_util.as_local(dt_value)
+
+
 def merge_configurations(
     base_config: dict[str, Any],
     user_config: dict[str, Any],


### PR DESCRIPTION
## Summary
- add shared helpers to normalize ISO date and datetime strings into timezone-aware values
- update sensors, binary sensors, datetime entities, and data managers to rely on the helpers for compliant timestamp handling
- align medication reminders and feeding analysis with local timezone conversions

## Testing
- pytest *(fails: pytest_homeassistant_custom_component distribution missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ce32a62e888331adc647caf152d07e