### PR TITLE
Add stub annotatedyaml dumper module

### DIFF
--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -1,0 +1,95 @@
+"""Minimal dumper helpers for the ``annotatedyaml`` stub package.
+
+The real :mod:`annotatedyaml.dumper` module is fairly feature rich and wraps
+`PyYAML <https://pyyaml.org/>`_.  The Home Assistant test-suite only needs the
+module to exist so that imports succeed and, on occasion, to serialise a small
+object graph back to YAML.  This lightweight re-implementation focuses on the
+behaviour that the tests rely on while remaining entirely dependency free.
+
+If :mod:`yaml` (PyYAML) is available it is used to produce the output; otherwise
+the functions fall back to a very small in-memory representation that mirrors
+the structure of the provided data.  The fallback keeps the return types stable
+for the tests without pulling a heavy dependency into the execution environment.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+try:  # pragma: no cover - optional dependency
+    import yaml
+except Exception:  # pragma: no cover - PyYAML is optional for the stub
+    yaml = None  # type: ignore[assignment]
+
+__all__ = ["add_representer", "dump", "represent_odict", "save_yaml"]
+
+# ``yaml`` maintains global registries for representers.  The real implementation
+# forwards the registration to PyYAML, so we simply do the same when available
+# and otherwise keep track of the request so the API surface remains compatible.
+_registered_representers: list[tuple[type[Any], Callable[..., Any]]] = []
+
+
+def add_representer(data_type: type[Any], representer: Callable[..., Any]) -> None:
+    """Register a custom representer with PyYAML if available.
+
+    When PyYAML is not installed we store the registration request so that tests
+    inspecting the registry can still observe the representative metadata.  This
+    mirrors the behaviour relied upon by the Home Assistant utilities without
+    introducing a hard dependency on PyYAML.
+    """
+
+    if yaml is not None:  # pragma: no branch - trivial guard
+        yaml.add_representer(data_type, representer)
+    _registered_representers.append((data_type, representer))
+
+
+def represent_odict(value: OrderedDict[Any, Any] | dict[str, Any]) -> list[tuple[Any, Any]]:
+    """Return a list representation for ordered dictionaries.
+
+    PyYAML uses ``represent_odict`` to convert ordered dictionaries into a
+    sequence of key/value pairs.  Returning a list keeps the ordering intact and
+    works for both the real dumper and the simplified fallback used in tests.
+    """
+
+    if isinstance(value, OrderedDict):
+        items: Iterable[tuple[Any, Any]] = value.items()
+    else:
+        items = value.items()
+    return list(items)
+
+
+def dump(data: Any, stream: Any | None = None, **kwargs: Any) -> str | None:
+    """Serialise ``data`` to YAML.
+
+    When a stream is provided the YAML representation is written to it and the
+    function returns ``None`` (matching :func:`yaml.dump`).  Without PyYAML we
+    fall back to :func:`repr`, which is sufficient for the unit tests that only
+    need deterministic string output.
+    """
+
+    if yaml is None:
+        rendered = repr(data)
+    else:  # pragma: no cover - exercised indirectly via tests
+        rendered = yaml.safe_dump(data, **kwargs)
+
+    if stream is None:
+        return rendered
+
+    stream.write(rendered)
+    return None
+
+
+def save_yaml(filename: str | Path, data: Any) -> None:
+    """Persist ``data`` as YAML to ``filename``.
+
+    The helper mirrors the behaviour of the real ``save_yaml`` function which
+    always overwrites the target file.  We rely on :func:`dump` so that both the
+    PyYAML-backed and fallback implementations are covered.
+    """
+
+    path = Path(filename)
+    with path.open("w", encoding="utf-8") as handle:
+        dump(data, stream=handle)
+

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -15,8 +15,9 @@ for the tests without pulling a heavy dependency into the execution environment.
 from __future__ import annotations
 
 from collections import OrderedDict
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any
 
 try:  # pragma: no cover - optional dependency
     import yaml
@@ -45,7 +46,9 @@ def add_representer(data_type: type[Any], representer: Callable[..., Any]) -> No
     _registered_representers.append((data_type, representer))
 
 
-def represent_odict(value: OrderedDict[Any, Any] | dict[str, Any]) -> list[tuple[Any, Any]]:
+def represent_odict(
+    value: OrderedDict[Any, Any] | dict[str, Any],
+) -> list[tuple[Any, Any]]:
     """Return a list representation for ordered dictionaries.
 
     PyYAML uses ``represent_odict`` to convert ordered dictionaries into a
@@ -92,4 +95,3 @@ def save_yaml(filename: str | Path, data: Any) -> None:
     path = Path(filename)
     with path.open("w", encoding="utf-8") as handle:
         dump(data, stream=handle)
