### PR TITLE
Add garden tracking entities and translations

### DIFF
--- a/custom_components/pawcontrol/config_flow_dogs.py
+++ b/custom_components/pawcontrol/config_flow_dogs.py
@@ -52,6 +52,7 @@ from custom_components.pawcontrol.const import (
     MIN_DOG_WEIGHT,
     MODULE_DASHBOARD,
     MODULE_FEEDING,
+    MODULE_GARDEN,
     MODULE_GPS,
     MODULE_GROOMING,
     MODULE_HEALTH,
@@ -209,6 +210,7 @@ class DogManagementMixin:
                 MODULE_WALK: user_input.get("enable_walk", False),
                 MODULE_HEALTH: user_input.get("enable_health", False),
                 MODULE_GPS: user_input.get("enable_gps", False),
+                MODULE_GARDEN: user_input.get("enable_garden", False),
                 MODULE_NOTIFICATIONS: user_input.get("enable_notifications", False),
                 MODULE_DASHBOARD: user_input.get("enable_dashboard", False),
                 MODULE_VISITOR: user_input.get("enable_visitor", False),
@@ -253,6 +255,7 @@ class DogManagementMixin:
                 vol.Optional(
                     "enable_gps", default=suggested_gps
                 ): selector.BooleanSelector(),
+                vol.Optional("enable_garden", default=False): selector.BooleanSelector(),
                 vol.Optional(
                     "enable_notifications", default=False
                 ): selector.BooleanSelector(),

--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -71,6 +71,7 @@ MODULE_GPS: Final[str] = "gps"
 MODULE_FEEDING: Final[str] = "feeding"
 MODULE_HEALTH: Final[str] = "health"
 MODULE_WALK: Final[str] = "walk"
+MODULE_GARDEN: Final[str] = "garden"
 MODULE_NOTIFICATIONS: Final[str] = "notifications"
 MODULE_DASHBOARD: Final[str] = "dashboard"
 MODULE_VISITOR: Final[str] = "visitor"
@@ -87,6 +88,7 @@ ALL_MODULES: Final[frozenset[str]] = frozenset(
         MODULE_FEEDING,
         MODULE_HEALTH,
         MODULE_WALK,
+        MODULE_GARDEN,
         MODULE_NOTIFICATIONS,
         MODULE_DASHBOARD,
         MODULE_VISITOR,
@@ -322,6 +324,10 @@ SERVICE_LOG_POOP: Final[str] = "log_poop"
 SERVICE_LOG_HEALTH: Final[str] = "log_health_data"
 SERVICE_LOG_MEDICATION: Final[str] = "log_medication"
 SERVICE_START_GROOMING: Final[str] = "start_grooming"
+SERVICE_START_GARDEN_SESSION: Final[str] = "start_garden_session"
+SERVICE_END_GARDEN_SESSION: Final[str] = "end_garden_session"
+SERVICE_ADD_GARDEN_ACTIVITY: Final[str] = "add_garden_activity"
+SERVICE_CONFIRM_GARDEN_POOP: Final[str] = "confirm_garden_poop"
 SERVICE_TOGGLE_VISITOR_MODE: Final[str] = "toggle_visitor_mode"
 SERVICE_NOTIFY_TEST: Final[str] = "notify_test"
 SERVICE_DAILY_RESET: Final[str] = "daily_reset"
@@ -351,6 +357,8 @@ CORE_SERVICES: Final[frozenset[str]] = frozenset(
         SERVICE_END_WALK,
         SERVICE_LOG_HEALTH,
         SERVICE_NOTIFY_TEST,
+        SERVICE_START_GARDEN_SESSION,
+        SERVICE_END_GARDEN_SESSION,
     ]
 )
 
@@ -484,6 +492,7 @@ __all__ = (
     # Module identifiers
     "MODULE_GPS",
     "MODULE_HEALTH",
+    "MODULE_GARDEN",
     "MODULE_NOTIFICATIONS",
     "MODULE_VISITOR",
     "MODULE_WALK",
@@ -492,6 +501,10 @@ __all__ = (
     # Service identifiers
     "SERVICE_FEED_DOG",
     "SERVICE_LOG_HEALTH",
+    "SERVICE_START_GARDEN_SESSION",
+    "SERVICE_END_GARDEN_SESSION",
+    "SERVICE_ADD_GARDEN_ACTIVITY",
+    "SERVICE_CONFIRM_GARDEN_POOP",
     "SERVICE_START_WALK",
     # Performance constants
     "UPDATE_INTERVALS",

--- a/custom_components/pawcontrol/garden_manager.py
+++ b/custom_components/pawcontrol/garden_manager.py
@@ -185,7 +185,9 @@ class GardenStats:
     total_poop_count: int = 0
     average_session_duration: float = 0.0
     most_active_time_of_day: str | None = None
-    favorite_activities: list[str] = field(default_factory=list)
+    favorite_activities: list[dict[str, Any]] = field(default_factory=list)
+    total_activities: int = 0
+    weekly_summary: dict[str, Any] = field(default_factory=dict)
     last_garden_visit: datetime | None = None
 
 
@@ -315,6 +317,8 @@ class GardenManager:
                         "average_session_duration": stats.average_session_duration,
                         "most_active_time_of_day": stats.most_active_time_of_day,
                         "favorite_activities": stats.favorite_activities,
+                        "total_activities": stats.total_activities,
+                        "weekly_summary": stats.weekly_summary,
                         "last_garden_visit": stats.last_garden_visit.isoformat()
                         if stats.last_garden_visit
                         else None,
@@ -824,10 +828,13 @@ class GardenManager:
 
         # Calculate statistics
         stats.total_sessions = len(dog_sessions)
-        stats.total_time_minutes = sum(s.duration_minutes for s in dog_sessions)
+        stats.total_time_minutes = sum(
+            s.calculate_duration() / 60 for s in dog_sessions
+        )
         stats.total_poop_count = sum(s.poop_count for s in dog_sessions)
         stats.average_session_duration = stats.total_time_minutes / stats.total_sessions
         stats.last_garden_visit = max(s.end_time or s.start_time for s in dog_sessions)
+        stats.total_activities = sum(len(s.activities) for s in dog_sessions)
 
         # Find most active time of day (simplified)
         hour_counts = {}
@@ -855,9 +862,35 @@ class GardenManager:
                     activity_counts.get(activity_type, 0) + 1
                 )
 
-        stats.favorite_activities = sorted(
-            activity_counts.items(), key=lambda x: x[1], reverse=True
-        )[:3]
+        stats.favorite_activities = [
+            {"activity": activity_type, "count": count}
+            for activity_type, count in sorted(
+                activity_counts.items(), key=lambda item: item[1], reverse=True
+            )[:3]
+        ]
+
+        # Weekly summary (last 7 days)
+        now_utc = dt_util.utcnow()
+        week_start = now_utc - timedelta(days=7)
+        weekly_sessions = [
+            session
+            for session in dog_sessions
+            if (session.end_time or session.start_time) >= week_start
+        ]
+
+        if weekly_sessions:
+            total_week_minutes = sum(
+                session.calculate_duration() / 60 for session in weekly_sessions
+            )
+            stats.weekly_summary = {
+                "session_count": len(weekly_sessions),
+                "total_time_minutes": total_week_minutes,
+                "poop_events": sum(session.poop_count for session in weekly_sessions),
+                "average_duration": total_week_minutes / len(weekly_sessions),
+                "updated": now_utc.isoformat(),
+            }
+        else:
+            stats.weekly_summary = {}
 
     async def _update_all_statistics(self) -> None:
         """Update statistics for all dogs."""
@@ -907,6 +940,177 @@ class GardenManager:
         sessions.sort(key=lambda s: s.start_time, reverse=True)
 
         return sessions[:limit]
+
+    def has_pending_confirmation(self, dog_id: str) -> bool:
+        """Return True if a poop confirmation is pending for the dog."""
+
+        return any(
+            confirmation.get("dog_id") == dog_id
+            and confirmation.get("type") == "poop_confirmation"
+            for confirmation in self._pending_confirmations.values()
+        )
+
+    def get_pending_confirmations(self, dog_id: str) -> list[dict[str, Any]]:
+        """Return pending confirmation requests for a dog."""
+
+        confirmations: list[dict[str, Any]] = []
+        for confirmation in self._pending_confirmations.values():
+            if (
+                confirmation.get("dog_id") != dog_id
+                or confirmation.get("type") != "poop_confirmation"
+            ):
+                continue
+
+            timestamp = confirmation.get("timestamp")
+            timeout = confirmation.get("timeout")
+            confirmations.append(
+                {
+                    "session_id": confirmation.get("session_id"),
+                    "created": timestamp.isoformat() if timestamp else None,
+                    "expires": timeout.isoformat() if timeout else None,
+                }
+            )
+
+        return confirmations
+
+    def build_garden_snapshot(
+        self, dog_id: str, *, recent_limit: int = 50
+    ) -> dict[str, Any]:
+        """Build a snapshot of garden activity for sensors and diagnostics."""
+
+        snapshot: dict[str, Any] = {
+            "status": "idle",
+            "sessions_today": 0,
+            "time_today_minutes": 0.0,
+            "poop_today": 0,
+            "activities_today": 0,
+            "activities_total": 0,
+            "active_session": None,
+            "last_session": None,
+            "hours_since_last_session": None,
+            "stats": {},
+            "pending_confirmations": self.get_pending_confirmations(dog_id),
+            "weather_summary": None,
+        }
+
+        now_local = dt_util.now()
+        start_of_day = dt_util.start_of_local_day(now_local)
+
+        sessions = self.get_recent_sessions(dog_id, limit=recent_limit)
+        todays_sessions: list[GardenSession] = []
+
+        for session in sessions:
+            session_start_local = dt_util.as_local(session.start_time)
+            if session_start_local >= start_of_day:
+                todays_sessions.append(session)
+
+        active_session = self.get_active_session(dog_id)
+        if active_session:
+            snapshot["status"] = "active"
+            snapshot["active_session"] = {
+                "session_id": active_session.session_id,
+                "start_time": active_session.start_time.isoformat(),
+                "duration_minutes": round(
+                    active_session.calculate_duration() / 60, 2
+                ),
+                "activity_count": len(active_session.activities),
+                "poop_count": active_session.poop_count,
+            }
+
+        stats = self.get_dog_statistics(dog_id)
+        if stats:
+            snapshot["stats"] = {
+                "total_sessions": stats.total_sessions,
+                "total_time_minutes": stats.total_time_minutes,
+                "total_poop_count": stats.total_poop_count,
+                "average_session_duration": stats.average_session_duration,
+                "most_active_time_of_day": stats.most_active_time_of_day,
+                "favorite_activities": stats.favorite_activities,
+                "weekly_summary": stats.weekly_summary,
+                "last_garden_visit": stats.last_garden_visit.isoformat()
+                if stats.last_garden_visit
+                else None,
+            }
+            snapshot["activities_total"] = stats.total_activities
+
+        # Calculate today's aggregates including active session
+        total_seconds_today = 0
+        total_poop_today = 0
+        total_activities_today = 0
+        weather_conditions: list[str] = []
+        temperatures: list[float] = []
+
+        for session in todays_sessions:
+            duration = session.calculate_duration()
+            total_seconds_today += duration
+            total_poop_today += session.poop_count
+            total_activities_today += len(session.activities)
+            if session.weather_conditions:
+                weather_conditions.append(session.weather_conditions)
+            if session.temperature is not None:
+                temperatures.append(session.temperature)
+
+        active_started_today = False
+        if active_session:
+            active_started_today = (
+                dt_util.as_local(active_session.start_time) >= start_of_day
+            )
+
+        if active_session and active_started_today:
+            duration = active_session.calculate_duration()
+            total_seconds_today += duration
+            total_poop_today += active_session.poop_count
+            total_activities_today += len(active_session.activities)
+            if active_session.weather_conditions:
+                weather_conditions.append(active_session.weather_conditions)
+            if active_session.temperature is not None:
+                temperatures.append(active_session.temperature)
+
+        todays_session_count = len(todays_sessions)
+        if active_started_today:
+            todays_session_count += 1
+
+        snapshot["sessions_today"] = todays_session_count
+        snapshot["time_today_minutes"] = round(total_seconds_today / 60, 2)
+        snapshot["poop_today"] = total_poop_today
+        snapshot["activities_today"] = total_activities_today
+
+        if weather_conditions or temperatures:
+            average_temperature = (
+                sum(temperatures) / len(temperatures) if temperatures else None
+            )
+            snapshot["weather_summary"] = {
+                "conditions": weather_conditions,
+                "average_temperature": average_temperature,
+            }
+
+        if sessions:
+            last_session = sessions[0]
+            snapshot["last_session"] = {
+                "session_id": last_session.session_id,
+                "start_time": last_session.start_time.isoformat(),
+                "end_time": last_session.end_time.isoformat()
+                if last_session.end_time
+                else None,
+                "duration_minutes": round(
+                    last_session.calculate_duration() / 60, 2
+                ),
+                "activity_count": len(last_session.activities),
+                "poop_count": last_session.poop_count,
+                "status": last_session.status.value,
+                "weather_conditions": last_session.weather_conditions,
+                "temperature": last_session.temperature,
+                "notes": last_session.notes,
+            }
+
+            reference_time = last_session.end_time or last_session.start_time
+            if reference_time:
+                snapshot["hours_since_last_session"] = round(
+                    (dt_util.utcnow() - reference_time).total_seconds() / 3600,
+                    2,
+                )
+
+        return snapshot
 
     def is_dog_in_garden(self, dog_id: str) -> bool:
         """Check if dog is currently in garden.

--- a/custom_components/pawcontrol/options_flow.py
+++ b/custom_components/pawcontrol/options_flow.py
@@ -64,6 +64,7 @@ from .const import (
     MAX_GEOFENCE_RADIUS,
     MIN_GEOFENCE_RADIUS,
     MODULE_FEEDING,
+    MODULE_GARDEN,
     MODULE_GPS,
     MODULE_HEALTH,
     MODULE_WALK,
@@ -978,6 +979,7 @@ class PawControlOptionsFlow(OptionsFlow):
                         MODULE_FEEDING: user_input.get("module_feeding", True),
                         MODULE_WALK: user_input.get("module_walk", True),
                         MODULE_GPS: user_input.get("module_gps", False),
+                        MODULE_GARDEN: user_input.get("module_garden", False),
                         MODULE_HEALTH: user_input.get("module_health", True),
                         "notifications": user_input.get("module_notifications", True),
                         "dashboard": user_input.get("module_dashboard", True),
@@ -1033,6 +1035,10 @@ class PawControlOptionsFlow(OptionsFlow):
                 vol.Optional(
                     "module_gps",
                     default=current_modules.get(MODULE_GPS, False),
+                ): selector.BooleanSelector(),
+                vol.Optional(
+                    "module_garden",
+                    default=current_modules.get(MODULE_GARDEN, False),
                 ): selector.BooleanSelector(),
                 vol.Optional(
                     "module_health",

--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -29,7 +29,8 @@
           "enable_health": "Health Monitoring",
           "enable_visitor_mode": "Visitor Mode",
           "enable_dashboard": "Dashboard",
-          "enable_advanced_features": "Advanced Features"
+          "enable_advanced_features": "Advanced Features",
+          "enable_garden": "Garden Tracking"
         }
       },
       "configure_dashboard": {
@@ -149,7 +150,8 @@
           "walk": "Walk Monitoring",
           "health": "Health Monitoring",
           "gps": "GPS Location Tracking",
-          "notifications": "Smart Notifications"
+          "notifications": "Smart Notifications",
+          "module_garden": "Garden Tracking"
         }
       },
       "add_another": {
@@ -273,7 +275,8 @@
           "module_walk": "Walk Monitoring",
           "module_gps": "GPS Location Tracking",
           "module_health": "Health Monitoring",
-          "module_notifications": "Smart Notifications"
+          "module_notifications": "Smart Notifications",
+          "module_garden": "Garden Tracking"
         }
       },
       "notifications": {
@@ -404,6 +407,42 @@
       "weight": {
         "name": "Weight",
         "unit_of_measurement": "kg"
+      },
+      "garden_time_today": {
+        "name": "Garden Time Today"
+      },
+      "garden_sessions_today": {
+        "name": "Garden Sessions Today"
+      },
+      "garden_poop_count_today": {
+        "name": "Garden Poops Today"
+      },
+      "last_garden_session": {
+        "name": "Last Garden Session"
+      },
+      "garden_activities_count": {
+        "name": "Garden Activities Count"
+      },
+      "avg_garden_duration": {
+        "name": "Average Garden Duration"
+      },
+      "garden_stats_weekly": {
+        "name": "Weekly Garden Summary"
+      },
+      "favorite_garden_activities": {
+        "name": "Favorite Garden Activities"
+      },
+      "last_garden_duration": {
+        "name": "Last Garden Session Duration"
+      },
+      "garden_activities_last_session": {
+        "name": "Garden Activities Last Session"
+      },
+      "garden_activities_today": {
+        "name": "Garden Activities Today"
+      },
+      "last_garden_session_hours": {
+        "name": "Hours Since Last Garden Session"
       }
     },
     "binary_sensor": {
@@ -475,6 +514,15 @@
       },
       "activity_level_concern": {
         "name": "Activity Level Concern"
+      },
+      "garden_session_active": {
+        "name": "Garden Session Active"
+      },
+      "in_garden": {
+        "name": "In Garden"
+      },
+      "garden_poop_pending": {
+        "name": "Garden Poop Confirmation Pending"
       }
     },
     "button": {
@@ -543,6 +591,18 @@
       },
       "health_check": {
         "name": "Health Check"
+      },
+      "start_garden_session": {
+        "name": "Start Garden Session"
+      },
+      "end_garden_session": {
+        "name": "End Garden Session"
+      },
+      "log_garden_activity": {
+        "name": "Log Garden Activity"
+      },
+      "confirm_garden_poop": {
+        "name": "Confirm Garden Poop"
       }
     },
     "switch": {
@@ -629,6 +689,9 @@
       },
       "sound_alerts": {
         "name": "Sound Alerts"
+      },
+      "module_garden": {
+        "name": "Garden Module"
       }
     },
     "number": {

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -34,7 +34,8 @@
           "enable_grooming": "Pflege-Erinnerungen",
           "enable_medication": "Medikamenten-Verfolgung",
           "enable_training": "Trainingsfortschritt",
-          "enable_weather": "Wetter-Gesundheitsüberwachung"
+          "enable_weather": "Wetter-Gesundheitsüberwachung",
+          "enable_garden": "Garten-Tracking"
         }
       },
       "dog_gps": {
@@ -460,6 +461,42 @@
       },
       "active_weather_alerts": {
         "name": "Aktive Wetter-Warnungen"
+      },
+      "garden_time_today": {
+        "name": "Gartenzeit heute"
+      },
+      "garden_sessions_today": {
+        "name": "Gartensitzungen heute"
+      },
+      "garden_poop_count_today": {
+        "name": "Garten-Kotereignisse heute"
+      },
+      "last_garden_session": {
+        "name": "Letzte Gartensitzung"
+      },
+      "garden_activities_count": {
+        "name": "Anzahl Gartenaktivitäten"
+      },
+      "avg_garden_duration": {
+        "name": "Durchschnittliche Gartendauer"
+      },
+      "garden_stats_weekly": {
+        "name": "Wöchentliche Gartenübersicht"
+      },
+      "favorite_garden_activities": {
+        "name": "Beliebteste Gartenaktivitäten"
+      },
+      "last_garden_duration": {
+        "name": "Dauer der letzten Gartensitzung"
+      },
+      "garden_activities_last_session": {
+        "name": "Gartenaktivitäten letzte Sitzung"
+      },
+      "garden_activities_today": {
+        "name": "Gartenaktivitäten heute"
+      },
+      "last_garden_session_hours": {
+        "name": "Stunden seit letzter Gartensitzung"
       }
     },
     "binary_sensor": {
@@ -516,6 +553,15 @@
       },
       "storm_warning": {
         "name": "Sturmwarnung"
+      },
+      "garden_session_active": {
+        "name": "Gartensitzung aktiv"
+      },
+      "in_garden": {
+        "name": "Im Garten"
+      },
+      "garden_poop_pending": {
+        "name": "Offene Garten-Kotbestätigung"
       }
     },
     "button": {
@@ -578,6 +624,18 @@
       },
       "get_weather_recommendations": {
         "name": "Wetter-Empfehlungen abrufen"
+      },
+      "start_garden_session": {
+        "name": "Gartensitzung starten"
+      },
+      "end_garden_session": {
+        "name": "Gartensitzung beenden"
+      },
+      "log_garden_activity": {
+        "name": "Gartenaktivität protokollieren"
+      },
+      "confirm_garden_poop": {
+        "name": "Garten-Kot bestätigen"
       }
     },
     "switch": {
@@ -673,6 +731,9 @@
       },
       "storm_alerts": {
         "name": "Sturm-Warnungen"
+      },
+      "module_garden": {
+        "name": "Gartenmodul"
       }
     },
     "select": {
@@ -774,7 +835,7 @@
       "description": "Täglichen Reset der Zähler für alle Hunde durchführen"
     },
     "update_weather_data": {
-      "name": "Wetterdaten aktualisieren", 
+      "name": "Wetterdaten aktualisieren",
       "description": "Aktualisiert die Wetterdaten für die Gesundheitsüberwachung"
     },
     "get_weather_alerts": {
@@ -932,12 +993,12 @@
       "breed_specific_caution": "Zusätzliche Vorsicht für {breed}-Rasse während {alert_type}",
       "puppy_extra_monitoring": "Welpen sind verletzlicher - überwache genau",
       "senior_extra_protection": "Seniorenhunde brauchen zusätzlichen Schutz",
-      "respiratory_monitoring": "Atemwegserkrankung erfordert zusätzliche Überwachung", 
+      "respiratory_monitoring": "Atemwegserkrankung erfordert zusätzliche Überwachung",
       "heart_avoid_strenuous": "Herzerkrankung - vermeide anstrengende Aktivitäten"
     },
     "severity": {
       "low": "Niedrig",
-      "moderate": "Mäßig", 
+      "moderate": "Mäßig",
       "high": "Hoch",
       "extreme": "Extrem"
     },

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -34,7 +34,8 @@
           "enable_grooming": "Grooming Reminders",
           "enable_medication": "Medication Tracking",
           "enable_training": "Training Progress",
-          "enable_weather": "Weather Health Monitoring"
+          "enable_weather": "Weather Health Monitoring",
+          "enable_garden": "Garden Tracking"
         }
       },
       "dog_gps": {
@@ -311,7 +312,7 @@
         "data": {
           "weather_entity": "Weather Entity",
           "enable_weather_alerts": "Enable Weather Alerts",
-          "enable_weather_recommendations": "Enable Weather Recommendations", 
+          "enable_weather_recommendations": "Enable Weather Recommendations",
           "weather_update_interval": "Weather Update Interval (minutes)",
           "temperature_alerts": "Temperature Alerts",
           "uv_alerts": "UV Index Alerts",
@@ -460,6 +461,42 @@
       },
       "active_weather_alerts": {
         "name": "Active Weather Alerts"
+      },
+      "garden_time_today": {
+        "name": "Garden Time Today"
+      },
+      "garden_sessions_today": {
+        "name": "Garden Sessions Today"
+      },
+      "garden_poop_count_today": {
+        "name": "Garden Poops Today"
+      },
+      "last_garden_session": {
+        "name": "Last Garden Session"
+      },
+      "garden_activities_count": {
+        "name": "Garden Activities Count"
+      },
+      "avg_garden_duration": {
+        "name": "Average Garden Duration"
+      },
+      "garden_stats_weekly": {
+        "name": "Weekly Garden Summary"
+      },
+      "favorite_garden_activities": {
+        "name": "Favorite Garden Activities"
+      },
+      "last_garden_duration": {
+        "name": "Last Garden Session Duration"
+      },
+      "garden_activities_last_session": {
+        "name": "Garden Activities Last Session"
+      },
+      "garden_activities_today": {
+        "name": "Garden Activities Today"
+      },
+      "last_garden_session_hours": {
+        "name": "Hours Since Last Garden Session"
       }
     },
     "binary_sensor": {
@@ -516,6 +553,15 @@
       },
       "storm_warning": {
         "name": "Storm Warning"
+      },
+      "garden_session_active": {
+        "name": "Garden Session Active"
+      },
+      "in_garden": {
+        "name": "In Garden"
+      },
+      "garden_poop_pending": {
+        "name": "Garden Poop Confirmation Pending"
       }
     },
     "button": {
@@ -578,6 +624,18 @@
       },
       "get_weather_recommendations": {
         "name": "Get Weather Recommendations"
+      },
+      "start_garden_session": {
+        "name": "Start Garden Session"
+      },
+      "end_garden_session": {
+        "name": "End Garden Session"
+      },
+      "log_garden_activity": {
+        "name": "Log Garden Activity"
+      },
+      "confirm_garden_poop": {
+        "name": "Confirm Garden Poop"
       }
     },
     "switch": {
@@ -673,6 +731,9 @@
       },
       "storm_alerts": {
         "name": "Storm Alerts"
+      },
+      "module_garden": {
+        "name": "Garden Module"
       }
     },
     "select": {

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -34,6 +34,7 @@ if TYPE_CHECKING:
     from .entity_factory import EntityFactory
     from .feeding_manager import FeedingManager
     from .geofencing import PawControlGeofencing
+    from .garden_manager import GardenManager
     from .helper_manager import PawControlHelperManager
     from .notifications import PawControlNotificationManager
     from .walk_manager import WalkManager
@@ -279,6 +280,7 @@ class PawControlRuntimeData:
     dogs: list[DogConfigData]
     helper_manager: PawControlHelperManager | None = None
     geofencing_manager: PawControlGeofencing | None = None
+    garden_manager: GardenManager | None = None
 
     # Enhanced runtime tracking for Platinum-level monitoring
     performance_stats: dict[str, Any] = field(default_factory=dict)
@@ -309,6 +311,7 @@ class PawControlRuntimeData:
             "error_history": self.error_history,
             "helper_manager": self.helper_manager,
             "geofencing_manager": self.geofencing_manager,
+            "garden_manager": self.garden_manager,
         }
 
     def __getitem__(self, key: str) -> Any:


### PR DESCRIPTION
## Summary
- add a garden sensor base and new garden metrics backed by coordinator snapshots
- provide garden-aware binary sensors and control buttons with service validation
- surface the garden module throughout configuration flows and localize all new entities

## Testing
- pytest *(fails: existing import errors in door_sensor_manager and legacy tests)*

------
https://chatgpt.com/codex/tasks/task_e_68d09599b7288331b25080ef835ea0a4