### PR TITLE
Fix diagnostics redaction to avoid false positives

### DIFF
--- a/custom_components/pawcontrol/diagnostics.py
+++ b/custom_components/pawcontrol/diagnostics.py
@@ -611,4 +611,3 @@ def _redact_sensitive_data(data: Any) -> Any:
     """Recursively redact sensitive data from diagnostic information."""
 
     return redact_sensitive_data(data, patterns=_REDACTED_KEY_PATTERNS)
-

--- a/custom_components/pawcontrol/diagnostics.py
+++ b/custom_components/pawcontrol/diagnostics.py
@@ -31,6 +31,7 @@ from .const import (
     MODULE_WALK,
 )
 from .coordinator import PawControlCoordinator
+from .diagnostics_redaction import compile_redaction_patterns, redact_sensitive_data
 from .runtime_data import get_runtime_data
 from .types import PawControlConfigEntry, PawControlRuntimeData
 
@@ -56,6 +57,8 @@ REDACTED_KEYS = {
     CONF_API_ENDPOINT,
     CONF_API_TOKEN,
 }
+
+_REDACTED_KEY_PATTERNS = compile_redaction_patterns(REDACTED_KEYS)
 
 
 async def async_get_config_entry_diagnostics(
@@ -605,59 +608,7 @@ def _calculate_module_usage(dogs: list[dict[str, Any]]) -> dict[str, Any]:
 
 
 def _redact_sensitive_data(data: Any) -> Any:
-    """Recursively redact sensitive data from diagnostic information.
+    """Recursively redact sensitive data from diagnostic information."""
 
-    Args:
-        data: Data to redact
+    return redact_sensitive_data(data, patterns=_REDACTED_KEY_PATTERNS)
 
-    Returns:
-        Data with sensitive information redacted
-    """
-    if isinstance(data, dict):
-        redacted = {}
-        for key, value in data.items():
-            # Check if key contains sensitive information
-            key_lower = key.lower()
-            is_sensitive = any(sensitive in key_lower for sensitive in REDACTED_KEYS)
-
-            if is_sensitive:
-                redacted[key] = "**REDACTED**"
-            else:
-                redacted[key] = _redact_sensitive_data(value)
-        return redacted
-
-    elif isinstance(data, list):
-        return [_redact_sensitive_data(item) for item in data]
-
-    elif isinstance(data, str):
-        # Check for patterns that look like sensitive data
-        if _looks_like_sensitive_string(data):
-            return "**REDACTED**"
-        return data
-
-    else:
-        return data
-
-
-def _looks_like_sensitive_string(value: str) -> bool:
-    """Check if a string looks like sensitive data.
-
-    Args:
-        value: String to check
-
-    Returns:
-        True if string appears to contain sensitive data
-    """
-    # Check for common sensitive patterns
-    sensitive_patterns = [
-        # UUID
-        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
-        r"\b[A-Za-z0-9]{20,}\b",  # Long alphanumeric strings (tokens)
-        r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",  # IP addresses
-        # Email addresses
-        r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
-    ]
-
-    import re
-
-    return any(re.search(pattern, value) for pattern in sensitive_patterns)

--- a/custom_components/pawcontrol/diagnostics_redaction.py
+++ b/custom_components/pawcontrol/diagnostics_redaction.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Iterable
+from collections.abc import Iterable
+from typing import Any
 
 __all__ = [
     "compile_redaction_patterns",
@@ -21,9 +22,7 @@ def compile_redaction_patterns(keys: Iterable[str]) -> tuple[re.Pattern[str], ..
     )
 
 
-def redact_sensitive_data(
-    data: Any, *, patterns: tuple[re.Pattern[str], ...]
-) -> Any:
+def redact_sensitive_data(data: Any, *, patterns: tuple[re.Pattern[str], ...]) -> Any:
     """Recursively redact sensitive data using precompiled ``patterns``."""
 
     if isinstance(data, dict):

--- a/custom_components/pawcontrol/diagnostics_redaction.py
+++ b/custom_components/pawcontrol/diagnostics_redaction.py
@@ -1,0 +1,60 @@
+"""Helpers for redacting sensitive diagnostics information."""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Iterable
+
+__all__ = [
+    "compile_redaction_patterns",
+    "redact_sensitive_data",
+]
+
+
+def compile_redaction_patterns(keys: Iterable[str]) -> tuple[re.Pattern[str], ...]:
+    """Return compiled regex patterns for ``keys`` respecting word boundaries."""
+
+    normalized = {key.lower() for key in keys}
+    return tuple(
+        re.compile(rf"(?:^|[^a-z0-9]){re.escape(key)}(?:$|[^a-z0-9])")
+        for key in sorted(normalized)
+    )
+
+
+def redact_sensitive_data(
+    data: Any, *, patterns: tuple[re.Pattern[str], ...]
+) -> Any:
+    """Recursively redact sensitive data using precompiled ``patterns``."""
+
+    if isinstance(data, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in data.items():
+            key_lower = key.lower()
+            if any(pattern.search(key_lower) for pattern in patterns):
+                redacted[key] = "**REDACTED**"
+            else:
+                redacted[key] = redact_sensitive_data(value, patterns=patterns)
+        return redacted
+
+    if isinstance(data, list):
+        return [redact_sensitive_data(item, patterns=patterns) for item in data]
+
+    if isinstance(data, str):
+        if _looks_like_sensitive_string(data):
+            return "**REDACTED**"
+        return data
+
+    return data
+
+
+def _looks_like_sensitive_string(value: str) -> bool:
+    """Return True if ``value`` appears to contain sensitive information."""
+
+    sensitive_patterns = [
+        r"\b[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\b",
+        r"\b[A-Za-z0-9]{20,}\b",
+        r"\b\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}\b",
+        r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b",
+    ]
+
+    return any(re.search(pattern, value) for pattern in sensitive_patterns)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,46 @@
+"""Unit tests for diagnostics redaction helpers."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load module {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_redaction_helpers():
+    return _load_module(
+        "pawcontrol_diagnostics_redaction",
+        PROJECT_ROOT / "custom_components" / "pawcontrol" / "diagnostics_redaction.py",
+    )
+
+
+def test_redact_sensitive_keys_respects_word_boundaries() -> None:
+    """Ensure redaction matches keys at boundaries without over-redacting."""
+
+    module = _load_redaction_helpers()
+    patterns = module.compile_redaction_patterns({"location", "api_key"})
+    payload = {
+        "allocation": "keep",
+        "home_location": "secret",
+        "stats": {"gps_location": "secret", "api_key": "token"},
+    }
+
+    redacted = module.redact_sensitive_data(payload, patterns=patterns)
+
+    assert redacted["allocation"] == "keep"
+    assert redacted["home_location"] == "**REDACTED**"
+    assert redacted["stats"]["gps_location"] == "**REDACTED**"
+    assert redacted["stats"]["api_key"] == "**REDACTED**"


### PR DESCRIPTION
## Summary
- ensure diagnostics redaction uses boundary-aware patterns to avoid accidental removal of non-sensitive keys
- extract reusable redaction helper module shared by diagnostics
- add regression test covering key boundary handling for redaction helpers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e181587a708331bb762435b5b8e588