### PR TITLE
Fix asynchronous repair issue management

### DIFF
--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -81,7 +81,7 @@ async def async_create_issue(
     if data:
         issue_data.update(data)
 
-    ir.async_create_issue(
+    await ir.async_create_issue(
         hass,
         DOMAIN,
         issue_id,
@@ -893,7 +893,7 @@ class PawControlRepairsFlow(RepairsFlow):
             Flow result indicating completion
         """
         # Remove the issue from the issue registry
-        ir.async_delete_issue(self.hass, DOMAIN, self.issue_id)
+        await ir.async_delete_issue(self.hass, DOMAIN, self.issue_id)
 
         return self.async_create_entry(
             title="Repair completed",


### PR DESCRIPTION
## Summary
- await creation of repair issues so registry updates are executed
- await deleting repair issues when flows complete to avoid stale entries

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e16e3d03bc833180653e41d7e8cfa5