### PR TITLE
Add breed metadata to health metrics

### DIFF
--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -87,6 +87,7 @@ class HealthMetrics:
     ideal_weight: float | None = None
     height_cm: float | None = None
     age_months: int | None = None
+    breed: str | None = None
 
     # Health assessments
     body_condition_score: BodyConditionScore | None = None

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -7,6 +7,8 @@ recommendations for dogs.
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import timedelta
 from enum import Enum
@@ -78,14 +80,30 @@ class DietInteractionDetails(TypedDict):
     risk_level: Literal["low", "medium", "high"]
 
 
-@dataclass
+@dataclass(init=False)
 class HealthMetrics:
-    """Comprehensive health metrics for a dog."""
+    """Comprehensive health metrics for a dog.
+
+    Attributes:
+        breed: Standardized breed name (for example, "Golden Retriever").
+            The value must be a non-empty human readable breed description
+            and is leveraged by weather specific advice to tailor
+            recommendations.
+    """
 
     # Basic measurements
     current_weight: float
     age_months: int | None = None
-    breed: str | None = None
+    breed: str | None = field(
+        default=None,
+        metadata={
+            "doc": (
+                "Standardized breed name (e.g., 'Golden Retriever'). Used "
+                "by downstream weather guidance for breed-specific "
+                "recommendations."
+            )
+        },
+    )
     height_cm: float | None = None
     ideal_weight: float | None = None
 
@@ -107,6 +125,74 @@ class HealthMetrics:
     # NEW: Weather-related adjustments
     weather_conditions: dict[str, Any] | None = None
     weather_health_score: int | None = None
+
+    _BREED_ALLOWED_CHARACTERS = frozenset(" -'" )
+
+    def __init__(
+        self,
+        current_weight: float,
+        ideal_weight: float | None = None,
+        height_cm: float | None = None,
+        age_months: int | None = None,
+        breed: str | None = None,
+        body_condition_score: BodyConditionScore | None = None,
+        activity_level: ActivityLevel | None = None,
+        life_stage: LifeStage | None = None,
+        health_conditions: Iterable[str] | None = None,
+        medications: Iterable[str] | None = None,
+        special_diet: Iterable[str] | None = None,
+        daily_calorie_requirement: float | None = None,
+        portion_adjustment_factor: float = 1.0,
+        weight_goal: str | None = None,
+        weather_conditions: dict[str, Any] | None = None,
+        weather_health_score: int | None = None,
+    ) -> None:
+        self.current_weight = current_weight
+        self.ideal_weight = ideal_weight
+        self.height_cm = height_cm
+        self.age_months = age_months
+        self.breed = self._validate_breed(breed)
+        self.body_condition_score = body_condition_score
+        self.activity_level = activity_level
+        self.life_stage = life_stage
+        self.health_conditions = (
+            list(health_conditions) if health_conditions is not None else []
+        )
+        self.medications = list(medications) if medications is not None else []
+        self.special_diet = list(special_diet) if special_diet is not None else []
+        self.daily_calorie_requirement = daily_calorie_requirement
+        self.portion_adjustment_factor = portion_adjustment_factor
+        self.weight_goal = weight_goal
+        self.weather_conditions = weather_conditions
+        self.weather_health_score = weather_health_score
+
+    @classmethod
+    def _validate_breed(cls, breed: str | None) -> str | None:
+        """Validate and normalize the provided breed string."""
+
+        if breed is None:
+            return None
+        if not isinstance(breed, str):
+            raise TypeError("breed must be provided as a string")
+
+        normalized = breed.strip()
+        if not normalized:
+            raise ValueError("breed must not be empty when provided")
+
+        if len(normalized) < 2:
+            raise ValueError("breed must contain at least two characters")
+
+        if not all(
+            char.isalpha() or char in cls._BREED_ALLOWED_CHARACTERS
+            for char in normalized
+        ):
+            raise ValueError(
+                "breed may only contain letters, spaces, apostrophes, or hyphens"
+            )
+
+        # Collapse repeated internal whitespace to a single space for consistency.
+        normalized = re.sub(r"\s+", " ", normalized)
+        return normalized
 
 
 class HealthCalculator:

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -126,7 +126,7 @@ class HealthMetrics:
     weather_conditions: dict[str, Any] | None = None
     weather_health_score: int | None = None
 
-    _BREED_ALLOWED_CHARACTERS = frozenset(" -'" )
+    _BREED_ALLOWED_CHARACTERS = frozenset(" -'")
 
     def __init__(
         self,

--- a/custom_components/pawcontrol/health_calculator.py
+++ b/custom_components/pawcontrol/health_calculator.py
@@ -84,10 +84,10 @@ class HealthMetrics:
 
     # Basic measurements
     current_weight: float
-    ideal_weight: float | None = None
-    height_cm: float | None = None
     age_months: int | None = None
     breed: str | None = None
+    height_cm: float | None = None
+    ideal_weight: float | None = None
 
     # Health assessments
     body_condition_score: BodyConditionScore | None = None

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -15,7 +15,9 @@ def _load_health_calculator_module() -> types.ModuleType:
     """Load the health_calculator module with lightweight stubs."""
 
     project_root = pathlib.Path(__file__).resolve().parents[2]
-    module_path = project_root / "custom_components" / "pawcontrol" / "health_calculator.py"
+    module_path = (
+        project_root / "custom_components" / "pawcontrol" / "health_calculator.py"
+    )
 
     if "homeassistant" not in sys.modules:
         homeassistant_pkg = types.ModuleType("homeassistant")
@@ -39,7 +41,9 @@ def _load_health_calculator_module() -> types.ModuleType:
     module = types.ModuleType(module_name)
     module.__file__ = str(module_path)
     module.__package__ = "custom_components.pawcontrol"
-    module.__loader__ = importlib.machinery.SourceFileLoader(module_name, str(module_path))
+    module.__loader__ = importlib.machinery.SourceFileLoader(
+        module_name, str(module_path)
+    )
     module.ensure_local_datetime = lambda value: value
     sys.modules[module_name] = module
 
@@ -119,9 +123,7 @@ def test_breed_recommendations_are_requested_when_breed_valid() -> None:
     )
 
     # Breed value should be normalised and forwarded to the weather manager
