### PR TITLE
Add missing docstring for device client constructor

### DIFF
--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -24,7 +24,7 @@ class DeviceEndpoint:
 
 
 def validate_device_endpoint(endpoint: str) -> URL:
-    """Validate and normalise the configured device endpoint."""
+    """Validate and normalize the configured device endpoint."""
 
     if not endpoint:
         raise ValueError("endpoint must be provided for device client")
@@ -53,7 +53,7 @@ class PawControlDeviceClient:
         api_key: str | None = None,
         timeout: ClientTimeout | None = None,
     ) -> None:
-        """Initialise the client with a configured session and endpoint."""
+        """Initialize the client with a configured session and endpoint."""
 
         base_url = validate_device_endpoint(endpoint)
 
@@ -83,7 +83,7 @@ class PawControlDeviceClient:
         return await self.async_get_json(f"/api/dogs/{dog_id}/feeding")
 
     async def _async_request(self, method: str, path: str) -> ClientResponse:
-        """Execute an HTTP request and normalise errors."""
+        """Execute an HTTP request and normalize errors."""
 
         url = self._endpoint.base_url.join(URL(path))
         headers: dict[str, str] | None = None

--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -43,7 +43,12 @@ def validate_device_endpoint(endpoint: str) -> URL:
 
 
 class PawControlDeviceClient:
-    """Minimal client that talks to Paw Control companion devices."""
+    """Optional client for direct Paw Control companion communication.
+
+    Home Assistant primarily supplies data via the native app integration, so
+    this client only acts as the fallback path when external integrations are
+    enabled.
+    """
 
     def __init__(
         self,
@@ -53,7 +58,7 @@ class PawControlDeviceClient:
         api_key: str | None = None,
         timeout: ClientTimeout | None = None,
     ) -> None:
-        """Initialize the client with a configured session and endpoint."""
+        """Initialize the client for optional companion device access."""
 
         base_url = validate_device_endpoint(endpoint)
 
@@ -63,7 +68,7 @@ class PawControlDeviceClient:
 
     @property
     def base_url(self) -> URL:
-        """Return the configured base URL."""
+        """Return the configured base URL for the companion endpoint."""
 
         return self._endpoint.base_url
 
@@ -78,7 +83,7 @@ class PawControlDeviceClient:
         return payload
 
     async def async_get_feeding_payload(self, dog_id: str) -> Mapping[str, Any]:
-        """Fetch the latest feeding payload for a dog."""
+        """Fetch the latest feeding payload for a dog from the companion device."""
 
         return await self.async_get_json(f"/api/dogs/{dog_id}/feeding")
 

--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -53,6 +53,8 @@ class PawControlDeviceClient:
         api_key: str | None = None,
         timeout: ClientTimeout | None = None,
     ) -> None:
+        """Initialise the client with a configured session and endpoint."""
+
         base_url = validate_device_endpoint(endpoint)
 
         self._session = session


### PR DESCRIPTION
## Summary
- add a short docstring to the PawControlDeviceClient constructor to align with documentation guidelines

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8831b6ba883319c7a969ea13d0493