### PR TITLE
Track background monitor task for proper unload cleanup

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -760,9 +760,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: PawControlConfigEntry) 
             except asyncio.CancelledError:
                 _LOGGER.debug("Background monitor task cancelled")
             except Exception as err:  # pragma: no cover - defensive logging
-                _LOGGER.warning(
-                    "Error while awaiting background monitor task: %s", err
-                )
+                _LOGGER.warning("Error while awaiting background monitor task: %s", err)
             finally:
                 runtime_data.background_monitor_task = None
 

--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -611,7 +611,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
             _async_monitor_background_tasks(runtime_data)
         )
         runtime_data.background_monitor_task = monitor_task
-        entry.async_on_unload(monitor_task.cancel)
 
         # Add reload listener
         entry.async_on_unload(entry.add_update_listener(async_reload_entry))

--- a/custom_components/pawcontrol/health_enhancements.py
+++ b/custom_components/pawcontrol/health_enhancements.py
@@ -445,12 +445,11 @@ class EnhancedHealthCalculator:
                     )
                     continue
 
-                treatment_name = (
-                    deworming.treatment_type.value.replace("_", " ").title()
-                )
+                treatment_name = deworming.treatment_type.value.replace(
+                    "_", " "
+                ).title()
                 message = (
-                    f"{treatment_name} treatment is {abs(days_until_due)} "
-                    "days overdue"
+                    f"{treatment_name} treatment is {abs(days_until_due)} days overdue"
                 )
                 health_status["priority_alerts"].append(
                     {
@@ -471,9 +470,9 @@ class EnhancedHealthCalculator:
                     )
                     continue
 
-                treatment_name = (
-                    deworming.treatment_type.value.replace("_", " ").title()
-                )
+                treatment_name = deworming.treatment_type.value.replace(
+                    "_", " "
+                ).title()
                 message = f"{treatment_name} treatment due in {days_until_due} days"
                 health_status["upcoming_care"].append(
                     {

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -19,6 +19,7 @@ Python: 3.13+
 
 from __future__ import annotations
 
+from asyncio import Task
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -264,6 +265,9 @@ class PawControlRuntimeData:
         error_history: Historical error tracking for diagnostics
         helper_manager: Home Assistant helper creation and management service
         geofencing_manager: Geofencing and GPS zone monitoring service
+        garden_manager: Garden care automation service
+        daily_reset_unsub: Callback used to cancel the scheduled daily reset
+        background_monitor_task: Background health monitoring task handle
 
     Note:
         This class implements both dataclass and dictionary-like access
@@ -281,6 +285,7 @@ class PawControlRuntimeData:
     helper_manager: PawControlHelperManager | None = None
     geofencing_manager: PawControlGeofencing | None = None
     garden_manager: GardenManager | None = None
+    background_monitor_task: Task[None] | None = None
 
     # Enhanced runtime tracking for Platinum-level monitoring
     performance_stats: dict[str, Any] = field(default_factory=dict)
@@ -312,6 +317,7 @@ class PawControlRuntimeData:
             "helper_manager": self.helper_manager,
             "geofencing_manager": self.geofencing_manager,
             "garden_manager": self.garden_manager,
+            "background_monitor_task": self.background_monitor_task,
         }
 
     def __getitem__(self, key: str) -> Any:

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -282,10 +282,10 @@ class PawControlRuntimeData:
     entity_factory: EntityFactory
     entity_profile: str
     dogs: list[DogConfigData]
-    helper_manager: PawControlHelperManager | None = None
-    geofencing_manager: PawControlGeofencing | None = None
-    garden_manager: GardenManager | None = None
     background_monitor_task: Task[None] | None = None
+    garden_manager: GardenManager | None = None
+    geofencing_manager: PawControlGeofencing | None = None
+    helper_manager: PawControlHelperManager | None = None
 
     # Enhanced runtime tracking for Platinum-level monitoring
     performance_stats: dict[str, Any] = field(default_factory=dict)
@@ -314,10 +314,10 @@ class PawControlRuntimeData:
             "dogs": self.dogs,
             "performance_stats": self.performance_stats,
             "error_history": self.error_history,
-            "helper_manager": self.helper_manager,
-            "geofencing_manager": self.geofencing_manager,
-            "garden_manager": self.garden_manager,
             "background_monitor_task": self.background_monitor_task,
+            "garden_manager": self.garden_manager,
+            "geofencing_manager": self.geofencing_manager,
+            "helper_manager": self.helper_manager,
         }
 
     def __getitem__(self, key: str) -> Any:


### PR DESCRIPTION
## Summary
- create and store the background task monitor with Home Assistant's task helper
- cancel and await the monitor task during unload so it cannot leak after removal
- document the runtime data attribute that exposes the background monitor task

## Testing
- `ruff check custom_components/pawcontrol`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d32e0b39308331a62d1fb043a19f1e