### PR TITLE
Use SystemRandom for retry jitter

### DIFF
--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -339,7 +339,7 @@ async def retry_with_backoff(
             if retry_config.jitter:
                 import random
 
-                delay = delay * (0.5 + random.random())
+                delay = delay * (0.5 + random.SystemRandom().random())
 
             _LOGGER.warning(
                 "Retry attempt %d/%d failed for %s: %s - waiting %.1fs",


### PR DESCRIPTION
## Summary
- switch retry jitter calculation to use random.SystemRandom for cryptographic security

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e042058ecc833180013ca636766562