### PR TITLE
Update session guard scan roots dynamically

### DIFF
--- a/scripts/enforce_shared_session_guard.py
+++ b/scripts/enforce_shared_session_guard.py
@@ -78,7 +78,10 @@ def _resolve_configured_roots() -> set[Path]:
     return roots
 
 
-SCAN_ROOTS: tuple[Path, ...] = tuple(sorted(_resolve_configured_roots()))
+def _get_scan_roots() -> tuple[Path, ...]:
+    """Return the directories that should be scanned for violations."""
+
+    return tuple(sorted(_resolve_configured_roots()))
 
 
 def _collect_client_session_aliases(tree: ast.AST) -> tuple[set[str], set[str]]:
@@ -171,7 +174,7 @@ def main() -> int:
 
     failures: list[str] = []
 
-    for root in SCAN_ROOTS:
+    for root in _get_scan_roots():
         for file_path in _iter_python_files(root):
             if file_path in ALLOWED_FILES:
                 continue

--- a/tests/tooling/test_enforce_shared_session_guard.py
+++ b/tests/tooling/test_enforce_shared_session_guard.py
@@ -130,7 +130,7 @@ def test_main_handles_syntax_errors_gracefully(
         "CONFIG_PATH",
         repo_root / "scripts" / "shared_session_guard_roots.toml",
     )
-    monkeypatch.setattr(guard, "SCAN_ROOTS", (integration_root,))
+    monkeypatch.setattr(guard, "_get_scan_roots", lambda: (integration_root,))
 
     exit_code = guard.main()
     output = capsys.readouterr().out


### PR DESCRIPTION
## Summary
- recompute the enforce_shared_session_guard scan roots on demand so configuration edits are respected immediately
- update the guard regression test to patch the new scan-root helper when simulating CLI execution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1453891048331856670f3cf51efc8