### PR TITLE
Add repair issue translations and refine GPS warnings

### DIFF
--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -40,6 +40,7 @@ ISSUE_INVALID_GPS_CONFIG = "invalid_gps_configuration"
 ISSUE_MISSING_NOTIFICATIONS = "missing_notification_config"
 ISSUE_OUTDATED_CONFIG = "outdated_configuration"
 ISSUE_PERFORMANCE_WARNING = "performance_warning"
+ISSUE_GPS_UPDATE_INTERVAL = "gps_update_interval_warning"
 ISSUE_STORAGE_WARNING = "storage_warning"
 ISSUE_MODULE_CONFLICT = "module_configuration_conflict"
 ISSUE_INVALID_DOG_DATA = "invalid_dog_data"
@@ -285,9 +286,8 @@ async def _check_gps_configuration_issues(
             hass,
             entry,
             f"{entry.entry_id}_gps_update_too_frequent",
-            ISSUE_PERFORMANCE_WARNING,
+            ISSUE_GPS_UPDATE_INTERVAL,
             {
-                "issue": "gps_update_too_frequent",
                 "current_interval": update_interval,
                 "recommended_interval": 30,
             },
@@ -510,7 +510,10 @@ class PawControlRepairsFlow(RepairsFlow):
             return await self.async_step_missing_notifications()
         elif self._repair_type == ISSUE_OUTDATED_CONFIG:
             return await self.async_step_outdated_config()
-        elif self._repair_type == ISSUE_PERFORMANCE_WARNING:
+        elif self._repair_type in {
+            ISSUE_PERFORMANCE_WARNING,
+            ISSUE_GPS_UPDATE_INTERVAL,
+        }:
             return await self.async_step_performance_warning()
         elif self._repair_type == ISSUE_STORAGE_WARNING:
             return await self.async_step_storage_warning()

--- a/custom_components/pawcontrol/strings.json
+++ b/custom_components/pawcontrol/strings.json
@@ -1136,5 +1136,51 @@
     "module_not_enabled": {
       "message": "The required module is not enabled for this dog"
     }
+  },
+  "issues": {
+    "missing_dog_configuration": {
+      "title": "Add at least one dog",
+      "description": "Paw Control needs at least one dog profile. Configure a dog to continue. Dogs configured: {dogs_count}."
+    },
+    "duplicate_dog_ids": {
+      "title": "Duplicate dog IDs detected",
+      "description": "The following IDs are used more than once: {duplicate_ids}. Each of the {total_dogs} dogs must have a unique ID."
+    },
+    "invalid_dog_data": {
+      "title": "Incomplete dog details",
+      "description": "Some dogs are missing required information: {invalid_dogs}. Provide a name and ID for each of the {total_dogs} dogs."
+    },
+    "invalid_gps_configuration": {
+      "title": "GPS source missing",
+      "description": "GPS tracking is enabled for {gps_enabled_dogs} dog(s), but no GPS source is selected. Choose a GPS source in the options."
+    },
+    "missing_notification_config": {
+      "title": "Notification service unavailable",
+      "description": "The {missing_service} notification service is not available. {notification_enabled_dogs} dog(s) rely on this service."
+    },
+    "outdated_configuration": {
+      "title": "Update the configuration entry",
+      "description": "The configuration entry uses version {current_version}. Update it to version {required_version} through the options flow."
+    },
+    "performance_warning": {
+      "title": "Performance tuning recommended",
+      "description": "You configured {dog_count} dogs, which may affect performance. The recommended maximum is {recommended_max}."
+    },
+    "gps_update_interval_warning": {
+      "title": "GPS updates are too frequent",
+      "description": "The GPS update interval is {current_interval} seconds. Increase it to at least {recommended_interval} seconds to reduce load."
+    },
+    "storage_warning": {
+      "title": "Storage retention is too long",
+      "description": "Data retention is set to {current_retention} days. Reduce it to {recommended_max} days to keep the database lean."
+    },
+    "module_configuration_conflict": {
+      "title": "Too many intensive modules enabled",
+      "description": "{intensive_dogs} dog(s) use all intensive modules out of {total_dogs} configured. Disable some modules or enable performance mode."
+    },
+    "coordinator_error": {
+      "title": "Coordinator is unavailable",
+      "description": "Paw Control could not access its coordinator ({error}). Follow the suggested action or reload the integration."
+    }
   }
 }

--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -954,5 +954,51 @@
       "name": "Kot protokollieren",
       "description": "Protokolliert Kotgang-Informationen für Gesundheitsüberwachung"
     }
