### PR TITLE
Fix coordinator cache invalidation logic

### DIFF
--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -130,8 +130,8 @@ class _CoordinatorResolver:
         if self._cached_coordinator is None:
             return
 
-        if entry_id is not None and entry_id != self._cached_entry_id:
-            # Another config entry changed state; keep the cached coordinator.
+        if entry_id is not None and self._cached_entry_id is not None and entry_id != self._cached_entry_id:
+            # An unrelated config entry changed state; keep the cached coordinator.
             return
 
         self._cached_coordinator = None

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -130,7 +130,11 @@ class _CoordinatorResolver:
         if self._cached_coordinator is None:
             return
 
-        if entry_id is not None and self._cached_entry_id is not None and entry_id != self._cached_entry_id:
+        if (
+            entry_id is not None
+            and self._cached_entry_id is not None
+            and entry_id != self._cached_entry_id
+        ):
             # An unrelated config entry changed state; keep the cached coordinator.
             return
 

--- a/custom_components/pawcontrol/services.py
+++ b/custom_components/pawcontrol/services.py
@@ -130,6 +130,10 @@ class _CoordinatorResolver:
         if self._cached_coordinator is None:
             return
 
+        if entry_id is not None and entry_id != self._cached_entry_id:
+            # Another config entry changed state; keep the cached coordinator.
+            return
+
         self._cached_coordinator = None
         self._cached_entry_id = None
 

--- a/tests/components/pawcontrol/test_services.py
+++ b/tests/components/pawcontrol/test_services.py
@@ -320,7 +320,9 @@ async def test_other_entry_state_change_does_not_invalidate_cache(
         patch.object(
             hass.config_entries,
             "async_get_entry",
-            side_effect=lambda entry_id: entry if entry_id == entry.entry_id else other_entry,
+            side_effect=lambda entry_id: entry
+            if entry_id == entry.entry_id
+            else other_entry,
         ),
     ):
         handlers = await _register_services(hass, coordinator_mock)

--- a/tests/components/pawcontrol/test_services.py
+++ b/tests/components/pawcontrol/test_services.py
@@ -289,3 +289,64 @@ async def test_config_entry_state_change_invalidates_cache(
 
     assert entries_mock.call_count == 2
     get_entry_mock.assert_called_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_other_entry_state_change_does_not_invalidate_cache(
+    hass: HomeAssistant, coordinator_mock: SimpleNamespace
+) -> None:
+    """Ensure cache survives state changes for different config entries."""
+
+    hass.data.setdefault(DOMAIN, {})
+
+    entry = SimpleNamespace(
+        entry_id="test-entry",
+        state=ConfigEntryState.LOADED,
+        domain=DOMAIN,
+        runtime_data=SimpleNamespace(coordinator=coordinator_mock),
+    )
+    coordinator_mock.config_entry = entry
+
+    other_entry = SimpleNamespace(
+        entry_id="other-entry",
+        domain=DOMAIN,
+        state=ConfigEntryState.SETUP_ERROR,
+    )
+
+    with (
+        patch.object(
+            hass.config_entries, "async_entries", return_value=[entry]
+        ) as entries_mock,
+        patch.object(
+            hass.config_entries,
+            "async_get_entry",
+            side_effect=lambda entry_id: entry if entry_id == entry.entry_id else other_entry,
+        ),
+    ):
+        handlers = await _register_services(hass, coordinator_mock)
+        handler = handlers[(DOMAIN, SERVICE_START_WALK)]
+
+        call = ServiceCall(
+            hass,
+            DOMAIN,
+            SERVICE_START_WALK,
+            {"dog_id": "doggo"},
+        )
+
+        await handler(call)
+        assert entries_mock.call_count == 1
+
+        hass.bus.async_fire(
+            EVENT_CONFIG_ENTRY_STATE_CHANGED,
+            {
+                "entry_id": other_entry.entry_id,
+                "from_state": ConfigEntryState.LOADED,
+                "to_state": ConfigEntryState.SETUP_ERROR,
+            },
+        )
+        await hass.async_block_till_done()
+
+        await handler(call)
+
+    # Cache is still valid, so async_entries should not have been queried again.
+    assert entries_mock.call_count == 1


### PR DESCRIPTION
## Summary
- keep the cached PawControl coordinator when unrelated config entries change state
- add a regression test to ensure service handlers reuse the cached coordinator across other entry events

## Testing
- pytest tests/components/pawcontrol/test_services.py --override-ini addopts="" -k invalidate_cache *(fails: missing Home Assistant test dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e089750d4c8331bb83ed9d66d77bae