### PR TITLE
Refine coordinator runtime orchestration

### DIFF
--- a/custom_components/pawcontrol/coordinator.py
+++ b/custom_components/pawcontrol/coordinator.py
@@ -1,11 +1,8 @@
 """Coordinator for the PawControl integration."""
 
-"""Coordinator for the PawControl integration."""
-
 from __future__ import annotations
 
 import logging
-import time
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -23,19 +20,19 @@ from .const import (
     CONF_EXTERNAL_INTEGRATIONS,
     UPDATE_INTERVALS,
 )
-from .coordinator_runtime import AdaptivePollingController, EntityBudgetSnapshot
-from .coordinator_support import CoordinatorMetrics, DogConfigRegistry, UpdateResult
+from .coordinator_runtime import (
+    AdaptivePollingController,
+    CoordinatorRuntime,
+    EntityBudgetSnapshot,
+)
+from .coordinator_support import CoordinatorMetrics, DogConfigRegistry
 from .coordinator_tasks import (
     build_runtime_statistics,
     build_update_statistics,
     ensure_background_task,
-    fetch_all_dogs,
-    fetch_single_dog,
     run_maintenance,
 )
-from .coordinator_tasks import (
-    shutdown as shutdown_tasks,
-)
+from .coordinator_tasks import shutdown as shutdown_tasks
 from .device_api import PawControlDeviceClient
 from .exceptions import ValidationError
 from .module_adapters import CoordinatorModuleAdapters
@@ -94,16 +91,10 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             config_entry=entry,
         )
 
-        use_external_api = bool(entry.options.get(CONF_EXTERNAL_INTEGRATIONS, False))
-        self._api_client = self._build_api_client(
-            endpoint=entry.options.get(CONF_API_ENDPOINT, ""),
-            token=entry.options.get(CONF_API_TOKEN, ""),
-        )
-
         self._modules = CoordinatorModuleAdapters(
             session=self.session,
             config_entry=entry,
-            use_external_api=use_external_api,
+            use_external_api=self._use_external_api,
             cache_ttl=timedelta(seconds=CACHE_TTL_SECONDS),
             api_client=self._api_client,
         )
@@ -211,14 +202,12 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not self._entity_budget_snapshots:
             return 0.0
 
