### PR TITLE
Remove unsupported repairs translation keys

### DIFF
--- a/custom_components/pawcontrol/translations/de.json
+++ b/custom_components/pawcontrol/translations/de.json
@@ -1000,10 +1000,5 @@
       "title": "Koordinator nicht verfügbar",
       "description": "Paw Control konnte nicht auf den Koordinator zugreifen ({error}). Folge der empfohlenen Maßnahme oder lade die Integration neu."
     }
-  },
-  "repairs": {
-    "errors": {
-      "reload_failed": "Neuladen fehlgeschlagen. Prüfe die Protokolle und versuche es erneut."
-    }
   }
 }

--- a/custom_components/pawcontrol/translations/en.json
+++ b/custom_components/pawcontrol/translations/en.json
@@ -1000,10 +1000,5 @@
       "title": "Coordinator is unavailable",
       "description": "Paw Control could not access its coordinator ({error}). Follow the suggested action or reload the integration."
     }
-  },
-  "repairs": {
-    "errors": {
-      "reload_failed": "Reload failed. Check the logs and try again."
-    }
   }
 }


### PR DESCRIPTION
## Summary
- remove the unsupported `repairs` translation section from the English and German resources so the schema validator passes

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e183a79da08331aba46489f9bb6432