### PR TITLE
Clean invalid PawControl runtime data store

### DIFF
--- a/custom_components/pawcontrol/runtime_data.py
+++ b/custom_components/pawcontrol/runtime_data.py
@@ -29,6 +29,11 @@ def _get_domain_store(
 
     if not isinstance(domain_data, MutableMapping):
         if not create:
+            # The store was populated with an unexpected container type. Remove
+            # it so future lookups and writes can recreate a clean mapping. The
+            # tests exercise this behaviour by ensuring ``DOMAIN`` is removed
+            # when invalid data is encountered.
+            hass.data.pop(DOMAIN, None)
             return None
         domain_data = {}
         hass.data[DOMAIN] = domain_data

--- a/tests/test_runtime_data.py
+++ b/tests/test_runtime_data.py
@@ -158,6 +158,9 @@ def test_get_runtime_data_with_unexpected_container_type(
     hass = SimpleNamespace(data={DOMAIN: []})
 
     assert get_runtime_data(hass, "legacy") is None
+    # The invalid container should be cleaned up entirely so future lookups do
+    # not keep encountering the bad structure.
+    assert DOMAIN not in hass.data
 
     # After storing data the invalid container should be replaced with a mapping.
     entry = _entry("recovered")


### PR DESCRIPTION
## Summary
- remove unexpected containers from the PawControl runtime data namespace when reading without creating
- extend runtime data tests to ensure invalid stores are cleaned up before recreating the mapping

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e170b9474c8331bcd6e3ef014676a0