### PR TITLE
Add unit tests to increase PawControlDataManager coverage

### DIFF
--- a/tests/unit/test_data_manager_additional_coverage.py
+++ b/tests/unit/test_data_manager_additional_coverage.py
@@ -1,0 +1,102 @@
+"""Additional branch coverage for data_manager cache/report helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.pawcontrol.data_manager import PawControlDataManager
+
+
+@pytest.mark.unit
+def test_cache_repair_summary_collects_errors_and_normalizes_values() -> None:
+    """Cache repair summaries should normalize numeric text and anomaly payloads."""
+    manager = object.__new__(PawControlDataManager)
+
+    summary = manager.cache_repair_summary({
+        "": {"stats": {"entries": 99}},  # ignored empty cache name
+        "feeding": {
+            "stats": {
+                "entries": "4",
+                "hits": "2",
+                "misses": "3",
+            },
+            "diagnostics": {
+                "expired_entries": "2",
+                "pending_expired_entries": "1",
+                "active_override_flags": "1",
+                "errors": "cache read timeout",
+                "timestamp_anomalies": {"buddy": "clock skew"},
+            },
+        },
+    })
+
+    assert summary is not None
+    assert summary.severity == "error"
+    assert summary.total_caches == 2
+    assert summary.anomaly_count == 1
+    assert summary.totals.entries == 4
+    assert summary.totals.hits == 2
+    assert summary.totals.misses == 3
+    assert summary.totals.expired_entries == 2
+    assert summary.caches_with_errors == ["feeding"]
+    assert summary.issues is not None
+    assert summary.issues[0]["timestamp_anomalies"] == {"buddy": "clock skew"}
+    assert summary.issues[0]["errors"] == ["cache read timeout"]
+
+
+@pytest.mark.unit
+def test_cache_repair_summary_derives_hit_rate_when_missing() -> None:
+    """Summaries should derive low hit-rate anomalies from hits/misses counts."""
+    manager = object.__new__(PawControlDataManager)
+
+    summary = manager.cache_repair_summary({
+        "health": {
+            "stats": {
+                "entries": 5,
+                "hits": 1,
+                "misses": 4,
+            },
+            "diagnostics": {},
+        }
+    })
+
+    assert summary is not None
+    assert summary.severity == "warning"
+    assert summary.caches_with_low_hit_rate == ["health"]
+    assert summary.caches_with_errors is None
+    assert summary.totals.overall_hit_rate == 20.0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_get_module_history_filters_sorts_and_limits() -> None:
+    """History retrieval should filter by bounds and sort newest-first."""
+    manager = object.__new__(PawControlDataManager)
+
+    now = datetime.now(UTC)
+    manager._dog_profiles = {
+        "buddy": SimpleNamespace(
+            health_history=[
+                {"timestamp": (now - timedelta(days=2)).isoformat(), "weight": 10},
+                {"timestamp": (now - timedelta(hours=2)).isoformat(), "weight": 11},
+                {"timestamp": "not-a-date", "weight": 12},
+                123,
+            ]
+        )
+    }
+
+    result = await manager.async_get_module_history(
+        "health",
+        "buddy",
+        since=now - timedelta(days=1),
+        limit=1,
+    )
+
+    assert len(result) == 1
+    assert result[0]["weight"] == 11
+
+    assert await manager.async_get_module_history("unknown", "buddy") == []
+    assert await manager.async_get_module_history("health", "missing") == []


### PR DESCRIPTION
### Motivation
- Close a coverage hotspot by adding focused unit tests for the data manager module identified in the coverage backlog. 
- Exercise normalization, anomaly detection, and history filtering branches in `PawControlDataManager` without changing runtime code.

### Description
- Add a new test module `tests/unit/test_data_manager_additional_coverage.py` that targets `PawControlDataManager` behavior. 
- Cover `cache_repair_summary` normalization and anomaly extraction including numeric-string inputs and `timestamp_anomalies`. 
- Cover derived low-hit-rate detection when explicit `hit_rate` is missing. 
- Cover `async_get_module_history` filtering, sorting (newest-first), limiting, and guard paths for unknown modules and missing dog profiles.

### Testing
- Ran formatting and lint checks with `ruff format tests/unit/test_data_manager_additional_coverage.py` and `ruff check tests/unit/test_data_manager_additional_coverage.py`, which passed. 
- Executed the new unit tests with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_data_manager_additional_coverage.py -q -n 0 --dist no -p xdist.plugin -p pytest_cov.plugin`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bea1987c83319d66c982ccdaf4d3)