### PR TITLE
Set PARALLEL_UPDATES to 0 for coordinator platforms

### DIFF
--- a/custom_components/pawcontrol/binary_sensor.py
+++ b/custom_components/pawcontrol/binary_sensor.py
@@ -53,7 +53,7 @@ _LOGGER = logging.getLogger(__name__)
 AttributeDict = dict[str, Any]
 
 # Home Assistant platform configuration
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 # OPTIMIZATION: Performance constants for batched entity creation
 ENTITY_CREATION_BATCH_SIZE = 12  # Optimized for binary sensors

--- a/custom_components/pawcontrol/button.py
+++ b/custom_components/pawcontrol/button.py
@@ -99,7 +99,7 @@ def _prepare_service_proxy(
 
 
 # Home Assistant platform configuration
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 # OPTIMIZATION: Profile-based entity reduction
 PROFILE_BUTTON_LIMITS = {

--- a/custom_components/pawcontrol/date.py
+++ b/custom_components/pawcontrol/date.py
@@ -45,9 +45,10 @@ from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
-# Date helpers mutate coordinator-managed settings, so restrict concurrency to
-# one update at a time for the ``parallel-updates`` quality scale rule.
-PARALLEL_UPDATES = 1
+# Date helpers mutate coordinator-managed settings. We rely on the
+# coordinator's own locking and therefore allow Home Assistant to schedule
+# entity updates without artificial limits.
+PARALLEL_UPDATES = 0
 
 
 async def _async_add_entities_in_batches(

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -34,9 +34,10 @@ from .utils import (
 
 _LOGGER = logging.getLogger(__name__)
 
-# Date/time helpers write settings back to Paw Control, so limit concurrent
-# updates to a single request to satisfy the ``parallel-updates`` rule.
-PARALLEL_UPDATES = 1
+# Date/time helpers write settings back to Paw Control. The coordinator
+# serialises writes, so we lift the entity-level cap and let Home Assistant run
+# updates in parallel when possible.
+PARALLEL_UPDATES = 0
 
 
 async def _async_add_entities_in_batches(

--- a/custom_components/pawcontrol/number.py
+++ b/custom_components/pawcontrol/number.py
@@ -55,10 +55,10 @@ _LOGGER = logging.getLogger(__name__)
 # Type aliases for better code readability
 AttributeDict = dict[str, Any]
 
-# Many number entities trigger write operations (service calls) so we keep
-# the concurrency at one to honor the ``parallel-updates`` quality scale
-# rule while still allowing sequential updates from Home Assistant.
-PARALLEL_UPDATES = 1
+# Many number entities trigger write operations (service calls). The
+# coordinator applies its own throttling so we can keep Home Assistant's
+# parallel scheduling fully enabled.
+PARALLEL_UPDATES = 0
 
 # Configuration limits and defaults
 DEFAULT_WALK_DURATION_TARGET = 60  # minutes

--- a/custom_components/pawcontrol/quality_scale.yaml
+++ b/custom_components/pawcontrol/quality_scale.yaml
@@ -70,7 +70,7 @@ rules:
     comment: "Invalid payloads validated and logged before processing."
   parallel-updates:
     status: done
-    comment: "Data coordinator schedules parallel refreshes for entities."
+    comment: "All platforms set PARALLEL_UPDATES = 0 so coordinators can refresh entities in parallel."
   reauthentication-flow:
     status: done
     comment: "Config flow implements async_step_reauth and async_step_reauth_confirm handling (see config_flow.py)."

--- a/custom_components/pawcontrol/select.py
+++ b/custom_components/pawcontrol/select.py
@@ -57,9 +57,10 @@ _LOGGER = logging.getLogger(__name__)
 # Type aliases for better code readability
 AttributeDict = dict[str, Any]
 
-# Select entities invoke coordinator-backed actions; limit concurrency to one
-# operation at a time to comply with the ``parallel-updates`` requirement.
-PARALLEL_UPDATES = 1
+# Select entities invoke coordinator-backed actions. The coordinator is
+# responsible for serialising writes, so we allow unlimited parallel updates at
+# the entity layer.
+PARALLEL_UPDATES = 0
 
 
 # Additional option lists for selects

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -54,7 +54,7 @@ SensorValue = str | int | float | datetime | None
 AttributeDict = dict[str, Any]
 
 # Home Assistant platform configuration
-PARALLEL_UPDATES = 1
+PARALLEL_UPDATES = 0
 
 # OPTIMIZED: Performance constants for Platinum profiles
 ENTITY_CREATION_DELAY = 0.005  # 5ms between batches (optimized for profiles)

--- a/custom_components/pawcontrol/switch.py
+++ b/custom_components/pawcontrol/switch.py
@@ -51,10 +51,10 @@ BATCH_SIZE = 15  # Optimized for profile-filtered entities
 BATCH_DELAY = 0.003  # Reduced to 3ms for faster setup
 MAX_CONCURRENT_BATCHES = 8  # Balanced for profile optimization
 
-# Switches toggle features and therefore execute actions. Limit concurrent
-# operations so we comply with the ``parallel-updates`` rule while preventing
-# conflicting commands to the same device.
-PARALLEL_UPDATES = 1
+# Switches toggle features and therefore execute actions. The coordinator
+# prevents conflicting commands, so we can expose unlimited parallel entity
+# updates to Home Assistant.
+PARALLEL_UPDATES = 0
 
 
 class ProfileOptimizedSwitchFactory:

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -30,9 +30,9 @@ from .utils import PawControlDeviceLinkMixin, async_call_add_entities
 
 _LOGGER = logging.getLogger(__name__)
 
-# Text helpers persist updates back to the coordinator; use a single
-# concurrent operation to satisfy the ``parallel-updates`` quality scale rule.
-PARALLEL_UPDATES = 1
+# Text helpers persist updates back to the coordinator. Coordinator-side
+# locking keeps writes safe, so we remove the entity-level concurrency cap.
+PARALLEL_UPDATES = 0
 
 
 def _normalize_dog_configs(

--- a/docs/QUALITY_CHECKLIST.md
+++ b/docs/QUALITY_CHECKLIST.md
@@ -14,7 +14,7 @@ for transparency.
 
 ## Silver
 - [x] Services validated with rich error handling and typed schemas (`services.py`).
-- [x] `PARALLEL_UPDATES` tuned per platform with coordinator-backed scheduling.
+- [x] `PARALLEL_UPDATES = 0` on all coordinator-backed platforms to allow unlimited parallel refreshes.
 - [x] End-to-end style runtime simulations covered by scaling tests.
 
 ## Gold & Platinum


### PR DESCRIPTION
## Summary
- allow coordinator-backed Paw Control platforms to run without a parallel updates cap by setting `PARALLEL_UPDATES = 0`
- document the concurrency change in the quality checklist and quality scale metadata

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e136acffac8331b49e25efd586ee4f