### PR TITLE
Use Ruff module instead of subprocess

### DIFF
--- a/scripts/enforce_docstring_baseline.py
+++ b/scripts/enforce_docstring_baseline.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import argparse
-import importlib.util
+import contextlib
+import io
 import json
-import shutil
-import subprocess
+import os
 import sys
 from collections.abc import Sequence
 from pathlib import Path
@@ -21,27 +21,29 @@ RUFF_ARGS = (
     "json",
 )
 
+def _execute_ruff(repo_root: Path, args: Sequence[str]) -> tuple[int, str, str]:
+    """Run Ruff using its Python entrypoint and capture output."""
 
-def _resolve_ruff_command() -> list[str]:
-    """Return a fully-qualified command for invoking Ruff safely.
-
-    The command is built using ``python -m ruff`` when possible so that the
-    interpreter already running this script is re-used.  Falling back to a
-    ``ruff`` binary from ``PATH`` uses the absolute path detected by
-    :func:`shutil.which` to avoid executing an unexpected executable that might
-    be shadowing the desired one.
-    """
-
-    if importlib.util.find_spec("ruff") is not None:
-        return [sys.executable, "-m", "ruff", *RUFF_ARGS]
-
-    resolved = shutil.which("ruff")
-    if not resolved:
+    try:
+        from ruff import __main__ as ruff_main
+    except ModuleNotFoundError as exc:
         raise SystemExit(
-            "Unable to locate the Ruff executable. Ensure it is installed and on PATH."
-        )
+            "Ruff is not installed. Install it in the active environment to run the check."
+        ) from exc
 
-    return [resolved, *RUFF_ARGS]
+    stdout_buffer = io.StringIO()
+    stderr_buffer = io.StringIO()
+    previous_cwd = Path.cwd()
+    try:
+        os.chdir(repo_root)
+        with contextlib.redirect_stdout(stdout_buffer), contextlib.redirect_stderr(
+            stderr_buffer
+        ):
+            exit_code = ruff_main.main(list(args))
+    finally:
+        os.chdir(previous_cwd)
+
+    return exit_code, stdout_buffer.getvalue(), stderr_buffer.getvalue()
 
 
 def load_baseline(path: Path) -> list[dict[str, object]]:
@@ -61,27 +63,14 @@ def write_baseline(path: Path, diagnostics: list[dict[str, object]]) -> None:
         handle.write("\n")
 
 
-def collect_diagnostics(
-    repo_root: Path, command: Sequence[str]
-) -> list[dict[str, object]]:
-    try:
-        process = subprocess.run(
-            list(command),
-            capture_output=True,
-            text=True,
-            cwd=repo_root,
-            check=False,
-        )
-    except FileNotFoundError as exc:
-        raise SystemExit(
-            f"Failed to execute Ruff command '{command[0]}': {exc.strerror}."
-        ) from exc
-    if process.returncode not in (0, 1):
-        sys.stderr.write(process.stdout)
-        sys.stderr.write(process.stderr)
-        raise SystemExit(process.returncode)
+def collect_diagnostics(repo_root: Path) -> list[dict[str, object]]:
+    exit_code, stdout, stderr = _execute_ruff(repo_root, RUFF_ARGS)
+    if exit_code not in (0, 1):
+        sys.stderr.write(stdout)
+        sys.stderr.write(stderr)
+        raise SystemExit(exit_code)
 
-    raw = json.loads(process.stdout) if process.stdout.strip() else []
+    raw = json.loads(stdout) if stdout.strip() else []
 
     diagnostics = []
     for entry in raw:
@@ -141,8 +130,7 @@ def run() -> int:
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parent.parent
-    ruff_command = _resolve_ruff_command()
-    diagnostics = collect_diagnostics(repo_root, ruff_command)
+    diagnostics = collect_diagnostics(repo_root)
 
     if args.update_baseline:
         write_baseline(args.baseline, diagnostics)


### PR DESCRIPTION
## Summary
- replace the subprocess-based Ruff invocation with the in-process module entrypoint
- capture Ruff output via string buffers to preserve diagnostic parsing

## Testing
- python -m compileall scripts/enforce_docstring_baseline.py

------
https://chatgpt.com/codex/tasks/task_e_68e05d0a86b08331af9d9362a794d609