### PR TITLE
Improve runtime data typing helpers

### DIFF
--- a/custom_components/pawcontrol/runtime_data.py
+++ b/custom_components/pawcontrol/runtime_data.py
@@ -2,12 +2,54 @@
 
 from __future__ import annotations
 
-from typing import Any
+from collections.abc import Mapping, MutableMapping
+from typing import Any, cast
 
 from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 from .types import PawControlConfigEntry, PawControlRuntimeData
+
+
+DomainRuntimeStore = MutableMapping[str, PawControlRuntimeData | Mapping[str, Any]]
+
+
+def _resolve_entry_id(entry_or_id: PawControlConfigEntry | str) -> str:
+    """Return the entry identifier for ``entry_or_id``."""
+
+    return entry_or_id if isinstance(entry_or_id, str) else entry_or_id.entry_id
+
+
+def _get_domain_store(
+    hass: HomeAssistant, *, create: bool
+) -> DomainRuntimeStore | None:
+    """Return the PawControl storage dictionary from ``hass.data``."""
+
+    domain_data: Any
+    if create:
+        domain_data = hass.data.setdefault(DOMAIN, {})
+    else:
+        domain_data = hass.data.get(DOMAIN)
+
+    if not isinstance(domain_data, MutableMapping):
+        if not create:
+            return None
+        domain_data = {}
+        hass.data[DOMAIN] = domain_data
+
+    return cast(DomainRuntimeStore, domain_data)
+
+
+def _coerce_runtime_data(value: Any) -> PawControlRuntimeData | None:
+    """Return a :class:`PawControlRuntimeData` instance if one is embedded."""
+
+    if isinstance(value, PawControlRuntimeData):
+        return value
+    if isinstance(value, Mapping):
+        candidate = value.get("runtime_data")
+        if isinstance(candidate, PawControlRuntimeData):
+            return candidate
+    return None
 
 
 def store_runtime_data(
@@ -17,8 +59,9 @@ def store_runtime_data(
 ) -> None:
     """Store runtime data in ``hass.data`` for the given config entry."""
 
-    domain_data = hass.data.setdefault(DOMAIN, {})
-    domain_data[entry.entry_id] = runtime_data
+    store = _get_domain_store(hass, create=True)
+    assert store is not None  # Satisfies the type checker
+    store[entry.entry_id] = runtime_data
 
 
 def get_runtime_data(
@@ -26,21 +69,12 @@ def get_runtime_data(
 ) -> PawControlRuntimeData | None:
     """Return the runtime data associated with a config entry."""
 
-    entry_id = entry_or_id if isinstance(entry_or_id, str) else entry_or_id.entry_id
-    domain_data = hass.data.get(DOMAIN)
-    if not domain_data:
+    entry_id = _resolve_entry_id(entry_or_id)
+    store = _get_domain_store(hass, create=False)
+    if not store:
         return None
 
-    data: Any = domain_data.get(entry_id)
-    if isinstance(data, PawControlRuntimeData):
-        return data
-
-    if isinstance(data, dict):
-        candidate = data.get("runtime_data")
-        if isinstance(candidate, PawControlRuntimeData):
-            return candidate
-
-    return None
+    return _coerce_runtime_data(store.get(entry_id))
 
 
 def pop_runtime_data(
@@ -48,18 +82,10 @@ def pop_runtime_data(
 ) -> PawControlRuntimeData | None:
     """Remove and return runtime data for a config entry if present."""
 
-    entry_id = entry_or_id if isinstance(entry_or_id, str) else entry_or_id.entry_id
-    domain_data = hass.data.get(DOMAIN)
-    if not domain_data:
+    entry_id = _resolve_entry_id(entry_or_id)
+    store = _get_domain_store(hass, create=False)
+    if not store:
         return None
 
-    data: Any = domain_data.pop(entry_id, None)
-    if isinstance(data, PawControlRuntimeData):
-        return data
-
-    if isinstance(data, dict):
-        candidate = data.get("runtime_data")
-        if isinstance(candidate, PawControlRuntimeData):
-            return candidate
-
-    return None
+    value = store.pop(entry_id, None)
+    return _coerce_runtime_data(value)

--- a/custom_components/pawcontrol/types.py
+++ b/custom_components/pawcontrol/types.py
@@ -430,15 +430,15 @@ class PawControlRuntimeData:
 
 
 # PLATINUM: Custom ConfigEntry type for PawControl integrations
-type PawControlConfigEntry = ConfigEntry
+type PawControlConfigEntry = ConfigEntry[PawControlRuntimeData]
 """Type alias for PawControl-specific config entries.
 
-Home Assistant has deprecated direct use of ``ConfigEntry.runtime_data``.  This
-integration stores its runtime payload in ``hass.data`` and exposes helper
-functions (for example ``get_runtime_data``) that return the typed
-``PawControlRuntimeData`` instance.  The alias keeps call sites expressive while
-remaining faithful to the underlying data flow and forward compatible with
-future Home Assistant releases and their typing changes.
+Home Assistant now exposes ``ConfigEntry`` as a generic container whose type
+parameter describes the stored ``runtime_data`` payload.  By binding the alias to
+``PawControlRuntimeData`` we provide precise typing for every consumer of the
+integration's config entries.  This keeps call sites expressive while remaining
+faithful to the underlying data flow and forward compatible with future Home
+Assistant releases and their typing changes.
 """
 
 

--- a/tests/test_runtime_data.py
+++ b/tests/test_runtime_data.py
@@ -1,0 +1,176 @@
+"""Unit tests for runtime data helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _ensure_package(name: str, path: Path) -> ModuleType:
+    """Ensure a namespace package exists for dynamic imports."""
+
+    module = sys.modules.get(name)
+    if module is None:
+        module = ModuleType(name)
+        module.__path__ = [str(path)]  # type: ignore[attr-defined]
+        sys.modules[name] = module
+    return module
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    """Load ``name`` from ``path`` without importing the package ``__init__``."""
+
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_homeassistant_stub() -> None:
+    """Register lightweight stubs for the Home Assistant modules we use."""
+
+    if "homeassistant.core" in sys.modules:
+        return
+
+    homeassistant = ModuleType("homeassistant")
+    sys.modules.setdefault("homeassistant", homeassistant)
+
+    core = ModuleType("homeassistant.core")
+
+    class HomeAssistant:  # pragma: no cover - simple attribute container
+        def __init__(self) -> None:
+            self.data = {}
+
+    core.HomeAssistant = HomeAssistant
+    sys.modules["homeassistant.core"] = core
+
+
+_ensure_package("custom_components", PROJECT_ROOT / "custom_components")
+_ensure_package(
+    "custom_components.pawcontrol",
+    PROJECT_ROOT / "custom_components" / "pawcontrol",
+)
+
+const = _load_module(
+    "custom_components.pawcontrol.const",
+    PROJECT_ROOT / "custom_components" / "pawcontrol" / "const.py",
+)
+types_module = _load_module(
+    "custom_components.pawcontrol.types",
+    PROJECT_ROOT / "custom_components" / "pawcontrol" / "types.py",
+)
+_install_homeassistant_stub()
+runtime_module = _load_module(
+    "custom_components.pawcontrol.runtime_data",
+    PROJECT_ROOT / "custom_components" / "pawcontrol" / "runtime_data.py",
+)
+
+DOMAIN = const.DOMAIN
+PawControlRuntimeData = types_module.PawControlRuntimeData
+PawControlConfigEntry = types_module.PawControlConfigEntry
+store_runtime_data = runtime_module.store_runtime_data
+get_runtime_data = runtime_module.get_runtime_data
+pop_runtime_data = runtime_module.pop_runtime_data
+
+
+class _DummyEntry:
+    """Lightweight stand-in for a Home Assistant config entry."""
+
+    def __init__(self, entry_id: str) -> None:
+        self.entry_id = entry_id
+
+
+@pytest.fixture
+def runtime_data() -> PawControlRuntimeData:
+    """Return a fully initialised runtime data container for tests."""
+
+    return PawControlRuntimeData(
+        coordinator=MagicMock(),
+        data_manager=MagicMock(),
+        notification_manager=MagicMock(),
+        feeding_manager=MagicMock(),
+        walk_manager=MagicMock(),
+        entity_factory=MagicMock(),
+        entity_profile="standard",
+        dogs=[],
+    )
+
+
+def _entry(entry_id: str = "test-entry") -> PawControlConfigEntry:
+    """Create a dummy config entry with the given identifier."""
+
+    return cast(PawControlConfigEntry, _DummyEntry(entry_id))
+
+
+def test_store_and_get_runtime_data_roundtrip(runtime_data: PawControlRuntimeData) -> None:
+    """Storing runtime data should make it retrievable via the helper."""
+
+    hass = SimpleNamespace(data={})
+    entry = _entry()
+
+    store_runtime_data(hass, entry, runtime_data)
+
+    assert get_runtime_data(hass, entry) is runtime_data
+    assert get_runtime_data(hass, entry.entry_id) is runtime_data
+
+
+def test_get_runtime_data_handles_legacy_container(runtime_data: PawControlRuntimeData) -> None:
+    """Legacy dict containers should still be unwrapped."""
+
+    hass = SimpleNamespace(data={DOMAIN: {"legacy": {"runtime_data": runtime_data}}})
+
+    assert get_runtime_data(hass, "legacy") is runtime_data
+
+
+def test_get_runtime_data_ignores_unknown_entries() -> None:
+    """Missing entries should return ``None`` without side effects."""
+
+    hass = SimpleNamespace(data={})
+
+    assert get_runtime_data(hass, "missing") is None
+
+
+def test_get_runtime_data_with_unexpected_container_type(runtime_data: PawControlRuntimeData) -> None:
+    """Non-mapping containers are treated as absent data."""
+
+    hass = SimpleNamespace(data={DOMAIN: []})
+
+    assert get_runtime_data(hass, "legacy") is None
+
+    # After storing data the invalid container should be replaced with a mapping.
+    entry = _entry("recovered")
+    store_runtime_data(hass, entry, runtime_data)
+    assert isinstance(hass.data[DOMAIN], dict)
+    assert get_runtime_data(hass, entry.entry_id) is runtime_data
+
+
+def test_pop_runtime_data_removes_entry(runtime_data: PawControlRuntimeData) -> None:
+    """Popping runtime data should remove the stored value."""
+
+    hass = SimpleNamespace(data={})
+    entry = _entry("pop-entry")
+
+    store_runtime_data(hass, entry, runtime_data)
+    assert pop_runtime_data(hass, entry) is runtime_data
+    assert get_runtime_data(hass, entry) is None
+
+
+def test_pop_runtime_data_handles_legacy_container(runtime_data: PawControlRuntimeData) -> None:
+    """Legacy dict containers should be handled by ``pop_runtime_data`` too."""
+
+    hass = SimpleNamespace(data={DOMAIN: {"legacy": {"runtime_data": runtime_data}}})
+
+    assert pop_runtime_data(hass, "legacy") is runtime_data
+    assert hass.data[DOMAIN] == {}


### PR DESCRIPTION
## Summary
- type the PawControl config entry alias to reference the integration runtime payload
- harden the runtime data helpers with shared coercion/lookup utilities
- add focused unit tests that exercise storing, reading and popping runtime data without Home Assistant deps

## Testing
- pytest tests/test_runtime_data.py

------
https://chatgpt.com/codex/tasks/task_e_68e1289a7e6483319fbdd7b01a99af51