### PR TITLE
Add docstrings for entity registry lifecycle helpers

### DIFF
--- a/custom_components/pawcontrol/optimized_entity_base.py
+++ b/custom_components/pawcontrol/optimized_entity_base.py
@@ -1229,6 +1229,8 @@ class EntityRegistry:
     __slots__ = ("_refs", "_sentinel")
 
     def __init__(self) -> None:
+        """Initialize an empty registry without any tracked entities."""
+
         self._refs: set[weakref.ReferenceType[OptimizedEntityBase]] = set()
         self._sentinel: weakref.ReferenceType[OptimizedEntityBase] | None = None
 
@@ -1241,6 +1243,8 @@ class EntityRegistry:
         return self._sentinel is not None and self._sentinel() is not None
 
     def _prune_dead_refs(self) -> None:
+        """Remove dead references and drop the sentinel if it is gone."""
+
         if self._refs:
             gc.collect()
         for reference in tuple(self._refs):
@@ -1249,20 +1253,30 @@ class EntityRegistry:
                 self._refs.discard(reference)
 
     def add(self, reference: weakref.ReferenceType[OptimizedEntityBase]) -> None:
+        """Track a new entity reference inside the registry."""
+
         self._refs.add(reference)
 
     def discard(self, reference: weakref.ReferenceType[OptimizedEntityBase]) -> None:
+        """Stop tracking a specific entity reference."""
+
         self._refs.discard(reference)
 
     def __iter__(self) -> Iterator[weakref.ReferenceType[OptimizedEntityBase]]:
+        """Iterate over live references after pruning stale entries."""
+
         self._prune_dead_refs()
         yield from tuple(self._refs)
 
     def __len__(self) -> int:
+        """Return the number of live references currently tracked."""
+
         self._prune_dead_refs()
         return len(self._refs)
 
     def __bool__(self) -> bool:
+        """Return True when at least one live reference or sentinel remains."""
+
         return bool(self._refs) or self._sentinel_alive()
 
     def all_refs(self) -> tuple[weakref.ReferenceType[OptimizedEntityBase], ...]:

--- a/dev.md
+++ b/dev.md
@@ -11,3 +11,4 @@
 
 ## Recently Addressed
 - Reworked the global entity registry to register entities exactly once and keep the sentinel alive through cleanup, so `test_cleanup_preserves_live_entities` now survives full-suite garbage collection without duplicating weakrefs. 【F:custom_components/pawcontrol/optimized_entity_base.py†L1306-L1399】
+- Documented the entity registry lifecycle helpers to satisfy the docstring baseline and keep the public API discoverable for Home Assistant reviewers. 【F:custom_components/pawcontrol/optimized_entity_base.py†L1227-L1260】


### PR DESCRIPTION
## Summary
- document the entity registry initialization, pruning, and lifecycle helpers to satisfy the docstring baseline
- record the docstring remediation in the development log for future reviewers

## Testing
- `ruff check`


------
https://chatgpt.com/codex/tasks/task_e_68e66c1c8c4083318a0968d141c7d67d