### PR TITLE
Add compatibility shims for running tests without Home Assistant

### DIFF
--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -13,10 +13,49 @@ Python: 3.13+
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import Enum
+from types import SimpleNamespace
 from typing import Final
 
-from homeassistant.const import Platform
-from homeassistant.helpers import selector
+try:
+    from homeassistant.const import Platform
+    from homeassistant.helpers import selector
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class Platform(str, Enum):
+        """Minimal Platform enum used when Home Assistant isn't installed."""
+
+        SENSOR = "sensor"
+        BINARY_SENSOR = "binary_sensor"
+        BUTTON = "button"
+        SWITCH = "switch"
+        NUMBER = "number"
+        SELECT = "select"
+        TEXT = "text"
+        DEVICE_TRACKER = "device_tracker"
+        DATE = "date"
+        DATETIME = "datetime"
+
+    class NumberSelectorMode(str, Enum):
+        BOX = "box"
+
+    @dataclass(frozen=True)
+    class NumberSelectorConfig:
+        min: float
+        max: float
+        step: float
+        mode: NumberSelectorMode
+        unit_of_measurement: str | None = None
+
+    class NumberSelector:
+        def __init__(self, config: NumberSelectorConfig) -> None:
+            self.config = config
+
+    selector = SimpleNamespace(
+        NumberSelector=NumberSelector,
+        NumberSelectorConfig=NumberSelectorConfig,
+        NumberSelectorMode=NumberSelectorMode,
+    )
 
 # OPTIMIZED: Storage versions for data persistence
 STORAGE_VERSION: Final[int] = 1

--- a/custom_components/pawcontrol/const.py
+++ b/custom_components/pawcontrol/const.py
@@ -22,6 +22,7 @@ try:
     from homeassistant.const import Platform
     from homeassistant.helpers import selector
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class Platform(str, Enum):
         """Minimal Platform enum used when Home Assistant isn't installed."""
 

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -31,6 +31,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
         def utcnow() -> datetime:
             return datetime.utcnow()
             return datetime.now(datetime.timezone.utc)
+
     dt_util = _DateTimeModule()
 
 from .coordinator_support import CoordinatorMetrics, DogConfigRegistry

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -12,9 +12,28 @@ from datetime import datetime
 from statistics import fmean
 from typing import Any
 
-from homeassistant.exceptions import ConfigEntryAuthFailed
-from homeassistant.helpers.update_coordinator import CoordinatorUpdateFailed
-from homeassistant.util import dt as dt_util
+try:
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import CoordinatorUpdateFailed
+    from homeassistant.util import dt as dt_util
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class ConfigEntryAuthFailed(RuntimeError):
+        """Fallback error used when Home Assistant isn't available."""
+
+
+    class CoordinatorUpdateFailed(RuntimeError):
+        """Fallback error used when Home Assistant isn't available."""
+
+
+    class _DateTimeModule:
+        """Minimal subset of :mod:`homeassistant.util.dt` used in tests."""
+
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime.utcnow()
+
+
+    dt_util = _DateTimeModule()
 
 from .coordinator_support import CoordinatorMetrics, DogConfigRegistry
 from .exceptions import GPSUnavailableError, NetworkError, ValidationError

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -8,7 +8,7 @@ import time
 from collections import deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from statistics import fmean
 from typing import Any
 
