### PR TITLE
Improve numeric coercion in validation helpers

### DIFF
--- a/custom_components/pawcontrol/validation.py
+++ b/custom_components/pawcontrol/validation.py
@@ -161,7 +161,7 @@ def _coerce_int(field: str, value: Any) -> int:
         except ValueError:
             try:
                 float_value = float(stripped)
-            except ValueError as err:  # noqa: PERF203 - explicit error context
+            except ValueError as err:
                 raise ValidationError(
                     field,
                     value,

--- a/custom_components/pawcontrol/validation.py
+++ b/custom_components/pawcontrol/validation.py
@@ -175,7 +175,7 @@ def _coerce_int(field: str, value: Any) -> int:
                     value,
                     "Must be a whole number",
                     f"Received fractional value: {float_value}",
-                )
+                ) from None
 
             return int(float_value)
 


### PR DESCRIPTION
## Summary
- add shared helpers for coercing numeric input with consistent ValidationError messaging
- reuse the new helpers across weight, age, GPS, and other validators to accept numeric strings

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e11dda1d548331bdad6a6c43d7358b