### PR TITLE
Handle awaitable add_entities callbacks

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -171,7 +171,6 @@ async def _async_add_entities_in_batches(
             async_add_entities_func, batch, update_before_add=False
         )
 
-
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch
             await asyncio.sleep(delay_between_batches)

--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -40,7 +40,11 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .types import PawControlConfigEntry
-from .utils import PawControlDeviceLinkMixin, ensure_utc_datetime
+from .utils import (
+    PawControlDeviceLinkMixin,
+    async_call_add_entities,
+    ensure_utc_datetime,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -163,7 +167,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        await async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch
@@ -224,7 +230,9 @@ async def async_setup_entry(
     # OPTIMIZED: Smart batching based on entity count
     if len(entities) <= PARALLEL_THRESHOLD:
         # Small setup: Create all at once for better performance
-        await async_add_entities(entities, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities, entities, update_before_add=False
+        )
         _LOGGER.info(
             "Created %d binary sensor entities for %d dogs (single batch)",
             len(entities),

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -49,7 +49,7 @@ from .const import (
 from .coordinator import PawControlCoordinator
 from .exceptions import WalkAlreadyInProgressError, WalkNotInProgressError
 from .types import PawControlConfigEntry
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -591,29 +591,25 @@ async def async_setup_entry(
 
     if total_buttons_created <= batch_size:
         # Small setup: Add all at once
-        await async_add_entities(all_entities, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities, all_entities, update_before_add=False
+        )
         _LOGGER.info(
             "Created %d button entities (single batch) - profile-optimized count",
             total_buttons_created,
         )
     else:
         # Large setup: Efficient batching
-        async def add_batch(batch: list[PawControlButtonBase]) -> None:
-            """Add a batch of entities."""
-            await async_add_entities(batch, update_before_add=False)
-
         # Create and execute batches
         batches = [
             all_entities[i : i + batch_size]
             for i in range(0, len(all_entities), batch_size)
         ]
 
-        tasks = [add_batch(batch) for batch in batches]
-        try:
-            await asyncio.gather(*tasks)
-        except TypeError:
-            for task in tasks:
-                await task
+        for batch in batches:
+            await async_call_add_entities(
+                async_add_entities, batch, update_before_add=False
+            )
 
         _LOGGER.info(
             "Created %d button entities for %d dogs (profile-based batching)",

--- a/custom_components/pawcontrol/date.py
+++ b/custom_components/pawcontrol/date.py
@@ -13,7 +13,6 @@ Python: 3.13+
 from __future__ import annotations
 
 import asyncio
-import inspect
 import logging
 from contextlib import suppress
 from datetime import date
@@ -41,7 +40,7 @@ from .const import (
 from .coordinator import PawControlCoordinator
 from .exceptions import PawControlError, ValidationError
 from .helpers import performance_monitor
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -85,9 +84,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        result = async_add_entities_func(batch, update_before_add=False)
-        if inspect.isawaitable(result):
-            await result
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -26,7 +26,11 @@ from .const import (
     MODULE_WALK,
 )
 from .coordinator import PawControlCoordinator
-from .utils import PawControlDeviceLinkMixin, ensure_utc_datetime
+from .utils import (
+    PawControlDeviceLinkMixin,
+    async_call_add_entities,
+    ensure_utc_datetime,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -70,7 +74,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch

--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -42,7 +42,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .types import PawControlConfigEntry
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -110,7 +110,9 @@ async def async_setup_entry(
             entities.append(tracker)
 
     if entities:
-        async_add_entities(entities, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities, entities, update_before_add=False
+        )
         _LOGGER.info(
             "Set up %d GPS device trackers with profile '%s'",
             len(entities),

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -49,7 +49,7 @@ from .const import (
     MODULE_WALK,
 )
 from .coordinator import PawControlCoordinator
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -102,7 +102,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch

--- a/custom_components/pawcontrol/optimized_entity_base.py
+++ b/custom_components/pawcontrol/optimized_entity_base.py
@@ -41,7 +41,11 @@ from homeassistant.util import dt as dt_util
 
 from .const import ATTR_DOG_ID, ATTR_DOG_NAME
 from .coordinator import PawControlCoordinator
-from .utils import PawControlDeviceLinkMixin, ensure_utc_datetime
+from .utils import (
+    PawControlDeviceLinkMixin,
+    async_call_add_entities,
+    ensure_utc_datetime,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -1013,7 +1017,9 @@ async def create_optimized_entities_batched(
             len(batch),
         )
 
-        async_add_entities_callback(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_callback, batch, update_before_add=False
+        )
 
         if i + batch_size < total_entities:
             await asyncio.sleep(delay_between_batches)

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -44,7 +44,7 @@ from .const import (
     PERFORMANCE_MODES,
 )
 from .coordinator import PawControlCoordinator
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -137,7 +137,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -39,7 +39,12 @@ from .const import (
 from .coordinator import PawControlCoordinator
 from .entity_factory import EntityFactory
 from .types import PawControlConfigEntry
-from .utils import PawControlDeviceLinkMixin, ensure_utc_datetime, is_number
+from .utils import (
+    PawControlDeviceLinkMixin,
+    async_call_add_entities,
+    ensure_utc_datetime,
+    is_number,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -583,12 +588,16 @@ async def _add_entities_optimized(
 
     if total_entities <= PARALLEL_THRESHOLD:
         # Small setup: Create all at once
-        await async_add_entities(all_entities, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities, all_entities, update_before_add=False
+        )
     else:
         # Large setup: Use optimized batching
         for i in range(0, total_entities, MAX_ENTITIES_PER_BATCH):
             batch = all_entities[i : i + MAX_ENTITIES_PER_BATCH]
-            await async_add_entities(batch, update_before_add=False)
+            await async_call_add_entities(
+                async_add_entities, batch, update_before_add=False
+            )
 
             # Small delay between batches for system stability
             if i + MAX_ENTITIES_PER_BATCH < total_entities:
@@ -2233,8 +2242,6 @@ class PawControlPortionsTodaySensor(PawControlSensorBase):
 
         try:
             return int(feeding_data.get("portions_today", 0))
-        except (TypeError, ValueError):
-            return 0
         except (TypeError, ValueError):
             return 0
 

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -43,7 +43,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .types import PawControlRuntimeData
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -245,7 +245,9 @@ async def _async_add_entities_in_batches(
         )
 
         # Add batch without update_before_add to reduce Registry load
-        await async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         # Small delay between batches to prevent Registry flooding
         if i + batch_size < total_entities:  # No delay after last batch

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -26,7 +26,7 @@ from .const import (
 )
 from .coordinator import PawControlCoordinator
 from .types import DogConfigData, PawControlConfigEntry, PawControlRuntimeData
-from .utils import PawControlDeviceLinkMixin
+from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,7 +120,9 @@ async def _async_add_entities_in_batches(
             len(batch),
         )
 
-        async_add_entities_func(batch, update_before_add=False)
+        await async_call_add_entities(
+            async_add_entities_func, batch, update_before_add=False
+        )
 
         if delay_between_batches > 0 and batch_index + 1 < total_batches:
             await asyncio.sleep(delay_between_batches)

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -131,8 +131,8 @@ def create_device_info(
 
 
 async def async_call_add_entities(
-    add_entities_callback: Callable[[Iterable[Any], bool], Any],
-    entities: Iterable[Any],
+    add_entities_callback: Callable[[Iterable["Entity"], bool], Any],
+    entities: Iterable["Entity"],
     *,
     update_before_add: bool = False,
 ) -> None:

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import inspect
 import logging
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
@@ -127,6 +128,20 @@ def create_device_info(
         device_info["suggested_area"] = suggested_area
 
     return device_info
+
+
+async def async_call_add_entities(
+    add_entities_callback: Callable[[Iterable[Any], bool], Any],
+    entities: Iterable[Any],
+    *,
+    update_before_add: bool = False,
+) -> None:
+    """Invoke Home Assistant's async_add_entities callback and await when needed."""
+
+    result = add_entities_callback(entities, update_before_add=update_before_add)
+
+    if inspect.isawaitable(result):
+        await cast(Awaitable[Any], result)
 
 
 async def async_get_or_create_dog_device_entry(

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -131,8 +131,8 @@ def create_device_info(
 
 
 async def async_call_add_entities(
-    add_entities_callback: Callable[[Iterable["Entity"], bool], Any],
-    entities: Iterable["Entity"],
+    add_entities_callback: Callable[[Iterable[Entity], bool], Any],
+    entities: Iterable[Entity],
     *,
     update_before_add: bool = False,
 ) -> None:

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -23,6 +23,7 @@ from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo
 from homeassistant.util import dt as dt_util
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -23,8 +23,8 @@ from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.entity import Entity
 from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo
+from homeassistant.helpers.entity import Entity
 from homeassistant.util import dt as dt_util
 
 from .const import DEFAULT_MODEL, DOMAIN, MANUFACTURER


### PR DESCRIPTION
## Summary
- add a shared async_call_add_entities helper to await async_add_entities callbacks when they return a coroutine
- route each PawControl platform's setup batching logic through the helper so awaited callbacks work across sensors, buttons, switches, and other entities

## Testing
- pytest tests/components/pawcontrol/test_all_platforms.py -q *(fails: Skipping PawControl tests because dependencies are missing: homeassistant)*

------
https://chatgpt.com/codex/tasks/task_e_68d6fa15609c83319793349ca346ff05