### PR TITLE
Fix repairs platform registration

### DIFF
--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -14,7 +14,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components.repairs import RepairsFlow
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant, callback
+from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.selector import selector
@@ -1014,13 +1014,17 @@ class PawControlRepairsFlow(RepairsFlow):
         self.hass.config_entries.async_update_entry(entry, options=new_options)
 
 
-@callback
-def async_create_repair_flow(
+async def async_create_fix_flow(
     hass: HomeAssistant,
     issue_id: str,
     data: dict[str, Any] | None,
 ) -> PawControlRepairsFlow:
-    """Create a repair flow.
+    """Create a repair flow compatible with the Repairs integration.
+
+    Home Assistant loads `repairs.py` integration platforms via
+    :func:`homeassistant.helpers.integration_platform.async_process_integration_platforms`
+    and expects them to expose an ``async_create_fix_flow`` coroutine that
+    returns a :class:`~homeassistant.components.repairs.RepairsFlow` instance.
 
     Args:
         hass: Home Assistant instance


### PR DESCRIPTION
## Summary
- expose `async_create_fix_flow` from the repairs platform so Home Assistant can register Paw Control repair flows
- clean up the repairs module import and document the expected registration contract

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e170b9474c8331bcd6e3ef014676a0