### PR TITLE
Configure submit-pypi workflow to use Python 3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,36 @@ jobs:
           prerelease: false
           generate_release_notes: true
 
+  submit-pypi:
+    name: Publish to PyPI
+    needs: [prepare-release, test-and-validate]
+    runs-on: ubuntu-latest
+    if: ${{ secrets.PYPI_API_TOKEN != '' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          cache: "pip"
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build
+
+      - name: Build package
+        run: python -m build
+
+      - name: Publish distribution to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_API_TOKEN }}
+
   notify-release:
     name: Notify Release
     needs: [prepare-release, create-github-release]


### PR DESCRIPTION
## Summary
- add a submit-pypi job to the release workflow that builds and publishes the package
- configure the workflow to set up Python 3.13 before running build and publish steps

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e14c9120bc8331b6210c078bdca9e6