### PR TITLE
Handle mobile app notify services in repair checks

### DIFF
--- a/custom_components/pawcontrol/repairs.py
+++ b/custom_components/pawcontrol/repairs.py
@@ -339,18 +339,35 @@ async def _check_notification_configuration_issues(
 
     # Check for mobile app availability
     mobile_enabled = notification_config.get("mobile_notifications", True)
-    if mobile_enabled and not hass.services.has_service("notify", "mobile_app"):
-        await async_create_issue(
-            hass,
-            entry,
-            f"{entry.entry_id}_mobile_app_missing",
-            ISSUE_MISSING_NOTIFICATIONS,
-            {
-                "missing_service": "mobile_app",
-                "notification_enabled_dogs": len(notification_enabled_dogs),
-            },
-            severity="warning",
-        )
+    if mobile_enabled:
+        has_mobile_app_service = hass.services.has_service("notify", "mobile_app")
+
+        if not has_mobile_app_service:
+            async_services = getattr(hass.services, "async_services", None)
+            if callable(async_services):
+                notify_services: Any
+                try:
+                    notify_services = async_services().get("notify", {})
+                except Exception:  # pragma: no cover - defensive fallback
+                    notify_services = {}
+
+                if isinstance(notify_services, dict):
+                    has_mobile_app_service = any(
+                        service.startswith("mobile_app") for service in notify_services
+                    )
+
+        if not has_mobile_app_service:
+            await async_create_issue(
+                hass,
+                entry,
+                f"{entry.entry_id}_mobile_app_missing",
+                ISSUE_MISSING_NOTIFICATIONS,
+                {
+                    "missing_service": "mobile_app",
+                    "notification_enabled_dogs": len(notification_enabled_dogs),
+                },
+                severity="warning",
+            )
 
 
 async def _check_outdated_configuration(

--- a/tests/test_repairs.py
+++ b/tests/test_repairs.py
@@ -284,3 +284,76 @@ def test_async_create_issue_preserves_iterable_metadata(
     assert placeholders["duplicate_ids"] == "dog_alpha, dog_bravo"
     assert "failed=2" in placeholders["metrics"]
     assert "total=5" in placeholders["metrics"]
+
+
+def test_async_check_for_issues_checks_coordinator_health(
+    repairs_module: tuple[ModuleType, AsyncMock, type[Any]],
+) -> None:
+    """Coordinator health should be validated when scanning for issues."""
+
+    module, create_issue_mock, _ = repairs_module
+
+    hass = SimpleNamespace()
+    hass.services = SimpleNamespace(has_service=lambda *args, **kwargs: True)
+
+    entry = SimpleNamespace(
+        entry_id="entry",
+        data={
+            module.CONF_DOGS: [
+                {
+                    module.CONF_DOG_ID: "dog_alpha",
+                    module.CONF_DOG_NAME: "Dog Alpha",
+                    "modules": {},
+                }
+            ]
+        },
+        options={},
+        version=1,
+    )
+
+    original_get_runtime_data = module.get_runtime_data
+    module.get_runtime_data = lambda _hass, _entry: None
+
+    try:
+        asyncio.run(module.async_check_for_issues(hass, entry))
+    finally:
+        module.get_runtime_data = original_get_runtime_data
+
+    assert create_issue_mock.await_count == 1
+    kwargs = create_issue_mock.await_args.kwargs
+    assert kwargs["translation_key"] == module.ISSUE_COORDINATOR_ERROR
+    assert kwargs["data"]["error"] == "coordinator_not_initialized"
+
+
+def test_notification_check_accepts_mobile_app_service_prefix(
+    repairs_module: tuple[ModuleType, AsyncMock, type[Any]],
+) -> None:
+    """Notification checks should detect mobile_app_* notify services."""
+
+    module, create_issue_mock, _ = repairs_module
+
+    hass = SimpleNamespace()
+
+    hass.services = SimpleNamespace(
+        has_service=lambda domain, service: False,
+        async_services=lambda: {"notify": {"mobile_app_jane": object()}},
+    )
+
+    entry = SimpleNamespace(
+        entry_id="entry",
+        data={
+            module.CONF_DOGS: [
+                {
+                    module.CONF_DOG_ID: "dog_alpha",
+                    module.CONF_DOG_NAME: "Dog Alpha",
+                    "modules": {module.MODULE_NOTIFICATIONS: True},
+                }
+            ]
+        },
+        options={"notifications": {"mobile_notifications": True}},
+        version=1,
+    )
+
+    asyncio.run(module._check_notification_configuration_issues(hass, entry))
+
+    assert create_issue_mock.await_count == 0


### PR DESCRIPTION
## Summary
- ensure the notification repair logic treats mobile_app-prefixed notify services as valid mobile push targets
- exercise the coordinator health scan and the updated notification detection with focused unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e17c1ea1748331982a92b16dd22ab3