### PR TITLE
Fix number type guard to accept Real values

### DIFF
--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -18,6 +18,7 @@ import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from datetime import datetime, time, timedelta
 from functools import wraps
+from numbers import Real
 from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 
 from homeassistant.core import HomeAssistant
@@ -37,7 +38,7 @@ K = TypeVar("K")
 V = TypeVar("V")
 P = ParamSpec("P")
 R = TypeVar("R")
-Number = int | float
+Number = Real
 
 
 class PortionValidationResult(TypedDict):
@@ -54,7 +55,7 @@ def is_number(value: Any) -> TypeGuard[Number]:
 
     if isinstance(value, bool):
         return False
-    return isinstance(value, int | float)
+    return isinstance(value, Real)
 
 
 def create_device_info(


### PR DESCRIPTION
## Summary
- update `is_number` utility to treat any real number types as valid
- rely on the `numbers.Real` ABC so decimals and fractions are supported while still excluding booleans

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d61730ac8331a51ece758a8cb346