-    assert manager.requests == [
-        ("golden retriever", 30, ["arthritis"])
-    ]
+    assert manager.requests == [("golden retriever", 30, ["arthritis"])]
     assert report["recommendations"] == [
         "limit midday walks",
         "ensure hydration",

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -1,0 +1,140 @@
+"""Unit tests for the HealthMetrics dataclass enhancements."""
+
+from __future__ import annotations
+
+import importlib.machinery
+import pathlib
+import sys
+import types
+from dataclasses import dataclass
+
+import pytest
+
+
+def _load_health_calculator_module() -> types.ModuleType:
+    """Load the health_calculator module with lightweight stubs."""
+
+    project_root = pathlib.Path(__file__).resolve().parents[2]
+    module_path = project_root / "custom_components" / "pawcontrol" / "health_calculator.py"
+
+    if "homeassistant" not in sys.modules:
+        homeassistant_pkg = types.ModuleType("homeassistant")
+        homeassistant_pkg.__path__ = []
+        sys.modules["homeassistant"] = homeassistant_pkg
+
+    ha_util = types.ModuleType("homeassistant.util")
+    ha_dt = types.ModuleType("homeassistant.util.dt")
+
+    def _now():
+        from datetime import datetime
+
+        return datetime.utcnow()
+
+    ha_dt.now = _now
+    ha_util.dt = ha_dt
+    sys.modules["homeassistant.util"] = ha_util
+    sys.modules["homeassistant.util.dt"] = ha_dt
+
+    module_name = "custom_components.pawcontrol.health_calculator"
+    module = types.ModuleType(module_name)
+    module.__file__ = str(module_path)
+    module.__package__ = "custom_components.pawcontrol"
+    module.__loader__ = importlib.machinery.SourceFileLoader(module_name, str(module_path))
+    module.ensure_local_datetime = lambda value: value
+    sys.modules[module_name] = module
+
+    source = module_path.read_text(encoding="utf-8")
+    source = source.replace("from .utils import ensure_local_datetime\n", "")
+    exec(compile(source, module.__file__, "exec"), module.__dict__)
+    return module
+
+
+health_calculator = _load_health_calculator_module()
+HealthCalculator = health_calculator.HealthCalculator
+HealthMetrics = health_calculator.HealthMetrics
+
+
+@dataclass
+class _WeatherConditions:
+    temperature_c: float | None = None
+    humidity_percent: float | None = None
+
+
+class _StubWeatherHealthManager:
+    """Simple stub that tracks recommendation requests."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, int | None, list[str]]] = []
+
+    @staticmethod
+    def get_weather_health_score() -> int:
+        return 82
+
+    @staticmethod
+    def get_active_alerts() -> list:
+        return []
+
+    def get_recommendations_for_dog(
+        self,
+        *,
+        dog_breed: str,
+        dog_age_months: int | None,
+        health_conditions: list[str],
+    ) -> list[str]:
+        self.requests.append((dog_breed, dog_age_months, list(health_conditions)))
+        return [
+            "limit midday walks",
+            "ensure hydration",
+            "monitor paw pads",
+            "consider protective booties",
+        ]
+
+
+def _blank_report() -> dict[str, object]:
+    return {
+        "recommendations": [],
+        "areas_of_concern": [],
+        "positive_indicators": [],
+        "health_score": 100,
+    }
+
+
+def test_breed_recommendations_are_requested_when_breed_valid() -> None:
+    manager = _StubWeatherHealthManager()
+    metrics = HealthMetrics(
+        current_weight=24.5,
+        ideal_weight=23.0,
+        height_cm=55.0,
+        age_months=30,
+        breed="  golden retriever  ",
+        health_conditions=["arthritis"],
+    )
+
+    report = _blank_report()
+    HealthCalculator._assess_weather_impact(
+        metrics,
+        _WeatherConditions(temperature_c=21.0),
+        manager,
+        report,
+    )
+
+    # Breed value should be normalised and forwarded to the weather manager
+    assert manager.requests == [
+        ("golden retriever", 30, ["arthritis"])
+    ]
+    assert report["recommendations"] == [
+        "limit midday walks",
+        "ensure hydration",
+        "monitor paw pads",
+    ]
+
+
+@pytest.mark.parametrize("invalid_breed", ["", " ", "?", "1", "a"])
+def test_invalid_breed_values_raise_value_error(invalid_breed: str) -> None:
+    with pytest.raises(ValueError):
+        HealthMetrics(current_weight=10.0, breed=invalid_breed)
+
+
+def test_non_string_breed_values_raise_type_error() -> None:
+    with pytest.raises(TypeError):
+        HealthMetrics(current_weight=12.0, breed=123)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
- add an optional breed field to the HealthMetrics dataclass so downstream weather advice can read it safely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d7d9377dec8331ba2460bab4349ec9