### PR TITLE
Refactor unit conversion helper

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -1134,8 +1134,7 @@ def convert_units(value: float, from_unit: str, to_unit: str) -> float:
     conversion = _UNIT_CONVERSIONS.get((normalized_from, normalized_to))
     if conversion is None:
         raise ValueError(
-            "Conversion from %s to %s not supported (available: %s)"
-            % (normalized_from, normalized_to, _AVAILABLE_CONVERSIONS_MESSAGE)
+            f"Conversion from {normalized_from} to {normalized_to} not supported (available: {_AVAILABLE_CONVERSIONS_MESSAGE})"
         )
 
     return conversion(value)

--- a/tests/test_utils_convert_units.py
+++ b/tests/test_utils_convert_units.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import pytest
-
 from custom_components.pawcontrol.utils import convert_units
 
 

--- a/tests/test_utils_convert_units.py
+++ b/tests/test_utils_convert_units.py
@@ -1,0 +1,40 @@
+"""Tests for :mod:`custom_components.pawcontrol.utils.convert_units`."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.pawcontrol.utils import convert_units
+
+
+@pytest.mark.parametrize(
+    ("value", "from_unit", "to_unit", "expected"),
+    [
+        (1.0, "kg", "lb", pytest.approx(2.20462)),
+        (32.0, "f", "c", pytest.approx(0)),
+        (5280.0, "ft", "mi", pytest.approx(1.0)),
+    ],
+)
+def test_convert_units_known_conversion(
+    value: float, from_unit: str, to_unit: str, expected: float
+) -> None:
+    """The helper converts between supported unit pairs."""
+
+    assert convert_units(value, from_unit, to_unit) == expected
+
+
+def test_convert_units_same_unit_returns_original_value() -> None:
+    """No conversion is performed when the requested units match."""
+
+    assert convert_units(10.0, "kg", "KG") == 10.0
+
+
+def test_convert_units_unsupported_pair_raises_value_error() -> None:
+    """Unsupported unit pairs produce a helpful :class:`ValueError`."""
+
+    with pytest.raises(ValueError) as excinfo:
+        convert_units(1.0, "lightyear", "m")
+
+    message = str(excinfo.value)
+    assert "lightyear" in message
+    assert "available" in message


### PR DESCRIPTION
## Summary
- move unit conversion mapping in `utils.convert_units` to reusable module-level constants
- improve normalization and error reporting for unsupported unit conversions
- add direct unit tests that cover supported and unsupported conversions

## Testing
- pytest *(fails: dependencies missing: homeassistant)*

------
https://chatgpt.com/codex/tasks/task_e_68d65a85a9dc83318e7230d20ebf1686