+  },
+  "issues": {
+    "missing_dog_configuration": {
+      "title": "Mindestens einen Hund hinzufügen",
+      "description": "Paw Control benötigt mindestens ein Hundeprofil. Bitte richte einen Hund ein. Konfigurierte Hunde: {dogs_count}."
+    },
+    "duplicate_dog_ids": {
+      "title": "Doppelte Hunde-IDs erkannt",
+      "description": "Folgende IDs werden mehrfach verwendet: {duplicate_ids}. Alle {total_dogs} Hunde benötigen eine eindeutige ID."
+    },
+    "invalid_dog_data": {
+      "title": "Unvollständige Hundedaten",
+      "description": "Für einige Hunde fehlen Pflichtangaben: {invalid_dogs}. Vergib für alle {total_dogs} Hunde einen Namen und eine ID."
+    },
+    "invalid_gps_configuration": {
+      "title": "GPS-Quelle fehlt",
+      "description": "Für {gps_enabled_dogs} Hund(e) ist GPS aktiviert, aber keine Quelle ausgewählt. Wähle eine GPS-Quelle in den Optionen."
+    },
+    "missing_notification_config": {
+      "title": "Benachrichtigungsdienst nicht verfügbar",
+      "description": "Der Benachrichtigungsdienst {missing_service} ist nicht verfügbar. {notification_enabled_dogs} Hund(e) sind darauf angewiesen."
+    },
+    "outdated_configuration": {
+      "title": "Konfigurationseintrag aktualisieren",
+      "description": "Der Konfigurationseintrag verwendet Version {current_version}. Aktualisiere ihn im Options-Dialog auf Version {required_version}."
+    },
+    "performance_warning": {
+      "title": "Leistungsoptimierung empfohlen",
+      "description": "Es sind {dog_count} Hunde konfiguriert, was die Leistung beeinträchtigen kann. Empfohlen sind höchstens {recommended_max}."
+    },
+    "gps_update_interval_warning": {
+      "title": "GPS-Aktualisierung zu häufig",
+      "description": "Das GPS-Aktualisierungsintervall beträgt {current_interval} Sekunden. Erhöhe es auf mindestens {recommended_interval} Sekunden, um die Last zu reduzieren."
+    },
+    "storage_warning": {
+      "title": "Speicheraufbewahrung zu lang",
+      "description": "Die Datenaufbewahrung ist auf {current_retention} Tage gesetzt. Reduziere sie auf {recommended_max} Tage, um die Datenbank schlank zu halten."
+    },
+    "module_configuration_conflict": {
+      "title": "Zu viele ressourcenintensive Module aktiv",
+      "description": "{intensive_dogs} Hund(e) nutzen alle ressourcenintensiven Module bei insgesamt {total_dogs} Hunden. Deaktiviere Module oder aktiviere den Performance-Modus."
+    },
+    "coordinator_error": {
+      "title": "Koordinator nicht verfügbar",
+      "description": "Paw Control konnte nicht auf den Koordinator zugreifen ({error}). Folge der empfohlenen Maßnahme oder lade die Integration neu."
+    }
   }
 }

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -954,5 +954,51 @@
       "name": "Log Poop",
       "description": "Logs bowel movement information for health monitoring"
     }
+  },
+  "issues": {
+    "missing_dog_configuration": {
+      "title": "Add at least one dog",
+      "description": "Paw Control needs at least one dog profile. Configure a dog to continue. Dogs configured: {dogs_count}."
+    },
+    "duplicate_dog_ids": {
+      "title": "Duplicate dog IDs detected",
+      "description": "The following IDs are used more than once: {duplicate_ids}. Each of the {total_dogs} dogs must have a unique ID."
+    },
+    "invalid_dog_data": {
+      "title": "Incomplete dog details",
+      "description": "Some dogs are missing required information: {invalid_dogs}. Provide a name and ID for each of the {total_dogs} dogs."
+    },
+    "invalid_gps_configuration": {
+      "title": "GPS source missing",
+      "description": "GPS tracking is enabled for {gps_enabled_dogs} dog(s), but no GPS source is selected. Choose a GPS source in the options."
+    },
+    "missing_notification_config": {
+      "title": "Notification service unavailable",
+      "description": "The {missing_service} notification service is not available. {notification_enabled_dogs} dog(s) rely on this service."
+    },
+    "outdated_configuration": {
+      "title": "Update the configuration entry",
+      "description": "The configuration entry uses version {current_version}. Update it to version {required_version} through the options flow."
+    },
+    "performance_warning": {
+      "title": "Performance tuning recommended",
+      "description": "You configured {dog_count} dogs, which may affect performance. The recommended maximum is {recommended_max}."
+    },
+    "gps_update_interval_warning": {
+      "title": "GPS updates are too frequent",
+      "description": "The GPS update interval is {current_interval} seconds. Increase it to at least {recommended_interval} seconds to reduce load."
+    },
+    "storage_warning": {
+      "title": "Storage retention is too long",
+      "description": "Data retention is set to {current_retention} days. Reduce it to {recommended_max} days to keep the database lean."
+    },
+    "module_configuration_conflict": {
+      "title": "Too many intensive modules enabled",
+      "description": "{intensive_dogs} dog(s) use all intensive modules out of {total_dogs} configured. Disable some modules or enable performance mode."
+    },
+    "coordinator_error": {
+      "title": "Coordinator is unavailable",
+      "description": "Paw Control could not access its coordinator ({error}). Follow the suggested action or reload the integration."
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add localized copy for each repair issue so the UI can surface descriptive text
- introduce a dedicated repair issue for overly frequent GPS updates and reuse the existing performance repair flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1784c59088331868f915dd4555b3d