-        dog_ids = self.registry.ids()
-        data, cycle = await self._runtime.execute_cycle(
-            dog_ids,
-            self._data,
-            empty_payload_factory=self.registry.empty_payload,
+        total_capacity = sum(
+            snapshot.capacity for snapshot in self._entity_budget_snapshots.values()
         )
         if total_capacity <= 0:
             return 0.0
+
         total_allocated = sum(
             snapshot.total_allocated
             for snapshot in self._entity_budget_snapshots.values()
@@ -298,32 +287,14 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         if not dog_ids:
             raise CoordinatorUpdateFailed("No valid dogs configured")
 
-        self._metrics.start_cycle()
-        cycle_start = time.perf_counter()
-        result = await self._fetch_all_dogs(dog_ids)
-
-        duration = max(time.perf_counter() - cycle_start, 0.0)
-        error_ratio = result.errors / len(dog_ids)
-        new_interval = self._adaptive_polling.record_cycle(
-            duration=duration,
-            success=result.errors < len(dog_ids),
-            error_ratio=error_ratio,
+        data, cycle = await self._runtime.execute_cycle(
+            dog_ids,
+            self._data,
+            empty_payload_factory=self.registry.empty_payload,
         )
-        self._apply_adaptive_interval(new_interval)
+        self._apply_adaptive_interval(cycle.new_interval)
 
-        success_rate, all_failed = self._metrics.record_cycle(
-            len(dog_ids), result.errors
-        )
-        if all_failed:
-            raise CoordinatorUpdateFailed(f"All {len(dog_ids)} dogs failed to update")
-        if success_rate < 0.5:
-            _LOGGER.warning(
-                "Low success rate: %d/%d dogs updated successfully",
-                len(dog_ids) - result.errors,
-                len(dog_ids),
-            )
-
-        self._data = result.payload
+        self._data = data
         return self._data
 
     def _apply_adaptive_interval(self, new_interval: float) -> None:
@@ -337,24 +308,6 @@ class PawControlCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             new_interval,
         )
         self.update_interval = timedelta(seconds=new_interval)
-
-    async def _fetch_all_dogs(self, dog_ids: list[str]) -> UpdateResult:
-        return await fetch_all_dogs(self, dog_ids)
-
-    async def _fetch_with_resilience(self, dog_id: str) -> dict[str, Any]:
-        return await self.resilience_manager.execute_with_resilience(
-            self._fetch_dog_data_protected,
-            dog_id,
-            circuit_breaker_name=f"dog_data_{dog_id}",
-            retry_config=self._retry_config,
-        )
-
-    async def _fetch_dog_data_protected(self, dog_id: str) -> dict[str, Any]:
-        async with asyncio.timeout(API_TIMEOUT):
-            return await self._fetch_dog_data(dog_id)
-
-    async def _fetch_dog_data(self, dog_id: str) -> dict[str, Any]:
-        return await fetch_single_dog(self, dog_id)
 
     def get_dog_config(self, dog_id: str) -> Any:
         return self.registry.get(dog_id)

--- a/custom_components/pawcontrol/coordinator_tasks.py
+++ b/custom_components/pawcontrol/coordinator_tasks.py
@@ -2,111 +2,18 @@
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.core import callback
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.event import async_track_time_interval
 from homeassistant.util import dt as dt_util
 
 from .coordinator_runtime import summarize_entity_budgets
-from .coordinator_support import UpdateResult
-from .exceptions import GPSUnavailableError, NetworkError, ValidationError
 
 if TYPE_CHECKING:  # pragma: no cover - import for typing only
     from datetime import timedelta
 
     from .coordinator import PawControlCoordinator
-
-
-async def fetch_all_dogs(
-    coordinator: PawControlCoordinator, dog_ids: list[str]
-) -> UpdateResult:
-    """Fetch all dog payloads with resilience handling."""
-
-    result = UpdateResult()
-    tasks = [coordinator._fetch_with_resilience(dog_id) for dog_id in dog_ids]
-    responses = await asyncio.gather(*tasks, return_exceptions=True)
-
-    for dog_id, response in zip(dog_ids, responses, strict=True):
-        if isinstance(response, ConfigEntryAuthFailed):
-            raise response
-
-        if isinstance(response, ValidationError):
-            coordinator.logger().error(
-                "Invalid configuration for dog %s: %s", dog_id, response
-            )
-            result.add_error(dog_id, coordinator.registry.empty_payload())
-            continue
-
-        if isinstance(response, Exception):
-            coordinator.logger().error(
-                "Resilience exhausted for dog %s: %s (%s)",
-                dog_id,
-                response,
-                response.__class__.__name__,
-            )
-            result.add_error(
-                dog_id,
-                coordinator._data.get(dog_id, coordinator.registry.empty_payload()),
-            )
-            continue
-
-        result.add_success(dog_id, response)
-
-    return result
-
-
-async def fetch_single_dog(
-    coordinator: PawControlCoordinator, dog_id: str
-) -> dict[str, Any]:
-    """Fetch data for a single dog across all modules."""
-
-    dog_config = coordinator.registry.get(dog_id)
-    if not dog_config:
-        raise ValidationError("dog_id", dog_id, "Dog configuration not found")
-
-    payload = {
-        "dog_info": dog_config,
-        "status": "online",
-        "last_update": dt_util.utcnow().isoformat(),
-    }
-
-    modules = dog_config.get("modules", {})
-    module_tasks = coordinator._modules.build_tasks(dog_id, modules)
-    if not module_tasks:
-        return payload
-
-    results = await asyncio.gather(
-        *(task for _, task in module_tasks), return_exceptions=True
-    )
-
-    for (module_name, _), result in zip(module_tasks, results, strict=True):
-        if isinstance(result, GPSUnavailableError):
-            coordinator.logger().debug("GPS unavailable for %s: %s", dog_id, result)
-            payload[module_name] = {"status": "unavailable", "reason": str(result)}
-        elif isinstance(result, NetworkError):
-            coordinator.logger().warning(
-                "Network error fetching %s data for %s: %s",
-                module_name,
-                dog_id,
-                result,
-            )
-            payload[module_name] = {"status": "network_error"}
-        elif isinstance(result, Exception):
-            coordinator.logger().warning(
-                "Failed to fetch %s data for %s: %s (%s)",
-                module_name,
-                dog_id,
-                result,
-                result.__class__.__name__,
-            )
-            payload[module_name] = {"status": "error"}
-        else:
-            payload[module_name] = result
-
-    return payload
 
 
 def build_update_statistics(coordinator: PawControlCoordinator) -> dict[str, Any]:

--- a/docs/architecture/adr/ADR-005-maintainability-targets.md
+++ b/docs/architecture/adr/ADR-005-maintainability-targets.md
@@ -21,6 +21,6 @@ targets risk regressing over time.
 ## Consequences
 
 - Contributors have clear guidance on where to place new logic.
-- The coordinator file currently sits at 373 lines, providing headroom for
+- The coordinator file currently sits at 353 lines, providing headroom for
   minor tweaks without violating the target.
 - Documentation and ADRs record the rationale, making it part of onboarding.


### PR DESCRIPTION
## Summary
- lean on `CoordinatorRuntime` for data fetching to keep the coordinator under 400 lines and in line with the manager architecture
- streamline `coordinator_tasks` helpers to focus on diagnostics, maintenance, and shutdown responsibilities
- refresh ADR-005 with the updated coordinator line count headroom

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db7e4d2ab88331bda818fa2e6d9add