### PR TITLE
Specify parallel update limits for Paw Control platforms

### DIFF
--- a/custom_components/pawcontrol/date.py
+++ b/custom_components/pawcontrol/date.py
@@ -44,6 +44,10 @@ from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
+# Date helpers mutate coordinator-managed settings, so restrict concurrency to
+# one update at a time for the ``parallel-updates`` quality scale rule.
+PARALLEL_UPDATES = 1
+
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -34,6 +34,10 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Date/time helpers write settings back to Paw Control, so limit concurrent
+# updates to a single request to satisfy the ``parallel-updates`` rule.
+PARALLEL_UPDATES = 1
+
 
 async def _async_add_entities_in_batches(
     async_add_entities_func,

--- a/custom_components/pawcontrol/device_tracker.py
+++ b/custom_components/pawcontrol/device_tracker.py
@@ -47,6 +47,11 @@ from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
+# Coordinator drives refreshes, so we can safely allow unlimited parallel
+# updates for this read-only platform while still complying with the
+# ``parallel-updates`` quality scale rule.
+PARALLEL_UPDATES = 0
+
 # GPS tracker constants
 DEFAULT_GPS_ACCURACY = 50  # meters
 MIN_LOCATION_UPDATE_INTERVAL = 30  # seconds

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -56,7 +56,7 @@ _LOGGER = logging.getLogger(__name__)
 AttributeDict = dict[str, Any]
 
 # Many number entities trigger write operations (service calls) so we keep
-# the concurrency at one to honour the ``parallel-updates`` quality scale
+# the concurrency at one to honor the ``parallel-updates`` quality scale
 # rule while still allowing sequential updates from Home Assistant.
 PARALLEL_UPDATES = 1
 

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -55,6 +55,11 @@ _LOGGER = logging.getLogger(__name__)
 # Type aliases for better code readability
 AttributeDict = dict[str, Any]
 
+# Many number entities trigger write operations (service calls) so we keep
+# the concurrency at one to honour the ``parallel-updates`` quality scale
+# rule while still allowing sequential updates from Home Assistant.
+PARALLEL_UPDATES = 1
+
 # Configuration limits and defaults
 DEFAULT_WALK_DURATION_TARGET = 60  # minutes
 DEFAULT_FEEDING_REMINDER_HOURS = 8  # hours

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -54,12 +54,13 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Type aliases for better code readability
+AttributeDict = dict[str, Any]
+
 # Select entities invoke coordinator-backed actions; limit concurrency to one
 # operation at a time to comply with the ``parallel-updates`` requirement.
 PARALLEL_UPDATES = 1
 
-# Type aliases for better code readability
-AttributeDict = dict[str, Any]
 
 # Additional option lists for selects
 WALK_MODES = [

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -54,6 +54,10 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
+# Select entities invoke coordinator-backed actions; limit concurrency to one
+# operation at a time to comply with the ``parallel-updates`` requirement.
+PARALLEL_UPDATES = 1
+
 # Type aliases for better code readability
 AttributeDict = dict[str, Any]
 

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -51,6 +51,11 @@ BATCH_SIZE = 15  # Optimized for profile-filtered entities
 BATCH_DELAY = 0.003  # Reduced to 3ms for faster setup
 MAX_CONCURRENT_BATCHES = 8  # Balanced for profile optimization
 
+# Switches toggle features and therefore execute actions. Limit concurrent
+# operations so we comply with the ``parallel-updates`` rule while preventing
+# conflicting commands to the same device.
+PARALLEL_UPDATES = 1
+
 
 class ProfileOptimizedSwitchFactory:
     """Factory for efficient profile-based switch creation with minimal entity count."""

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -30,6 +30,10 @@ from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
+# Text helpers persist updates back to the coordinator; use a single
+# concurrent operation to satisfy the ``parallel-updates`` quality scale rule.
+PARALLEL_UPDATES = 1
+
 
 def _normalize_dog_configs(
     raw_configs: Iterable[Any] | None,


### PR DESCRIPTION
## Summary
- annotate Paw Control platforms with explicit `PARALLEL_UPDATES` values to satisfy the quality scale requirement
- keep the device tracker read-only path unlimited while serialising mutating entity updates

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e10c1a26148331a25a788f90526a74