### PR TITLE
Fix repair issue severities to avoid unsupported logging

### DIFF
--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -313,7 +313,7 @@ async def _check_gps_configuration_issues(
                 "current_interval": update_interval,
                 "recommended_interval": 30,
             },
-            severity="info",
+            severity=ir.IssueSeverity.WARNING,
         )
 
 
@@ -373,7 +373,7 @@ async def _check_outdated_configuration(
                 "current_version": entry.version,
                 "required_version": 1,
             },
-            severity="info",
+            severity=ir.IssueSeverity.WARNING,
         )
 
 
@@ -398,7 +398,7 @@ async def _check_performance_issues(hass: HomeAssistant, entry: ConfigEntry) -> 
                 "recommended_max": 10,
                 "suggestion": "Consider performance mode optimization",
             },
-            severity="info",
+            severity=ir.IssueSeverity.WARNING,
         )
 
     # Check for conflicting module configurations
@@ -423,7 +423,7 @@ async def _check_performance_issues(hass: HomeAssistant, entry: ConfigEntry) -> 
                 "total_dogs": len(dogs),
                 "suggestion": "Consider selective module enabling",
             },
-            severity="info",
+            severity=ir.IssueSeverity.WARNING,
         )
 
 
@@ -448,7 +448,7 @@ async def _check_storage_issues(hass: HomeAssistant, entry: ConfigEntry) -> None
                 "recommended_max": 365,
                 "suggestion": "Consider reducing data retention period",
             },
-            severity="info",
+            severity=ir.IssueSeverity.WARNING,
         )
 
 


### PR DESCRIPTION
## Summary
- replace repair checks that used the unsupported "info" severity with IssueSeverity.WARNING so issues register without log noise

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17c1ea1748331982a92b16dd22ab3