### PR TITLE
Handle iterable webhook insecure configs

### DIFF
--- a/custom_components/pawcontrol/coordinator_observability.py
+++ b/custom_components/pawcontrol/coordinator_observability.py
@@ -185,7 +185,9 @@ def normalise_webhook_status(manager: Any) -> dict[str, Any]:
     status.setdefault("secure", False)
     status.setdefault("hmac_ready", False)
     insecure = status.get("insecure_configs", ())
-    if isinstance(insecure, list | tuple | set):
+    if isinstance(insecure, Iterable) and not isinstance(
+        insecure, (str, bytes, bytearray)
+    ):
         status["insecure_configs"] = tuple(insecure)
     else:
         status["insecure_configs"] = (insecure,) if insecure else ()

--- a/custom_components/pawcontrol/coordinator_observability.py
+++ b/custom_components/pawcontrol/coordinator_observability.py
@@ -186,7 +186,7 @@ def normalise_webhook_status(manager: Any) -> dict[str, Any]:
     status.setdefault("hmac_ready", False)
     insecure = status.get("insecure_configs", ())
     if isinstance(insecure, Iterable) and not isinstance(
-        insecure, (str, bytes, bytearray)
+        insecure, str | bytes | bytearray
     ):
         status["insecure_configs"] = tuple(insecure)
     else:

--- a/tests/coverage/test_coordinator_observability.py
+++ b/tests/coverage/test_coordinator_observability.py
@@ -405,6 +405,19 @@ def test_normalise_webhook_status_defaults_and_errors() -> None:
     iterable_status = normalise_webhook_status(IterableManager())
     assert iterable_status["insecure_configs"] == ("dog-b", "dog-c")
 
+    class GeneratorManager:
+        @staticmethod
+        def webhook_security_status() -> dict[str, object]:
+            return {
+                "configured": True,
+                "secure": False,
+                "hmac_ready": False,
+                "insecure_configs": (config for config in ("dog-d", "dog-e")),
+            }
+
+    generator_status = normalise_webhook_status(GeneratorManager())
+    assert generator_status["insecure_configs"] == ("dog-d", "dog-e")
+
 
 def test_summarize_entity_budgets_empty_input() -> None:
     """Summary helper should handle empty iterables gracefully."""


### PR DESCRIPTION
## Summary
- normalize webhook security payloads to convert any iterable insecure config collection into a tuple without breaking on generators
- extend coverage test to verify generator-based webhook payloads are handled correctly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e16e197fb88331828da0773532c6b4