### PR TITLE
Fix helper manager initialization and helper tracking

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -331,7 +331,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
             feeding_manager = FeedingManager()
             walk_manager = WalkManager()
             entity_factory = EntityFactory(coordinator)
-            helper_manager = PawControlHelperManager(hass, entry.entry_id)
+            helper_manager = PawControlHelperManager(hass, entry)
             door_sensor_manager = DoorSensorManager(hass, entry.entry_id)
             garden_manager = GardenManager(hass, entry.entry_id)
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -759,7 +759,7 @@ def flatten_dict(
     Returns:
         Flattened dictionary
     """
-    flattened = {}
+    flattened: dict[str, Any] = {}
 
     for key, value in data.items():
         new_key = f"{prefix}{separator}{key}" if prefix else key
@@ -782,7 +782,7 @@ def unflatten_dict(data: dict[str, Any], separator: str = ".") -> dict[str, Any]
     Returns:
         Nested dictionary
     """
-    result = {}
+    result: dict[str, Any] = {}
 
     for key, value in data.items():
         safe_set_nested(result, key, value, separator)


### PR DESCRIPTION
## Summary
- pass the full config entry into the helper manager and normalize stored dog/module configuration before helper creation
- add an async helper creation API that tracks created entities per dog and schedules the daily reset listener only once
- annotate utility helpers to satisfy strict typing requirements

## Testing
- ruff check custom_components/pawcontrol/helper_manager.py custom_components/pawcontrol/utils.py
- pytest
- mypy custom_components/pawcontrol/helper_manager.py custom_components/pawcontrol/utils.py

------
https://chatgpt.com/codex/tasks/task_e_68d385190fac83319c224d07f4fc847e