-

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
-from pathlib import Path
+from typing import Any, Callable, Iterable, TextIO
 from typing import Any
 
 try:  # pragma: no cover - optional dependency

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -15,12 +15,13 @@ for the tests without pulling a heavy dependency into the execution environment.
 from __future__ import annotations
 
 from collections import OrderedDict
-from collections.abc import Callable, Iterable
-from typing import Any
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any, TextIO
 
 try:  # pragma: no cover - optional dependency
     import yaml
-except Exception:  # pragma: no cover - PyYAML is optional for the stub
+except ImportError:  # pragma: no cover - PyYAML is optional for the stub
     yaml = None  # type: ignore[assignment]
 
 __all__ = ["add_representer", "dump", "represent_odict", "save_yaml"]
@@ -28,7 +29,7 @@ __all__ = ["add_representer", "dump", "represent_odict", "save_yaml"]
 # ``yaml`` maintains global registries for representers.  The real implementation
 # forwards the registration to PyYAML, so we simply do the same when available
 # and otherwise keep track of the request so the API surface remains compatible.
-_registered_representers: list[tuple[type[Any], Callable[..., Any]]] = []
+_registered_representers: dict[type[Any], Callable[..., Any]] = {}
 
 
 def add_representer(data_type: type[Any], representer: Callable[..., Any]) -> None:
@@ -42,39 +43,36 @@ def add_representer(data_type: type[Any], representer: Callable[..., Any]) -> No
 
     if yaml is not None:  # pragma: no branch - trivial guard
         yaml.add_representer(data_type, representer)
-    _registered_representers.append((data_type, representer))
+    _registered_representers[data_type] = representer
 
 
 def represent_odict(
-    value: OrderedDict[Any, Any] | dict[str, Any],
+    value: OrderedDict[Any, Any] | dict[Any, Any],
 ) -> list[tuple[Any, Any]]:
     """Return a list representation for ordered dictionaries.
 
     PyYAML uses ``represent_odict`` to convert ordered dictionaries into a
-    sequence of key/value pairs.  Returning a list keeps the ordering intact and
-    works for both the real dumper and the simplified fallback used in tests.
+    sequence of key/value pairs.  Returning a list keeps the ordering intact for
+    :class:`collections.OrderedDict` and mirrors CPython's insertion-ordered
+    ``dict`` implementation.
     """
 
-    if isinstance(value, OrderedDict):
-        items: Iterable[tuple[Any, Any]] = value.items()
-    else:
-        items = value.items()
-    return list(items)
+    return list(value.items())
 
 
-def dump(data: Any, stream: Any | None = None, **kwargs: Any) -> str | None:
+def dump(data: Any, stream: TextIO | None = None, **kwargs: Any) -> str | None:
     """Serialise ``data`` to YAML.
 
     When a stream is provided the YAML representation is written to it and the
     function returns ``None`` (matching :func:`yaml.dump`).  Without PyYAML we
-    fall back to :func:`repr`, which is sufficient for the unit tests that only
-    need deterministic string output.
+    fall back to a small, built-in serialiser that covers the primitive data
+    structures used within the test-suite.
     """
 
-    if yaml is None:
-        rendered = repr(data)
-    else:  # pragma: no cover - exercised indirectly via tests
+    if yaml is not None:  # pragma: no cover - exercised indirectly via tests
         rendered = yaml.safe_dump(data, **kwargs)
+    else:
+        rendered = _minimal_yaml_serialize(data)
 
     if stream is None:
         return rendered
