### PR TITLE
Improve runtime data migration and cleanup

### DIFF
--- a/custom_components/pawcontrol/runtime_data.py
+++ b/custom_components/pawcontrol/runtime_data.py
@@ -36,17 +36,26 @@ def _get_domain_store(
     return cast(DomainRuntimeStore, domain_data)
 
 
-def _coerce_runtime_data(value: Any) -> PawControlRuntimeData | None:
-    """Return a :class:`PawControlRuntimeData` instance if one is embedded."""
+def _coerce_runtime_data(
+    value: Any,
+) -> tuple[PawControlRuntimeData | None, bool]:
+    """Return runtime data and whether the store needs migration."""
 
     match value:
         case PawControlRuntimeData() as data:
-            return data
+            return data, False
 
         case {"runtime_data": PawControlRuntimeData() as data}:
-            return data
+            return data, True
 
-    return None
+    return None, False
+
+
+def _cleanup_domain_store(hass: HomeAssistant, store: DomainRuntimeStore | None) -> None:
+    """Remove the PawControl domain store when it no longer holds entries."""
+
+    if store is not None and not store:
+        hass.data.pop(DOMAIN, None)
 
 
 def store_runtime_data(
@@ -71,7 +80,18 @@ def get_runtime_data(
     if not store:
         return None
 
-    return _coerce_runtime_data(store.get(entry_id))
+    runtime_data, needs_migration = _coerce_runtime_data(store.get(entry_id))
+    if runtime_data and needs_migration:
+        store[entry_id] = runtime_data
+    elif runtime_data is None and needs_migration:
+        # ``needs_migration`` is only ``True`` when an old structure was present.
+        # If the payload could not be coerced we should remove the legacy
+        # container to avoid future lookups hitting invalid data.
+        store.pop(entry_id, None)
+        _cleanup_domain_store(hass, store)
+        return None
+
+    return runtime_data
 
 
 def pop_runtime_data(
@@ -85,4 +105,12 @@ def pop_runtime_data(
         return None
 
     value = store.pop(entry_id, None)
-    return _coerce_runtime_data(value)
+    _cleanup_domain_store(hass, store)
+
+    runtime_data, needs_migration = _coerce_runtime_data(value)
+    if runtime_data and needs_migration:
+        # ``pop`` removed the legacy container, so we can return the
+        # extracted runtime data directly.
+        return runtime_data
+
+    return runtime_data

--- a/tests/test_runtime_data.py
+++ b/tests/test_runtime_data.py
@@ -135,6 +135,9 @@ def test_get_runtime_data_handles_legacy_container(
     hass = SimpleNamespace(data={DOMAIN: {"legacy": {"runtime_data": runtime_data}}})
 
     assert get_runtime_data(hass, "legacy") is runtime_data
+    # The legacy container should be replaced with the actual runtime data for
+    # subsequent lookups to avoid repeated migrations.
+    assert hass.data[DOMAIN]["legacy"] is runtime_data
 
 
 def test_get_runtime_data_ignores_unknown_entries() -> None:
@@ -180,4 +183,15 @@ def test_pop_runtime_data_handles_legacy_container(
     hass = SimpleNamespace(data={DOMAIN: {"legacy": {"runtime_data": runtime_data}}})
 
     assert pop_runtime_data(hass, "legacy") is runtime_data
-    assert hass.data[DOMAIN] == {}
+    assert DOMAIN not in hass.data
+
+
+def test_pop_runtime_data_cleans_up_domain_store(
+    runtime_data: PawControlRuntimeData,
+) -> None:
+    """Removing the final entry should drop the PawControl data namespace."""
+
+    hass = SimpleNamespace(data={DOMAIN: {"entry": runtime_data}})
+
+    assert pop_runtime_data(hass, "entry") is runtime_data
+    assert DOMAIN not in hass.data


### PR DESCRIPTION
## Summary
- migrate legacy runtime data containers to direct dataclass storage
- ensure runtime data namespace is cleaned up when entries are removed
- extend runtime data tests to cover migration behaviour and storage cleanup

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e1398b3b648331a1d126e797260c2a