### PR TITLE
Fix TypeErrors from union types in isinstance checks

### DIFF
--- a/custom_components/pawcontrol/coordinator_observability.py
+++ b/custom_components/pawcontrol/coordinator_observability.py
@@ -186,7 +186,7 @@ def normalise_webhook_status(manager: Any) -> dict[str, Any]:
     status.setdefault("hmac_ready", False)
     insecure = status.get("insecure_configs", ())
     if isinstance(insecure, Iterable) and not isinstance(
-        insecure, str | bytes | bytearray
+        insecure, (str, bytes, bytearray)
     ):
         status["insecure_configs"] = tuple(insecure)
     else:

--- a/custom_components/pawcontrol/feeding_manager.py
+++ b/custom_components/pawcontrol/feeding_manager.py
@@ -864,7 +864,9 @@ class FeedingManager:
             stripped_value = raw_value.strip()
             return [stripped_value] if stripped_value else []
 
-        if isinstance(raw_value, Iterable) and not isinstance(raw_value, bytes | str):
+        if isinstance(raw_value, Iterable) and not isinstance(
+            raw_value, (bytes, str)
+        ):
             normalized: list[str] = []
             for item in raw_value:
                 if not isinstance(item, str):

--- a/custom_components/pawcontrol/helper_manager.py
+++ b/custom_components/pawcontrol/helper_manager.py
@@ -142,7 +142,7 @@ class PawControlHelperManager:
                 normalized.append(cast(DogConfigData, dog_dict))
             return normalized
 
-        if isinstance(dogs, Sequence) and not isinstance(dogs, str | bytes):
+        if isinstance(dogs, Sequence) and not isinstance(dogs, (str, bytes)):
             for dog_config in dogs:
                 if not isinstance(dog_config, Mapping):
                     continue
@@ -167,7 +167,7 @@ class PawControlHelperManager:
                 if isinstance(module, str) and bool(enabled)
             )
 
-        if isinstance(modules, Sequence) and not isinstance(modules, str | bytes):
+        if isinstance(modules, Sequence) and not isinstance(modules, (str, bytes)):
             return frozenset(str(module) for module in modules)
 
         if isinstance(modules, str):

--- a/custom_components/pawcontrol/helpers.py
+++ b/custom_components/pawcontrol/helpers.py
@@ -214,7 +214,7 @@ class OptimizedDataCache:
             # Fallback estimate
             if isinstance(value, str):
                 return len(value) * 2  # Unicode chars
-            elif isinstance(value, list | tuple):
+            elif isinstance(value, (list, tuple)):
                 return len(value) * 100  # Rough estimate
             elif isinstance(value, dict):
                 return len(value) * 200  # Rough estimate
@@ -520,7 +520,7 @@ class PawControlDataStorage:
         """Count total entries in data structure."""
         count = 0
         for value in data.values():
-            if isinstance(value, list | dict):
+            if isinstance(value, (list, dict)):
                 count += len(value)
             else:
                 count += 1

--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -110,10 +110,10 @@ async def async_create_issue(
     def _serialise_issue_value(value: Any) -> str | int | float | None:
         """Serialise issue metadata to supported storage/placeholder values."""
 
-        if value is None or isinstance(value, str | int | float):
+        if value is None or isinstance(value, (str, int, float)):
             return value
 
-        if isinstance(value, list | tuple | set):
+        if isinstance(value, (list, tuple, set)):
             return ", ".join(str(item) for item in value)
 
         return str(value)

--- a/custom_components/pawcontrol/sensor.py
+++ b/custom_components/pawcontrol/sensor.py
@@ -141,7 +141,7 @@ def _copy_base_docstring(
             )
             return
 
-        if isinstance(attribute, classmethod | staticmethod):
+        if isinstance(attribute, (classmethod, staticmethod)):
             func = attribute.__func__
             if getattr(func, "__doc__", None):
                 return

--- a/custom_components/pawcontrol/utils.py
+++ b/custom_components/pawcontrol/utils.py
@@ -109,7 +109,7 @@ def _normalize_identifier_pair(
     if isinstance(identifier, tuple):
         candidate = identifier
     elif isinstance(identifier, Sequence) and not isinstance(
-        identifier, str | bytes | bytearray
+        identifier, (str, bytes, bytearray)
     ):
         candidate = tuple(identifier)
     else:


### PR DESCRIPTION
## Summary
- replace isinstance checks that used PEP 604 unions with tuple-based guards so they no longer raise at runtime
- update helper utilities to consistently normalise iterable values after the new guards

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1784c59088331868f915dd4555b3d