@@ -92,5 +90,47 @@ def save_yaml(filename: str | Path, data: Any) -> None:
     """
 
     path = Path(filename)
-    with path.open("w", encoding="utf-8") as handle:
-        dump(data, stream=handle)
+    try:
+        with path.open("w", encoding="utf-8") as handle:
+            dump(data, stream=handle)
+    except OSError as exc:
+        raise IOError(f"Failed to save YAML to {filename}: {exc}") from exc
+
+
+def _minimal_yaml_serialize(data: Any, *, _indent: int = 0) -> str:
+    """Serialise ``data`` into a simple YAML representation."""
+
+    indent = " " * _indent
+    if data is None:
+        return f"{indent}null\n"
+    if isinstance(data, bool):
+        return f"{indent}{'true' if data else 'false'}\n"
+    if isinstance(data, (int, float)):
+        return f"{indent}{data}\n"
+    if isinstance(data, str):
+        return f"{indent}{data}\n"
+    if isinstance(data, (list, tuple)):
+        if not data:
+            return f"{indent}[]\n"
+        lines: list[str] = []
+        for item in data:
+            if isinstance(item, (list, tuple, dict)):
+                lines.append(f"{indent}-\n")
+                lines.append(_minimal_yaml_serialize(item, _indent=_indent + 2))
+            else:
+                rendered = _minimal_yaml_serialize(item, _indent=_indent + 2)
+                lines.append(f"{indent}- {rendered.strip()}\n")
+        return "".join(lines)
+    if isinstance(data, dict):
+        if not data:
+            return f"{indent}{{}}\n"
+        lines = []
+        for key, value in data.items():
+            if isinstance(value, (list, tuple, dict)):
+                lines.append(f"{indent}{key}:\n")
+                lines.append(_minimal_yaml_serialize(value, _indent=_indent + 2))
+            else:
+                rendered = _minimal_yaml_serialize(value, _indent=_indent + 2)
+                lines.append(f"{indent}{key}: {rendered.strip()}\n")
+        return "".join(lines)
+    return f"{indent}{repr(data)}\n"

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from collections.abc import Callable, Iterable
-from typing import Any, Callable, Iterable, TextIO
 from typing import Any
 
 try:  # pragma: no cover - optional dependency

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -14,6 +14,7 @@ for the tests without pulling a heavy dependency into the execution environment.
 
 from __future__ import annotations
 
+import json
 from collections import OrderedDict
 from collections.abc import Callable
 from pathlib import Path
@@ -108,7 +109,7 @@ def _minimal_yaml_serialize(data: Any, *, _indent: int = 0) -> str:
     if isinstance(data, int | float):
         return f"{indent}{data}\n"
     if isinstance(data, str):
-        return f"{indent}{data}\n"
+        return f"{indent}{json.dumps(data, ensure_ascii=False)}\n"
     if isinstance(data, list | tuple):
         if not data:
             return f"{indent}[]\n"

--- a/annotatedyaml/dumper.py
+++ b/annotatedyaml/dumper.py
@@ -94,7 +94,7 @@ def save_yaml(filename: str | Path, data: Any) -> None:
         with path.open("w", encoding="utf-8") as handle:
             dump(data, stream=handle)
     except OSError as exc:
-        raise IOError(f"Failed to save YAML to {filename}: {exc}") from exc
+        raise OSError(f"Failed to save YAML to {filename}: {exc}") from exc
 
 
 def _minimal_yaml_serialize(data: Any, *, _indent: int = 0) -> str:
@@ -105,16 +105,16 @@ def _minimal_yaml_serialize(data: Any, *, _indent: int = 0) -> str:
         return f"{indent}null\n"
     if isinstance(data, bool):
         return f"{indent}{'true' if data else 'false'}\n"
-    if isinstance(data, (int, float)):
+    if isinstance(data, int | float):
         return f"{indent}{data}\n"
     if isinstance(data, str):
         return f"{indent}{data}\n"
-    if isinstance(data, (list, tuple)):
+    if isinstance(data, list | tuple):
         if not data:
             return f"{indent}[]\n"
         lines: list[str] = []
         for item in data:
-            if isinstance(item, (list, tuple, dict)):
+            if isinstance(item, list | tuple | dict):
                 lines.append(f"{indent}-\n")
                 lines.append(_minimal_yaml_serialize(item, _indent=_indent + 2))
             else:
@@ -126,11 +126,11 @@ def _minimal_yaml_serialize(data: Any, *, _indent: int = 0) -> str:
             return f"{indent}{{}}\n"
         lines = []
         for key, value in data.items():
-            if isinstance(value, (list, tuple, dict)):
+            if isinstance(value, list | tuple | dict):
                 lines.append(f"{indent}{key}:\n")
                 lines.append(_minimal_yaml_serialize(value, _indent=_indent + 2))
             else:
                 rendered = _minimal_yaml_serialize(value, _indent=_indent + 2)
                 lines.append(f"{indent}{key}: {rendered.strip()}\n")
         return "".join(lines)
-    return f"{indent}{repr(data)}\n"
+    return f"{indent}{data!r}\n"

--- a/annotatedyaml/loader.py
+++ b/annotatedyaml/loader.py
@@ -6,7 +6,13 @@ from typing import Any
 
 from . import Input
 
-__all__ = ["load_yaml"]
+__all__ = ["HAS_C_LOADER", "load_yaml"]
+
+# ``HAS_C_LOADER`` is exposed by the real ``annotatedyaml`` package to signal
+# whether the optional LibYAML-based C extension is available.  Home Assistant
+# checks this flag during its import of the stub, so we provide it here and mark
+# it ``False`` because the stub never bundles the compiled extension.
+HAS_C_LOADER: bool = False
 
 
 def load_yaml(source: str | Input) -> Any:


### PR DESCRIPTION
## Summary
- add a lightweight annotatedyaml.dumper implementation so Home Assistant imports succeed
- provide minimal helpers for registering representers, dumping data, and saving YAML without requiring PyYAML

## Testing
- pytest -q *(fails: Skipping PawControl tests because dependencies are missing: homeassistant)*

------
https://chatgpt.com/codex/tasks/task_e_68d65db053888331ae012f2ee629b9b0