### PR TITLE
Increase coverage for error classification branches

### DIFF
--- a/tests/test_error_classification_reload.py
+++ b/tests/test_error_classification_reload.py
@@ -1,12 +1,14 @@
-"""Tests for verifying error classification module reload behavior.
-
-This test ensures top-level constants and helper definitions are re-executed
-when the module is reloaded.
-"""
+"""Tests for verifying error classification behavior and module reloads."""
 
 import importlib
 
+import pytest
+
 from custom_components.pawcontrol import error_classification
+
+
+class _CustomError(Exception):
+    """Custom error used to exercise Exception normalization."""
 
 
 def test_error_classification_module_reload_executes_top_level() -> None:
@@ -22,4 +24,54 @@ def test_error_classification_module_reload_executes_top_level() -> None:
     )
     assert error_classification.classify_error_reason(None, error="Timed out") == (
         "timeout"
+    )
+
+
+@pytest.mark.parametrize(
+    ("reason", "error", "expected"),
+    [
+        pytest.param(
+            "missing_services_api", None, "missing_service", id="mapped-reason"
+        ),
+        pytest.param(
+            "AUTHENTICATION_ERROR", None, "auth_error", id="mapped-reason-normalized"
+        ),
+        pytest.param(None, "forbidden by policy", "auth_error", id="auth-hint"),
+        pytest.param(None, "host is down", "device_unreachable", id="unreachable-hint"),
+        pytest.param(None, "Deadline exceeded", "timeout", id="timeout-hint"),
+        pytest.param(
+            None, "429 too many requests", "rate_limited", id="rate-limit-hint"
+        ),
+        pytest.param("exception", "", "exception", id="explicit-exception"),
+        pytest.param(None, None, "unknown", id="unknown-default"),
+    ],
+)
+def test_classify_error_reason_branches(
+    reason: str | None,
+    error: Exception | str | None,
+    expected: str,
+) -> None:
+    """Classifier should route reasons and message hints to stable categories."""
+    assert error_classification.classify_error_reason(reason, error=error) == expected
+
+
+def test_classify_error_reason_prefers_reason_mapping_over_error_hints() -> None:
+    """An explicit mapped reason should win over unrelated error hint text."""
+    assert (
+        error_classification.classify_error_reason(
+            "service_unavailable",
+            error="token expired",
+        )
+        == "missing_service"
+    )
+
+
+def test_classify_error_reason_normalizes_exception_objects() -> None:
+    """Exception instances should be stringified and normalized before matching."""
+    assert (
+        error_classification.classify_error_reason(
+            None,
+            error=_CustomError(" Connection Reset by peer "),
+        )
+        == "device_unreachable"
     )


### PR DESCRIPTION
### Motivation

- Improve branch coverage for the `error_classification` helpers so runtime telemetry decisions are reliably categorized.  
- Ensure `classify_error_reason` handles mapped reason strings, free-form error messages, and `Exception` instances consistently.  
- Add focused regression tests to lock in precedence rules and normalization behavior used by telemetry aggregation.

### Description

- Expanded `tests/test_error_classification_reload.py` with a parametrized matrix covering mapped reasons, normalized inputs, auth/unreachable/timeout/rate-limit hints, explicit `"exception"` handling, and the `unknown` fallback.  
- Added a `_CustomError` class and two targeted tests asserting precedence of explicit reason mapping over error hints and normalization of `Exception` objects.  
- Applied `ruff format` style fixes to the updated test file.

### Testing

- Ran the branch-focused test with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/test_error_classification_reload.py`, which passed (`11 passed`).  
- Ran `ruff format tests/test_error_classification_reload.py` and `ruff check tests/test_error_classification_reload.py` to enforce formatting and lint rules, both succeeding after the format step.  
- The change is intentionally scoped to tests for a single module to satisfy the coverage-package execution protocol and make reviewable, focused verification straightforward.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7be8ec9388331a2386cab601e3ec9)