### PR TITLE
Ensure ConfigEntryNotReady bases remain known setup errors

### DIFF
--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -465,7 +465,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
             if cls not in not_ready_hierarchy:
                 not_ready_hierarchy.append(cls)
     compat_not_ready = getattr(compat, "ConfigEntryNotReady", None)
-    if isinstance(compat_not_ready, type) and issubclass(compat_not_ready, BaseException):
+    if isinstance(compat_not_ready, type) and issubclass(
+        compat_not_ready, BaseException
+    ):
         if compat_not_ready not in not_ready_hierarchy:
             not_ready_hierarchy.append(compat_not_ready)
 

--- a/custom_components/pawcontrol/__init__.py
+++ b/custom_components/pawcontrol/__init__.py
@@ -455,8 +455,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: PawControlConfigEntry) -
     disable_logging = False
 
     not_ready_cls = _resolve_config_entry_not_ready()
+    not_ready_hierarchy: list[type[BaseException]] = []
+    if isinstance(not_ready_cls, type) and issubclass(not_ready_cls, BaseException):
+        for cls in not_ready_cls.__mro__:
+            if not isinstance(cls, type) or not issubclass(cls, BaseException):
+                continue
+            if cls in (BaseException, Exception):
+                continue
+            if cls not in not_ready_hierarchy:
+                not_ready_hierarchy.append(cls)
+    compat_not_ready = getattr(compat, "ConfigEntryNotReady", None)
+    if isinstance(compat_not_ready, type) and issubclass(compat_not_ready, BaseException):
+        if compat_not_ready not in not_ready_hierarchy:
+            not_ready_hierarchy.append(compat_not_ready)
+
     known_setup_errors: tuple[type[BaseException], ...] = (
-        not_ready_cls,
+        *not_ready_hierarchy,
         compat.ConfigEntryAuthFailed,
         PawControlSetupError,
     )


### PR DESCRIPTION
## Summary
- expand the ConfigEntryNotReady hierarchy captured during setup so Home Assistant retry signals continue to propagate

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e55cd06d308331b1a3dfa0bbcdd897