### PR TITLE
Validate aiohttp request coroutines

### DIFF
--- a/custom_components/pawcontrol/http_client.py
+++ b/custom_components/pawcontrol/http_client.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from typing import Any, cast
+import asyncio
+from inspect import unwrap
+from typing import Any, Callable, cast
 
 from aiohttp import ClientSession
 
@@ -30,6 +32,18 @@ def ensure_shared_client_session(session: Any, *, owner: str) -> ClientSession:
 
     request = getattr(session, "request", None)
     if not callable(request):
+        raise ValueError(
+            f"{owner} received an object without an aiohttp-compatible 'request' coroutine."
+        )
+
+    def _is_coroutine(func: Callable[..., Any] | None) -> bool:
+        if func is None:
+            return False
+
+        candidate = unwrap(getattr(func, "__func__", func))
+        return asyncio.iscoroutinefunction(candidate)
+
+    if not _is_coroutine(request) and not _is_coroutine(getattr(type(session), "request", None)):
         raise ValueError(
             f"{owner} received an object without an aiohttp-compatible 'request' coroutine."
         )

--- a/tests/unit/test_http_client.py
+++ b/tests/unit/test_http_client.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 from types import ModuleType
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
@@ -60,6 +60,23 @@ def test_ensure_shared_client_session_rejects_closed_pool(
         ensure_shared(session, owner="TestHelper")
 
     assert "received a closed aiohttp ClientSession" in str(excinfo.value)
+
+
+@pytest.mark.unit
+def test_ensure_shared_client_session_requires_coroutine_request(
+    http_client_module: ModuleType, session_factory
+) -> None:
+    """A synchronous request attribute should be rejected."""
+
+    ensure_shared = http_client_module.ensure_shared_client_session
+
+    session = session_factory()
+    session.request = Mock()
+
+    with pytest.raises(ValueError) as excinfo:
+        ensure_shared(session, owner="TestHelper")
+
+    assert "aiohttp-compatible 'request' coroutine" in str(excinfo.value)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- ensure the shared aiohttp session helper rejects synchronous request callables
- unwrap bound methods to confirm an aiohttp-compatible coroutine before accepting the session
- add regression coverage for synchronous request attributes in the helper tests

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e115b7dc048331bba1febf5088827f