### PR TITLE
Ensure API validator honours TLS verification settings

### DIFF
--- a/tests/unit/test_api_validator.py
+++ b/tests/unit/test_api_validator.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import AsyncMock
+
 import pytest
 
 pytest.importorskip(
@@ -67,3 +69,45 @@ async def test_api_validator_cleanup_is_noop(mock_hass, session_factory) -> None
     await validator.async_close()
 
     hass_session.close.assert_not_awaited()
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reachability_uses_secure_ssl_defaults(
+    mock_hass, session_factory
+) -> None:
+    """TLS verification should remain enabled unless explicitly disabled."""
+
+    hass_session = session_factory()
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = AsyncMock(status=200)
+    context_manager.__aexit__.return_value = False
+    hass_session.request.return_value = context_manager
+
+    validator = APIValidator(mock_hass, session=hass_session)
+
+    assert await validator._test_endpoint_reachability("https://example.com")
+    kwargs = hass_session.get.call_args.kwargs
+    assert kwargs["allow_redirects"] is True
+    assert "ssl" not in kwargs
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_reachability_allows_disabling_ssl_verification(
+    mock_hass, session_factory
+) -> None:
+    """Setting ``verify_ssl=False`` should opt into insecure requests explicitly."""
+
+    hass_session = session_factory()
+    context_manager = AsyncMock()
+    context_manager.__aenter__.return_value = AsyncMock(status=200)
+    context_manager.__aexit__.return_value = False
+    hass_session.request.return_value = context_manager
+
+    validator = APIValidator(mock_hass, session=hass_session, verify_ssl=False)
+
+    assert await validator._test_endpoint_reachability("https://example.org")
+    kwargs = hass_session.get.call_args.kwargs
+    assert kwargs["allow_redirects"] is True
+    assert kwargs["ssl"] is False


### PR DESCRIPTION
## Summary
- keep TLS certificate verification enabled by default when the API validator probes endpoints
- allow opting out of verification explicitly and reuse the helper for both reachability and authentication checks
- exercise the new behaviour with unit tests that assert the session is called securely

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e09bb3ef18833190cafc7afaf5b675