### PR TITLE
Remove defusedxml dependency from GPX exporter

### DIFF
--- a/custom_components/pawcontrol/manifest.json
+++ b/custom_components/pawcontrol/manifest.json
@@ -48,8 +48,7 @@
   ],
   "quality_scale": "platinum",
   "requirements": [
-    "aiofiles>=23.1.0",
-    "defusedxml>=0.7.1"
+    "aiofiles>=23.1.0"
   ],
   "usb": [
     {

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -19,9 +19,9 @@ from collections import deque
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import StrEnum
+from html import escape
 from typing import Any
 
-from html import escape
 from homeassistant.util import dt as dt_util
 
 from .utils import is_number

--- a/custom_components/pawcontrol/walk_manager.py
+++ b/custom_components/pawcontrol/walk_manager.py
@@ -21,7 +21,7 @@ from datetime import datetime, timedelta
 from enum import StrEnum
 from typing import Any
 
-from defusedxml.sax.saxutils import escape
+from html import escape
 from homeassistant.util import dt as dt_util
 
 from .utils import is_number
@@ -1610,7 +1610,8 @@ class WalkManager:
         """Generate GPX 1.1 compliant data with full metadata."""
 
         def _escape(value: str) -> str:
-            return escape(value, {'"': "&quot;", "'": "&apos;"})
+            escaped = escape(value, quote=True)
+            return escaped.replace("&#x27;", "&apos;")
 
         def _format_attrs(attrs: dict[str, Any]) -> str:
             parts: list[str] = []

--- a/docs/async_dependency_audit.md
+++ b/docs/async_dependency_audit.md
@@ -6,9 +6,9 @@ the mitigations in place to keep the Home Assistant event loop responsive.
 ## Third-party libraries with synchronous behaviour
 
 - **Async GPX builder** – the walk manager now renders GPX exports through a
-  dedicated XML serializer that escapes metadata inline, eliminating the
-  previous `defusedxml` dependency from the runtime manifest and top-level
-  requirements.【F:custom_components/pawcontrol/walk_manager.py†L1395-L1560】【F:custom_components/pawcontrol/manifest.json†L1-L60】【F:requirements.txt†L1-L3】
+  dedicated XML serializer that escapes metadata inline with Python's
+  standard-library helpers, eliminating the previous `defusedxml` dependency
+  from the runtime manifest and top-level requirements.【F:custom_components/pawcontrol/walk_manager.py†L1395-L1560】【F:custom_components/pawcontrol/manifest.json†L1-L60】【F:requirements.txt†L1-L3】
 - **Synchronous dependency cleanup** – unused libraries (`requests`,
   `urllib3`, `pyserial`, `cryptography`, `uv`, `aiodhcpwatcher`,
   `aiodiscover`, `aiousbwatcher`, `asyncio-mqtt`, `Jinja2`) have been pruned

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 aiofiles>=23.1.0
 aiohttp>=3.12.14
-defusedxml>=0.7.1
 voluptuous>=0.14.0


### PR DESCRIPTION
## Summary
- switch the GPX export serializer to Python's built-in escaping helpers
- drop the defusedxml requirement from the integration manifest and repo requirements
- refresh the async dependency audit to mention the new approach

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e1815011648331bb25ca9556c9b413