### PR TITLE
Fix repair flow registration and surface repair checks during setup

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -46,6 +46,7 @@ from .geofencing import PawControlGeofencing
 from .gps_manager import GPSGeofenceManager
 from .helper_manager import PawControlHelperManager
 from .notifications import PawControlNotificationManager
+from .repairs import async_check_for_issues
 from .runtime_data import get_runtime_data, pop_runtime_data, store_runtime_data
 from .script_manager import PawControlScriptManager
 from .services import PawControlServiceManager, async_setup_daily_reset_scheduler
@@ -741,6 +742,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
         # Get door sensor status
         door_sensor_status = await door_sensor_manager.async_get_detection_status()
         door_sensors_configured = door_sensor_status["configured_dogs"]
+
+        # Run repair checks to surface actionable issues in the repairs panel
+        await async_check_for_issues(hass, entry)
 
         setup_duration = time.time() - setup_start_time
         _LOGGER.info(

--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -1015,20 +1015,20 @@ class PawControlRepairsFlow(RepairsFlow):
 
 
 @callback
-def async_create_repair_flow(
+def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
     data: dict[str, Any] | None,
 ) -> PawControlRepairsFlow:
-    """Create a repair flow.
+    """Create a fix flow for a Paw Control repair issue.
 
     Args:
         hass: Home Assistant instance
-        issue_id: Issue identifier
-        data: Issue data
+        issue_id: Identifier of the repair issue
+        data: Issue metadata provided by the registry
 
     Returns:
-        Repair flow instance
+        Repair flow instance bound to the Paw Control handler
     """
     return PawControlRepairsFlow()
 


### PR DESCRIPTION
## Summary
- rename the repairs platform factory to `async_create_fix_flow` so the Home Assistant repairs manager can load it
- run `async_check_for_issues` during config entry setup to populate actionable issues in the repairs panel

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e170b9474c8331bcd6e3ef014676a0