### PR TITLE
Add diagnostics scorecard for adaptive polling and webhook security

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -7,7 +7,7 @@ import logging
 import time
 from collections import deque
 from dataclasses import dataclass
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from statistics import fmean
 from typing import TYPE_CHECKING, Any
 
@@ -89,13 +89,13 @@ class AdaptivePollingController:
     """Manage dynamic polling intervals based on runtime performance."""
 
     __slots__ = (
-        "_history",
-        "_min_interval",
-        "_max_interval",
-        "_target_cycle",
         "_current_interval",
-        "_error_streak",
         "_entity_saturation",
+        "_error_streak",
+        "_history",
+        "_max_interval",
+        "_min_interval",
+        "_target_cycle",
     )
 
     def __init__(
@@ -157,7 +157,9 @@ class AdaptivePollingController:
         else:
             load_factor = 1.0 + (self._entity_saturation * 0.5)
             if average_duration < self._target_cycle * 0.8:
-                reduction_factor = min(2.0, (self._target_cycle / average_duration) * 0.5)
+                reduction_factor = min(
+                    2.0, (self._target_cycle / average_duration) * 0.5
+                )
                 next_interval = max(
                     self._min_interval,
                     next_interval / max(1.0, reduction_factor * load_factor),
@@ -187,6 +189,7 @@ class AdaptivePollingController:
             "error_streak": self._error_streak,
             "entity_saturation": round(self._entity_saturation, 3),
         }
+
 
 class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
     """Central data coordinator with a compact, testable core."""
@@ -350,7 +353,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         average_utilization = (
             (total_allocated / total_capacity) if total_capacity else 0.0
         )
-        peak_utilization = max((snapshot.saturation for snapshot in snapshots), default=0.0)
+        peak_utilization = max(
+            (snapshot.saturation for snapshot in snapshots), default=0.0
+        )
 
         return {
             "active_dogs": len(snapshots),
@@ -488,16 +493,12 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             # PLATINUM: Enhanced failure analysis
             total_dogs = len(dog_ids)
-            success_rate = (
-                (total_dogs - errors) / total_dogs if total_dogs > 0 else 0
-            )
+            success_rate = (total_dogs - errors) / total_dogs if total_dogs > 0 else 0
 
             if errors == total_dogs:
                 self._error_count += 1
                 self._consecutive_errors += 1
-                raise CoordinatorUpdateFailed(
-                    f"All {total_dogs} dogs failed to update"
-                )
+                raise CoordinatorUpdateFailed(f"All {total_dogs} dogs failed to update")
 
             if success_rate < 0.5:
                 self._consecutive_errors += 1

--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -551,41 +551,9 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return self._data
 
     async def _fetch_all_dogs(self, dog_ids: list[str]) -> UpdateResult:
+        """Fetch data for all configured dogs with resilience protections."""
+
         result = UpdateResult()
-
-        Returns:
-            Dictionary containing update statistics and performance metrics
-        """
-        successful_updates = max(self._update_count - self._error_count, 0)
-        cache_metrics = self._modules.cache_metrics()
-        cache_entries = cache_metrics.entries
-        cache_hit_rate = cache_metrics.hit_rate
-        entity_budget_summary = self._summarize_entity_budgets()
-        adaptive_metrics = self._adaptive_polling.as_diagnostics()
-
-        return {
-            "update_counts": {
-                "total": self._update_count,
-                "successful": successful_updates,
-                "failed": self._error_count,
-                "consecutive_errors": self._consecutive_errors,
-            },
-            "performance_metrics": {
-                "api_calls": self._update_count if self._use_external_api else 0,
-                "cache_entries": cache_entries,
-                "cache_hit_rate": round(cache_hit_rate, 1),
-                "cache_ttl": CACHE_TTL_SECONDS,
-            },
-            "health_indicators": {
-                "success_rate": round(
-                    (successful_updates / max(self._update_count, 1)) * 100, 1
-                ),
-                "is_healthy": self._consecutive_errors < 3,
-                "external_api_enabled": self._use_external_api,
-            },
-            "entity_budget": entity_budget_summary,
-            "adaptive_polling": adaptive_metrics,
-        }
         tasks = [self._fetch_with_resilience(dog_id) for dog_id in dog_ids]
         responses = await asyncio.gather(*tasks, return_exceptions=True)
 
@@ -610,6 +578,90 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 result.add_success(dog_id, response)
 
         return result
+
+    def get_performance_snapshot(self) -> dict[str, Any]:
+        """Return a lightweight performance snapshot for diagnostics."""
+
+        successful_updates = max(self._update_count - self._error_count, 0)
+        cache_metrics = self._modules.cache_metrics()
+        entity_budget_summary = self._summarize_entity_budgets()
+        adaptive_metrics = self._adaptive_polling.as_diagnostics()
+
+        return {
+            "update_counts": {
+                "total": self._update_count,
+                "successful": successful_updates,
+                "failed": self._error_count,
+                "consecutive_errors": self._consecutive_errors,
+            },
+            "performance_metrics": {
+                "api_calls": self._update_count if self._use_external_api else 0,
+                "cache_entries": cache_metrics.entries,
+                "cache_hit_rate": round(cache_metrics.hit_rate, 1),
+                "cache_ttl": CACHE_TTL_SECONDS,
+            },
+            "health_indicators": {
+                "success_rate": round(
+                    (successful_updates / max(self._update_count, 1)) * 100, 1
+                ),
+                "is_healthy": self._consecutive_errors < 3,
+                "external_api_enabled": self._use_external_api,
+            },
+            "entity_budget": entity_budget_summary,
+            "adaptive_polling": adaptive_metrics,
+        }
+
+    def get_security_scorecard(self) -> dict[str, Any]:
+        """Evaluate performance and security posture for key subsystems."""
+
+        adaptive_metrics = self._adaptive_polling.as_diagnostics()
+        average_cycle_ms = adaptive_metrics.get("average_cycle_ms", 0.0)
+        current_interval_ms = adaptive_metrics.get("current_interval_ms", 0.0)
+        update_cycle_ms = average_cycle_ms or current_interval_ms
+        cycle_pass = update_cycle_ms <= 200.0
+
+        entity_budget_summary = self._summarize_entity_budgets()
+        budget_peak = entity_budget_summary.get("peak_utilization", 0.0)
+        denied_requests = entity_budget_summary.get("denied_requests", 0)
+        budget_pass = budget_peak <= 100.0 and denied_requests == 0
+
+        webhook_status = {
+            "configured": False,
+            "secure": False,
+            "hmac_ready": False,
+            "insecure_configs": (),
+        }
+        if self.notification_manager is not None:
+            webhook_status = self.notification_manager.webhook_security_status()
+
+        webhooks_pass = (not webhook_status["configured"]) or webhook_status["secure"]
+
+        overall_pass = cycle_pass and budget_pass and webhooks_pass
+
+        return {
+            "status": "pass" if overall_pass else "fail",
+            "checks": {
+                "adaptive_polling": {
+                    "target_cycle_ms": adaptive_metrics.get("target_cycle_ms", 200.0),
+                    "update_cycle_ms": round(update_cycle_ms, 2),
+                    "history_samples": adaptive_metrics.get("history_samples", 0),
+                    "pass": cycle_pass,
+                },
+                "entity_budget": {
+                    "peak_utilization": budget_peak,
+                    "denied_requests": denied_requests,
+                    "active_dogs": entity_budget_summary.get("active_dogs", 0),
+                    "pass": budget_pass,
+                },
+                "webhooks": {
+                    "configured": webhook_status.get("configured", False),
+                    "secure": webhook_status.get("secure", False),
+                    "hmac_ready": webhook_status.get("hmac_ready", False),
+                    "insecure_configs": webhook_status.get("insecure_configs", ()),
+                    "pass": webhooks_pass,
+                },
+            },
+        }
 
     async def _fetch_with_resilience(self, dog_id: str) -> dict[str, Any]:
         return await self.resilience_manager.execute_with_resilience(

--- a/custom_components/pawcontrol/entity_factory.py
+++ b/custom_components/pawcontrol/entity_factory.py
@@ -433,9 +433,7 @@ class EntityFactory:
 
         return self._active_budgets.get((dog_id, profile))
 
-    def finalize_budget(
-        self, dog_id: str, profile: str
-    ) -> EntityBudgetSnapshot | None:
+    def finalize_budget(self, dog_id: str, profile: str) -> EntityBudgetSnapshot | None:
         """Finalize and report the entity budget for a dog/profile."""
 
         key = (dog_id, profile)

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -1677,6 +1677,31 @@ class PawControlNotificationManager:
                 "person_entity_stats": person_stats,
             }
 
+    def webhook_security_status(self) -> dict[str, Any]:
+        """Return aggregated HMAC webhook security information."""
+
+        webhook_configs: list[str] = []
+        insecure_configs: list[str] = []
+
+        for config_key, config in self._configs.items():
+            if NotificationChannel.WEBHOOK not in config.channels:
+                continue
+
+            webhook_configs.append(config_key)
+            secret = config.custom_settings.get("webhook_secret")
+            if not isinstance(secret, str) or not secret.strip():
+                insecure_configs.append(config_key)
+
+        configured = bool(webhook_configs)
+        secure = configured and not insecure_configs
+
+        return {
+            "configured": configured,
+            "secure": secure,
+            "hmac_ready": secure,
+            "insecure_configs": tuple(insecure_configs),
+        }
+
     async def async_shutdown(self) -> None:
         """Enhanced shutdown with comprehensive cleanup."""
         # Cancel all background tasks

--- a/custom_components/pawcontrol/notifications.py
+++ b/custom_components/pawcontrol/notifications.py
@@ -1294,7 +1294,9 @@ class PawControlNotificationManager:
                 algorithm=algorithm,
                 tolerance_seconds=tolerance,
             )
-            headers.update(manager.build_headers(payload_bytes, header_prefix=header_prefix))
+            headers.update(
+                manager.build_headers(payload_bytes, header_prefix=header_prefix)
+            )
 
         timeout_seconds = float(config.custom_settings.get("webhook_timeout", 10))
         session = async_get_clientsession(self._hass)

--- a/custom_components/pawcontrol/webhook_security.py
+++ b/custom_components/pawcontrol/webhook_security.py
@@ -6,9 +6,10 @@ import base64
 import binascii
 import hmac
 import secrets
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import UTC, datetime
-from typing import ClassVar, Mapping
+from typing import ClassVar
 
 
 @dataclass(slots=True)
@@ -143,5 +144,5 @@ class WebhookSecurityManager:
     def _build_message(self, payload: bytes, timestamp: int, nonce: str) -> bytes:
         """Build the message that is signed or verified."""
 
-        prefix = f"{timestamp}.{nonce}".encode("utf-8")
+        prefix = f"{timestamp}.{nonce}".encode()
         return prefix + b"." + payload

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -10,6 +10,7 @@ Python: 3.13+
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -425,3 +426,53 @@ class TestConcurrency:
         # All should return same config
         assert all(r is not None for r in results)
         assert all(r["dog_id"] == "test_dog" for r in results)
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDiagnosticsAndSecurity:
+    """Test coordinator diagnostics and security scorecard."""
+
+    async def test_performance_snapshot_structure(self, mock_coordinator):
+        """Snapshot should expose key diagnostic sections."""
+
+        snapshot = mock_coordinator.get_performance_snapshot()
+
+        assert "update_counts" in snapshot
+        assert "performance_metrics" in snapshot
+        assert "adaptive_polling" in snapshot
+        assert snapshot["adaptive_polling"]["target_cycle_ms"] <= 200.0
+
+    async def test_security_scorecard_pass_without_webhooks(
+        self, mock_coordinator
+    ):
+        """Scorecard passes when no insecure webhook configs exist."""
+
+        scorecard = mock_coordinator.get_security_scorecard()
+
+        assert scorecard["status"] == "pass"
+        assert scorecard["checks"]["adaptive_polling"]["pass"] is True
+        assert scorecard["checks"]["webhooks"]["pass"] is True
+
+    async def test_security_scorecard_detects_insecure_webhooks(
+        self, mock_coordinator
+    ):
+        """Insecure webhook configurations should fail the scorecard."""
+
+        class InsecureWebhookManager:
+            @staticmethod
+            def webhook_security_status() -> dict[str, Any]:
+                return {
+                    "configured": True,
+                    "secure": False,
+                    "hmac_ready": False,
+                    "insecure_configs": ("dog1",),
+                }
+
+        mock_coordinator.notification_manager = InsecureWebhookManager()
+
+        scorecard = mock_coordinator.get_security_scorecard()
+
+        assert scorecard["status"] == "fail"
+        assert scorecard["checks"]["webhooks"]["pass"] is False
+        assert "dog1" in scorecard["checks"]["webhooks"]["insecure_configs"]

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -443,9 +443,7 @@ class TestDiagnosticsAndSecurity:
         assert "adaptive_polling" in snapshot
         assert snapshot["adaptive_polling"]["target_cycle_ms"] <= 200.0
 
-    async def test_security_scorecard_pass_without_webhooks(
-        self, mock_coordinator
-    ):
+    async def test_security_scorecard_pass_without_webhooks(self, mock_coordinator):
         """Scorecard passes when no insecure webhook configs exist."""
 
         scorecard = mock_coordinator.get_security_scorecard()
@@ -454,9 +452,7 @@ class TestDiagnosticsAndSecurity:
         assert scorecard["checks"]["adaptive_polling"]["pass"] is True
         assert scorecard["checks"]["webhooks"]["pass"] is True
 
-    async def test_security_scorecard_detects_insecure_webhooks(
-        self, mock_coordinator
-    ):
+    async def test_security_scorecard_detects_insecure_webhooks(self, mock_coordinator):
         """Insecure webhook configurations should fail the scorecard."""
 
         class InsecureWebhookManager:


### PR DESCRIPTION
## Summary
- fix the coordinator fetch path so it returns UpdateResult and provide new diagnostics helpers for performance snapshots and the security scorecard
- surface webhook HMAC configuration health through the notification manager and feed it into the scorecard
- extend unit tests to cover the new diagnostics and webhook security reporting

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db7b71d25c8331892230c88d909e5c