@@ -29,8 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.utcnow()
-            return datetime.now(datetime.timezone.utc)
+            return datetime.now(timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -18,10 +18,10 @@ try:
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
-    class ConfigEntryAuthFailed(RuntimeError):
+    class ConfigEntryAuthFailed(RuntimeError):  # noqa: N818 - mirror HA class name
         """Fallback error used when Home Assistant isn't available."""
 
-    class CoordinatorUpdateFailed(RuntimeError):
+    class CoordinatorUpdateFailed(RuntimeError):  # noqa: N818 - mirror HA class name
         """Fallback error used when Home Assistant isn't available."""
 
     class _DateTimeModule:

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
+            return datetime.now(datetime.timezone.utc)
     dt_util = _DateTimeModule()
 
 from .coordinator_support import CoordinatorMetrics, DogConfigRegistry

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -8,7 +8,7 @@ import time
 from collections import deque
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from statistics import fmean
 from typing import Any
 
@@ -29,7 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(timezone.utc)
+            return datetime.now(UTC)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/coordinator_runtime.py
+++ b/custom_components/pawcontrol/coordinator_runtime.py
@@ -17,13 +17,12 @@ try:
     from homeassistant.helpers.update_coordinator import CoordinatorUpdateFailed
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class ConfigEntryAuthFailed(RuntimeError):
         """Fallback error used when Home Assistant isn't available."""
 
-
     class CoordinatorUpdateFailed(RuntimeError):
         """Fallback error used when Home Assistant isn't available."""
-
 
     class _DateTimeModule:
         """Minimal subset of :mod:`homeassistant.util.dt` used in tests."""
@@ -31,7 +30,6 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from typing import Any
 
 from aiohttp import ClientResponse, ClientSession, ClientTimeout
-from homeassistant.exceptions import ConfigEntryAuthFailed
+
+try:
+    from homeassistant.exceptions import ConfigEntryAuthFailed
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class ConfigEntryAuthFailed(RuntimeError):
+        """Fallback error used when Home Assistant isn't installed."""
 from yarl import URL
 
 from .exceptions import NetworkError, RateLimitError

--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -12,7 +12,7 @@ try:
     from homeassistant.exceptions import ConfigEntryAuthFailed
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
-    class ConfigEntryAuthFailed(RuntimeError):
+    class ConfigEntryAuthFailed(RuntimeError):  # noqa: N818 - mirror HA class name
         """Fallback error used when Home Assistant isn't installed."""
 
 

--- a/custom_components/pawcontrol/device_api.py
+++ b/custom_components/pawcontrol/device_api.py
@@ -11,8 +11,11 @@ from aiohttp import ClientResponse, ClientSession, ClientTimeout
 try:
     from homeassistant.exceptions import ConfigEntryAuthFailed
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class ConfigEntryAuthFailed(RuntimeError):
         """Fallback error used when Home Assistant isn't installed."""
+
+
 from yarl import URL
 
 from .exceptions import NetworkError, RateLimitError

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -18,8 +18,21 @@ from datetime import datetime
 from enum import Enum
 from typing import Any, Final
 
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.util import dt as dt_util
+try:
+    from homeassistant.exceptions import HomeAssistantError
+    from homeassistant.util import dt as dt_util
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class HomeAssistantError(Exception):
+        """Fallback error used when Home Assistant isn't installed."""
+
+
+    class _DateTimeModule:
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime.utcnow()
+
+
+    dt_util = _DateTimeModule()
 
 from .types import GPSLocation
 

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import traceback
 from collections.abc import Callable
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any, Final
 
@@ -29,7 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(timezone.utc)
+            return datetime.now(UTC)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import traceback
 from collections.abc import Callable
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Final
 
@@ -29,7 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(datetime.timezone.utc)
+            return datetime.now(timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -29,7 +29,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.utcnow()
+            return datetime.now(datetime.timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/exceptions.py
+++ b/custom_components/pawcontrol/exceptions.py
@@ -22,15 +22,14 @@ try:
     from homeassistant.exceptions import HomeAssistantError
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class HomeAssistantError(Exception):
         """Fallback error used when Home Assistant isn't installed."""
-
 
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/module_adapters.py
+++ b/custom_components/pawcontrol/module_adapters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientSession
@@ -17,7 +17,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(timezone.utc)
+            return datetime.now(UTC)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/module_adapters.py
+++ b/custom_components/pawcontrol/module_adapters.py
@@ -13,11 +13,11 @@ from aiohttp import ClientSession
 try:
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/module_adapters.py
+++ b/custom_components/pawcontrol/module_adapters.py
@@ -16,7 +16,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
     class _DateTimeModule:
         @staticmethod
-        def utcnow() -> datetime:
+            return datetime.now(datetime.timezone.utc)
             return datetime.utcnow()
 
     dt_util = _DateTimeModule()

--- a/custom_components/pawcontrol/module_adapters.py
+++ b/custom_components/pawcontrol/module_adapters.py
@@ -9,7 +9,17 @@ from datetime import datetime, timedelta
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientSession
-from homeassistant.util import dt as dt_util
+
+try:
+    from homeassistant.util import dt as dt_util
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class _DateTimeModule:
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime.utcnow()
+
+
+    dt_util = _DateTimeModule()
 
 from .const import (
     CONF_WEATHER_ENTITY,

--- a/custom_components/pawcontrol/module_adapters.py
+++ b/custom_components/pawcontrol/module_adapters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Awaitable
 from dataclasses import dataclass
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any
 
 from aiohttp import ClientSession
@@ -16,8 +16,8 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
 
     class _DateTimeModule:
         @staticmethod
-            return datetime.now(datetime.timezone.utc)
-            return datetime.utcnow()
+        def utcnow() -> datetime:
+            return datetime.now(timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -347,6 +347,7 @@ async def retry_with_backoff(
             # Add jitter if enabled
             if retry_config.jitter:
                 import random
+
                 delay = delay * (0.5 + random.SystemRandom().random())
                 delay = delay * (0.5 + random.random())
 

--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -347,7 +347,7 @@ async def retry_with_backoff(
             # Add jitter if enabled
             if retry_config.jitter:
                 import random
-
+                delay = delay * (0.5 + random.SystemRandom().random())
                 delay = delay * (0.5 + random.random())
 
             _LOGGER.warning(

--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -22,12 +22,13 @@ try:
     from homeassistant.core import HomeAssistant
     from homeassistant.exceptions import HomeAssistantError
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class HomeAssistant:  # type: ignore[override]
         """Minimal stand-in used during unit tests."""
 
-
     class HomeAssistantError(Exception):
         """Fallback base error used when Home Assistant isn't installed."""
+
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -273,6 +273,7 @@ class RetryConfig:
     max_delay: float = 60.0  # seconds
     exponential_base: float = 2.0
     jitter: bool = True  # Add randomness to delays
+    random_source: Callable[[], float] | None = None
 
 
 class RetryExhaustedError(HomeAssistantError):
@@ -348,8 +349,12 @@ async def retry_with_backoff(
             if retry_config.jitter:
                 import random
 
-                delay = delay * (0.5 + random.SystemRandom().random())
-                delay = delay * (0.5 + random.random())
+                random_value = (
+                    retry_config.random_source()
+                    if retry_config.random_source is not None
+                    else random.SystemRandom().random()
+                )
+                delay = delay * (0.5 + random_value)
 
             _LOGGER.warning(
                 "Retry attempt %d/%d failed for %s: %s - waiting %.1fs",

--- a/custom_components/pawcontrol/resilience.py
+++ b/custom_components/pawcontrol/resilience.py
@@ -18,8 +18,16 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import ParamSpec, TypeVar
 
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+try:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.exceptions import HomeAssistantError
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class HomeAssistant:  # type: ignore[override]
+        """Minimal stand-in used during unit tests."""
+
+
+    class HomeAssistantError(Exception):
+        """Fallback base error used when Home Assistant isn't installed."""
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -339,7 +347,7 @@ async def retry_with_backoff(
             if retry_config.jitter:
                 import random
 
-                delay = delay * (0.5 + random.SystemRandom().random())
+                delay = delay * (0.5 + random.random())
 
             _LOGGER.warning(
                 "Retry attempt %d/%d failed for %s: %s - waiting %.1fs",

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -38,7 +38,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.utcnow()
+            return datetime.now(datetime.timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from asyncio import Task
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Final, Required, TypedDict
 
 try:
@@ -38,7 +38,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(datetime.timezone.utc)
+            return datetime.now(timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -29,17 +29,16 @@ try:
     from homeassistant.config_entries import ConfigEntry
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class ConfigEntry:  # type: ignore[override]
         """Lightweight stand-in used during unit tests."""
 
         entry_id: str
 
-
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from asyncio import Task
 from collections.abc import Mapping
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any, Final, Required, TypedDict
 
 try:
@@ -38,7 +38,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(timezone.utc)
+            return datetime.now(UTC)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -25,8 +25,23 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Final, Required, TypedDict
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.util import dt as dt_util
+try:
+    from homeassistant.config_entries import ConfigEntry
+    from homeassistant.util import dt as dt_util
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class ConfigEntry:  # type: ignore[override]
+        """Lightweight stand-in used during unit tests."""
+
+        entry_id: str
+
+
+    class _DateTimeModule:
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime.utcnow()
+
+
+    dt_util = _DateTimeModule()
 
 from .utils import is_number
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -20,13 +20,41 @@ from datetime import datetime, time, timedelta
 from functools import wraps
 from numbers import Real
 from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
+from types import SimpleNamespace
 
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo
-from homeassistant.helpers.entity import Entity
-from homeassistant.util import dt as dt_util
+try:
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import device_registry as dr
+    from homeassistant.helpers import entity_registry as er
+    from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo
+    from homeassistant.helpers.entity import Entity
+    from homeassistant.util import dt as dt_util
+except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+    class HomeAssistant:  # type: ignore[override]
+        """Minimal stand-in for type checking during unit tests."""
+
+
+    class Entity:  # type: ignore[override]
+        """Lightweight placeholder entity used for tests."""
+
+
+    DeviceEntry = dict[str, Any]  # type: ignore[assignment]
+    DeviceInfo = dict[str, Any]  # type: ignore[assignment]
+
+    def _missing_registry(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("Home Assistant registry helpers are unavailable in this environment")
+
+
+    dr = SimpleNamespace(async_get=_missing_registry)
+    er = SimpleNamespace(async_get=_missing_registry)
+
+    class _DateTimeModule:
+        @staticmethod
+        def utcnow() -> datetime:
+            return datetime.utcnow()
+
+
+    dt_util = _DateTimeModule()
 
 from .const import DEFAULT_MODEL, DOMAIN, MANUFACTURER
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -16,11 +16,11 @@ import inspect
 import logging
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from datetime import datetime, time, timedelta
+from datetime import datetime, time, timedelta, timezone
 from functools import wraps
 from numbers import Real
 from types import SimpleNamespace
-from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
+from typing import TYPE_CHECKING, Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 
 try:
     from homeassistant.core import HomeAssistant
@@ -37,8 +37,14 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class Entity:  # type: ignore[override]
         """Lightweight placeholder entity used for tests."""
 
-    DeviceEntry = dict[str, Any]  # type: ignore[assignment]
-    DeviceInfo = dict[str, Any]  # type: ignore[assignment]
+    if TYPE_CHECKING:
+        from homeassistant.helpers.device_registry import DeviceEntry, DeviceInfo
+        from homeassistant.helpers.entity import Entity as _Entity
+
+        Entity = _Entity
+    else:
+        DeviceEntry = dict[str, Any]  # type: ignore[assignment]
+        DeviceInfo = dict[str, Any]  # type: ignore[assignment]
 
     def _missing_registry(*args: Any, **kwargs: Any) -> Any:
         raise RuntimeError(
@@ -51,7 +57,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(datetime.timezone.utc)
+            return datetime.now(timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -51,7 +51,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.utcnow()
+            return datetime.now(datetime.timezone.utc)
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -19,8 +19,8 @@ from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from datetime import datetime, time, timedelta
 from functools import wraps
 from numbers import Real
-from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 from types import SimpleNamespace
+from typing import Any, ParamSpec, TypedDict, TypeGuard, TypeVar, cast
 
 try:
     from homeassistant.core import HomeAssistant
@@ -30,20 +30,20 @@ try:
     from homeassistant.helpers.entity import Entity
     from homeassistant.util import dt as dt_util
 except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
+
     class HomeAssistant:  # type: ignore[override]
         """Minimal stand-in for type checking during unit tests."""
 
-
     class Entity:  # type: ignore[override]
         """Lightweight placeholder entity used for tests."""
-
 
     DeviceEntry = dict[str, Any]  # type: ignore[assignment]
     DeviceInfo = dict[str, Any]  # type: ignore[assignment]
 
     def _missing_registry(*args: Any, **kwargs: Any) -> Any:
-        raise RuntimeError("Home Assistant registry helpers are unavailable in this environment")
-
+        raise RuntimeError(
+            "Home Assistant registry helpers are unavailable in this environment"
+        )
 
     dr = SimpleNamespace(async_get=_missing_registry)
     er = SimpleNamespace(async_get=_missing_registry)
@@ -52,7 +52,6 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
         @staticmethod
         def utcnow() -> datetime:
             return datetime.utcnow()
-
 
     dt_util = _DateTimeModule()
 

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -16,7 +16,7 @@ import inspect
 import logging
 import re
 from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
-from datetime import datetime, time, timedelta, timezone
+from datetime import UTC, datetime, time, timedelta
 from functools import wraps
 from numbers import Real
 from types import SimpleNamespace
@@ -57,7 +57,7 @@ except ModuleNotFoundError:  # pragma: no cover - compatibility shim for tests
     class _DateTimeModule:
         @staticmethod
         def utcnow() -> datetime:
-            return datetime.now(timezone.utc)
+            return datetime.now(UTC)
 
     dt_util = _DateTimeModule()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,11 +50,53 @@ if _missing:
     ]
 
     def pytest_addoption(parser):
-        """Register pytest-asyncio compatibility option when dependencies are absent."""
+        """Register compatibility shims when optional dependencies are absent."""
         parser.addini(
             "asyncio_mode",
             "pytest-asyncio compatibility shim for missing dependency",
             default="auto",
+        )
+
+        # ``pytest-cov`` is an optional plugin that provides additional command
+        # line flags.  When it isn't installed pytest will exit early because
+        # it can't parse the ``--cov`` options configured in ``pytest.ini``.
+        # Registering lightweight stand-ins allows the rest of the suite to run
+        # without requiring the plugin.
+        cov_group = parser.getgroup(
+            "cov", "No-op coverage options when pytest-cov is unavailable"
+        )
+        cov_group.addoption(
+            "--cov",
+            action="append",
+            default=[],
+            dest="cov",
+            help="No-op placeholder added when pytest-cov isn't installed.",
+        )
+        cov_group.addoption(
+            "--cov-report",
+            action="append",
+            default=[],
+            dest="cov_report",
+            help="No-op placeholder added when pytest-cov isn't installed.",
+        )
+        cov_group.addoption(
+            "--cov-branch",
+            action="store_true",
+            dest="cov_branch",
+            help="No-op placeholder added when pytest-cov isn't installed.",
+        )
+        cov_group.addoption(
+            "--cov-fail-under",
+            action="store",
+            type=float,
+            dest="cov_fail_under",
+            help="No-op placeholder added when pytest-cov isn't installed.",
+        )
+        cov_group.addoption(
+            "--no-cov-on-fail",
+            action="store_true",
+            dest="no_cov_on_fail",
+            help="No-op placeholder added when pytest-cov isn't installed.",
         )
 
     print(

--- a/tests/coverage/test_resilience_core.py
+++ b/tests/coverage/test_resilience_core.py
@@ -223,21 +223,20 @@ def test_circuit_breaker_half_open_cleanup() -> None:
     asyncio.run(scenario())
 
 
-def test_retry_with_backoff_success_and_failure(
-    fast_sleep: list[float], monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_retry_with_backoff_success_and_failure(fast_sleep: list[float]) -> None:
     """Retry helper handles successes, jitter and exhausted attempts."""
 
     async def scenario() -> None:
-        # Deterministic jitter
-        monkeypatch.setattr("random.random", lambda: 0.5)
-
         # Succeeds on second attempt
         flakey = AsyncMock(side_effect=[ValueError("fail"), "good"])
         result = await retry_with_backoff(
             flakey,
             config=RetryConfig(
-                max_attempts=3, initial_delay=0.1, exponential_base=2.0, jitter=True
+                max_attempts=3,
+                initial_delay=0.1,
+                exponential_base=2.0,
+                jitter=True,
+                random_source=lambda: 0.5,
             ),
         )
         assert result == "good"

--- a/tests/unit/test_coordinator_observability.py
+++ b/tests/unit/test_coordinator_observability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import pytest
@@ -19,7 +19,7 @@ from custom_components.pawcontrol.coordinator_support import CoordinatorMetrics
 @pytest.mark.unit
 def test_entity_budget_tracker_records_and_summarises() -> None:
     tracker = EntityBudgetTracker()
-    now = datetime.utcnow()
+    now = datetime.now(timezone.utc)
     tracker.record(
         EntityBudgetSnapshot(
             dog_id="a",

--- a/tests/unit/test_coordinator_observability.py
+++ b/tests/unit/test_coordinator_observability.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime, timezone
 from typing import Any
 
 import pytest
@@ -19,7 +19,7 @@ from custom_components.pawcontrol.coordinator_support import CoordinatorMetrics
 @pytest.mark.unit
 def test_entity_budget_tracker_records_and_summarises() -> None:
     tracker = EntityBudgetTracker()
-    now = datetime.now(timezone.utc)
+    now = datetime.now(UTC)
     tracker.record(
         EntityBudgetSnapshot(
             dog_id="a",

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -7,6 +7,7 @@ import pathlib
 import sys
 import types
 from dataclasses import dataclass
+from datetime import UTC
 
 import pytest
 
@@ -30,7 +31,7 @@ def _load_health_calculator_module() -> types.ModuleType:
     def _now():
         from datetime import datetime, timezone
 
-        return datetime.now(timezone.utc)
+        return datetime.now(UTC)
 
     ha_dt.now = _now
     ha_util.dt = ha_dt

--- a/tests/unit/test_health_metrics.py
+++ b/tests/unit/test_health_metrics.py
@@ -28,9 +28,9 @@ def _load_health_calculator_module() -> types.ModuleType:
     ha_dt = types.ModuleType("homeassistant.util.dt")
 
     def _now():
-        from datetime import datetime
+        from datetime import datetime, timezone
 
-        return datetime.utcnow()
+        return datetime.now(timezone.utc)
 
     ha_dt.now = _now
     ha_util.dt = ha_dt

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -9,7 +9,7 @@ Python: 3.13+
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
@@ -120,7 +120,7 @@ class TestNotificationWebhooks:
             priority=NotificationPriority.NORMAL,
             title="Title",
             message="Body",
-            created_at=datetime.utcnow(),
+            created_at=datetime.now(timezone.utc),
             channels=[NotificationChannel.WEBHOOK],
         )
 

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -9,7 +9,7 @@ Python: 3.13+
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone
 from unittest.mock import AsyncMock, Mock, call
 
 import pytest
@@ -120,7 +120,7 @@ class TestNotificationWebhooks:
             priority=NotificationPriority.NORMAL,
             title="Title",
             message="Body",
-            created_at=datetime.now(timezone.utc),
+            created_at=datetime.now(UTC),
             channels=[NotificationChannel.WEBHOOK],
         )
 


### PR DESCRIPTION
## Summary
- add lightweight pytest options so the suite still runs when pytest-cov is unavailable
- provide Home Assistant compatibility shims across core modules so they import without optional dependencies
- align retry jitter implementation with deterministic unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e089999e548331ae6b64b7b1aa42df