### PR TITLE
Add stub implementations for annotatedyaml input utilities

### DIFF
--- a/annotatedyaml/__init__.py
+++ b/annotatedyaml/__init__.py
@@ -3,9 +3,9 @@
 from __future__ import annotations
 
 __all__ = [
-    "SECRET_YAML",
     "Input",
-    "UndefinedSubstitutionError",
+    "SECRET_YAML",
+    "UndefinedSubstitution",
     "YamlTypeError",
     "extract_inputs",
     "substitute",
@@ -37,11 +37,12 @@ class Input(str):
         value: str,
         line: int | None = None,
         column: int | None = None,
+        name: str | None = None,
     ) -> Input:
         obj = super().__new__(cls, value)
         obj._line = line
         obj._column = column
-        obj._name = value
+        obj._name = name if name is not None else value
         return obj
 
     @property
@@ -63,4 +64,4 @@ class Input(str):
         return self._name
 
 
-from .input import UndefinedSubstitutionError, extract_inputs, substitute
+from .input import UndefinedSubstitution, extract_inputs, substitute

--- a/annotatedyaml/__init__.py
+++ b/annotatedyaml/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 __all__ = [
-    "Input",
     "SECRET_YAML",
+    "Input",
     "UndefinedSubstitutionError",
     "YamlTypeError",
     "extract_inputs",

--- a/annotatedyaml/__init__.py
+++ b/annotatedyaml/__init__.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 __all__ = [
-    "Input",
     "SECRET_YAML",
+    "Input",
     "UndefinedSubstitution",
     "YamlTypeError",
     "extract_inputs",

--- a/annotatedyaml/__init__.py
+++ b/annotatedyaml/__init__.py
@@ -2,11 +2,9 @@
 
 from __future__ import annotations
 
-from .input import UndefinedSubstitution, extract_inputs, substitute
-
 __all__ = [
-    "SECRET_YAML",
     "Input",
+    "SECRET_YAML",
     "UndefinedSubstitution",
     "YamlTypeError",
     "extract_inputs",
@@ -63,3 +61,6 @@ class Input(str):
         """Return the name of the input placeholder."""
 
         return self._name
+
+
+from .input import UndefinedSubstitution, extract_inputs, substitute

--- a/annotatedyaml/__init__.py
+++ b/annotatedyaml/__init__.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
-__all__ = ["SECRET_YAML", "Input", "YamlTypeError"]
+from .input import UndefinedSubstitution, extract_inputs, substitute
+
+__all__ = [
+    "SECRET_YAML",
+    "Input",
+    "UndefinedSubstitution",
+    "YamlTypeError",
+    "extract_inputs",
+    "substitute",
+]
 
 # ``!secret`` is a sentinel tag used by Home Assistant to reference entries in
 # ``secrets.yaml``.  It is not an actual secret value, but rather a public
@@ -23,7 +32,7 @@ class Input(str):
     behaves like a string and optionally stores line/column information.
     """
 
-    __slots__ = ("_column", "_line")
+    __slots__ = ("_column", "_line", "_name")
 
     def __new__(
         cls,
@@ -34,6 +43,7 @@ class Input(str):
         obj = super().__new__(cls, value)
         obj._line = line
         obj._column = column
+        obj._name = value
         return obj
 
     @property
@@ -47,3 +57,9 @@ class Input(str):
         """Return the column number associated with the value, if available."""
 
         return self._column
+
+    @property
+    def name(self) -> str:
+        """Return the name of the input placeholder."""
+
+        return self._name

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -31,7 +31,7 @@ def _extract_inputs(obj: Any, found: set[str]) -> None:
         found.add(obj.name)
         return
 
-    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
         for value in obj:
             _extract_inputs(value, found)
         return
@@ -51,7 +51,7 @@ def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
         except KeyError as exc:  # pragma: no cover - defensive guard
             raise UndefinedSubstitution(obj.name) from exc
 
-    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
         return [substitute(value, substitutions) for value in obj]
 
     if isinstance(obj, Mapping):

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -1,0 +1,60 @@
+"""Utility helpers for the ``annotatedyaml`` test stub."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from . import Input
+
+
+class UndefinedSubstitution(Exception):
+    """Error raised when a requested substitution is missing."""
+
+    def __init__(self, input_name: str) -> None:
+        super().__init__(f"No substitution found for input {input_name}")
+        self.input = input_name
+
+
+def extract_inputs(obj: Any) -> set[str]:
+    """Collect all :class:`Input` placeholders contained in ``obj``."""
+
+    found: set[str] = set()
+    _extract_inputs(obj, found)
+    return found
+
+
+def _extract_inputs(obj: Any, found: set[str]) -> None:
+    """Recursive helper for :func:`extract_inputs`."""
+
+    if isinstance(obj, Input):
+        found.add(obj.name)
+        return
+
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        for value in obj:
+            _extract_inputs(value, found)
+        return
+
+    if isinstance(obj, Mapping):
+        for value in obj.values():
+            _extract_inputs(value, found)
+        return
+
+
+def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
+    """Replace :class:`Input` placeholders in ``obj`` using ``substitutions``."""
+
+    if isinstance(obj, Input):
+        try:
+            return substitutions[obj.name]
+        except KeyError as exc:  # pragma: no cover - defensive guard
+            raise UndefinedSubstitution(obj.name) from exc
+
+    if isinstance(obj, Sequence) and not isinstance(obj, (str, bytes, bytearray)):
+        return [substitute(value, substitutions) for value in obj]
+
+    if isinstance(obj, Mapping):
+        return {key: substitute(value, substitutions) for key, value in obj.items()}
+
+    return obj

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -32,7 +32,7 @@ def _extract_inputs(obj: Any, found: set[str]) -> None:
             found.add(input_obj.name)
         case str() | bytes() | bytearray():
             pass
-        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+        case Sequence() as seq if not isinstance(seq, str | bytes | bytearray):
             for value in seq:
                 _extract_inputs(value, found)
         case Mapping() as mapping:
@@ -51,12 +51,11 @@ def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
                 raise UndefinedSubstitutionError(input_obj.name) from exc
         case str() | bytes() | bytearray():
             return obj
-        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+        case Sequence() as seq if not isinstance(seq, str | bytes | bytearray):
             return [substitute(value, substitutions) for value in seq]
         case Mapping() as mapping:
             return {
-                key: substitute(value, substitutions)
-                for key, value in mapping.items()
+                key: substitute(value, substitutions) for key, value in mapping.items()
             }
         case _:
             return obj

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -32,7 +32,7 @@ def _extract_inputs(obj: Any, found: set[str]) -> None:
             found.add(input_obj.name)
         case str() | bytes() | bytearray():
             pass
-        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+        case Sequence() as seq if not isinstance(seq, str | bytes | bytearray):
             for value in seq:
                 _extract_inputs(value, found)
         case Mapping() as mapping:
@@ -51,12 +51,11 @@ def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
                 raise UndefinedSubstitution(input_obj.name) from exc
         case str() | bytes() | bytearray():
             return obj
-        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+        case Sequence() as seq if not isinstance(seq, str | bytes | bytearray):
             return [substitute(value, substitutions) for value in seq]
         case Mapping() as mapping:
             return {
-                key: substitute(value, substitutions)
-                for key, value in mapping.items()
+                key: substitute(value, substitutions) for key, value in mapping.items()
             }
         case _:
             return obj

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -9,12 +9,16 @@ if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
     pass
 
 
-class UndefinedSubstitution(Exception):
+class UndefinedSubstitutionError(Exception):
     """Error raised when a requested substitution is missing."""
 
     def __init__(self, input_name: str) -> None:
         super().__init__(f"No substitution found for input {input_name}")
         self.input = input_name
+
+
+# ``UndefinedSubstitution`` is kept for compatibility with the real package.
+UndefinedSubstitution = UndefinedSubstitutionError
 
 
 def extract_inputs(obj: Any) -> set[str]:
@@ -53,7 +57,7 @@ def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
             try:
                 return substitutions[input_obj.name]
             except KeyError as exc:
-                raise UndefinedSubstitution(input_obj.name) from exc
+                raise UndefinedSubstitutionError(input_obj.name) from exc
         case str() | bytes() | bytearray():
             return obj
         case Sequence() as seq:

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -6,7 +6,7 @@ from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:  # pragma: no cover - imported for type checkers only
-    from . import Input
+    pass
 
 
 class UndefinedSubstitution(Exception):

--- a/annotatedyaml/input.py
+++ b/annotatedyaml/input.py
@@ -27,34 +27,36 @@ def extract_inputs(obj: Any) -> set[str]:
 def _extract_inputs(obj: Any, found: set[str]) -> None:
     """Recursive helper for :func:`extract_inputs`."""
 
-    if isinstance(obj, Input):
-        found.add(obj.name)
-        return
-
-    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
-        for value in obj:
-            _extract_inputs(value, found)
-        return
-
-    if isinstance(obj, Mapping):
-        for value in obj.values():
-            _extract_inputs(value, found)
-        return
+    match obj:
+        case Input() as input_obj:
+            found.add(input_obj.name)
+        case str() | bytes() | bytearray():
+            pass
+        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+            for value in seq:
+                _extract_inputs(value, found)
+        case Mapping() as mapping:
+            for value in mapping.values():
+                _extract_inputs(value, found)
 
 
 def substitute(obj: Any, substitutions: Mapping[str, Any]) -> Any:
     """Replace :class:`Input` placeholders in ``obj`` using ``substitutions``."""
 
-    if isinstance(obj, Input):
-        try:
-            return substitutions[obj.name]
-        except KeyError as exc:  # pragma: no cover - defensive guard
-            raise UndefinedSubstitution(obj.name) from exc
-
-    if isinstance(obj, Sequence) and not isinstance(obj, str | bytes | bytearray):
-        return [substitute(value, substitutions) for value in obj]
-
-    if isinstance(obj, Mapping):
-        return {key: substitute(value, substitutions) for key, value in obj.items()}
-
-    return obj
+    match obj:
+        case Input() as input_obj:
+            try:
+                return substitutions[input_obj.name]
+            except KeyError as exc:  # pragma: no cover - defensive guard
+                raise UndefinedSubstitution(input_obj.name) from exc
+        case str() | bytes() | bytearray():
+            return obj
+        case Sequence() as seq if not isinstance(seq, (str, bytes, bytearray)):
+            return [substitute(value, substitutions) for value in seq]
+        case Mapping() as mapping:
+            return {
+                key: substitute(value, substitutions)
+                for key, value in mapping.items()
+            }
+        case _:
+            return obj


### PR DESCRIPTION
## Summary
- add a minimal `annotatedyaml.input` module so imports succeed during test collection
- extend the stub `Input` class and re-export helper utilities for compatibility with Home Assistant expectations

## Testing
- pytest *(fails: Skipping PawControl tests because dependencies are missing: homeassistant)*

------
https://chatgpt.com/codex/tasks/task_e_68d64f0db13483318532d2f493d60a2b