### PR TITLE
Improve door sensor typing and diagnostics

### DIFF
--- a/custom_components/pawcontrol/door_sensor_manager.py
+++ b/custom_components/pawcontrol/door_sensor_manager.py
@@ -784,9 +784,7 @@ class DoorSensorManager:
             "configured_dogs": len(self._sensor_configs),
             "active_detections": 0,
             "detection_states": {},
-            "statistics": cast(
-                DetectionStatistics, dict(self._detection_stats)
-            ),
+            "statistics": cast(DetectionStatistics, dict(self._detection_stats)),
         }
 
         for dog_id, state in self._detection_states.items():

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -240,6 +240,50 @@ class DogConfigData(TypedDict):
     discovery_info: dict[str, Any] | None  # Device discovery integration support
 
 
+class DetectionStatistics(TypedDict):
+    """Aggregated statistics for door sensor walk detection diagnostics.
+
+    This structure mirrors the runtime statistics tracked by the
+    ``DoorSensorManager`` and is used for diagnostic payloads that surface
+    detection performance information through Home Assistant's diagnostics and
+    logging facilities.
+
+    Attributes:
+        total_detections: Total number of detection events processed.
+        successful_walks: Number of detections that resulted in confirmed walks.
+        false_positives: Count of detections that were dismissed as false alarms.
+        false_negatives: Number of missed walks detected through manual review.
+        average_confidence: Rolling average confidence score for detections.
+    """
+
+    total_detections: int
+    successful_walks: int
+    false_positives: int
+    false_negatives: int
+    average_confidence: float
+
+
+class DetectionStatusEntry(TypedDict):
+    """Status information for an individual dog's detection state."""
+
+    dog_name: str
+    door_sensor: str
+    current_state: str
+    confidence_score: float
+    active_walk_id: str | None
+    last_door_state: str | None
+    recent_activity: int
+
+
+class DetectionStatus(TypedDict):
+    """Structured detection status payload for diagnostics endpoints."""
+
+    configured_dogs: int
+    active_detections: int
+    detection_states: dict[str, DetectionStatusEntry]
+    statistics: DetectionStatistics
+
+
 @dataclass
 class PawControlRuntimeData:
     """Comprehensive runtime data container for the PawControl integration.


### PR DESCRIPTION
## Summary
- add forward-referenced typing for the door sensor manager's dependencies
- introduce typed dictionaries for detection statistics and status payloads to satisfy strict typing goals
- tighten optional checks around the walk and notification managers

## Testing
- ruff check custom_components/pawcontrol/door_sensor_manager.py
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d32e0b39308331a62d1fb043a19f1e