### PR TITLE
Add targeted validation tests to increase branch coverage

### DIFF
--- a/hypothesis/__init__.py
+++ b/hypothesis/__init__.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 
 class HealthCheck:
@@ -12,13 +13,13 @@ class HealthCheck:
 
 
 class _Strategy:
-    def __or__(self, _other: object) -> "_Strategy":
+    def __or__(self, _other: object) -> _Strategy:
         return self
 
-    def map(self, _func: Callable[[Any], Any]) -> "_Strategy":
+    def map(self, _func: Callable[[Any], Any]) -> _Strategy:
         return self
 
-    def filter(self, _func: Callable[[Any], bool]) -> "_Strategy":
+    def filter(self, _func: Callable[[Any], bool]) -> _Strategy:
         return self
 
 

--- a/tests/components/pawcontrol/test_validation_hotspot_package11.py
+++ b/tests/components/pawcontrol/test_validation_hotspot_package11.py
@@ -1,0 +1,194 @@
+"""Targeted branch coverage for validation helper edge paths."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.pawcontrol.exceptions import ValidationError
+from custom_components.pawcontrol.validation import (
+    clamp_float_range,
+    clamp_int_range,
+    validate_entity_id,
+    validate_gps_source,
+    validate_interval,
+    validate_notify_service,
+    validate_sensor_entity_id,
+)
+
+
+def _build_hass(
+    *,
+    states: dict[str, object] | None = None,
+    notify_services: dict[str, object] | None = None,
+) -> SimpleNamespace:
+    """Create a small Home Assistant stub for validation tests."""
+    return SimpleNamespace(
+        states=SimpleNamespace(get=lambda entity_id: (states or {}).get(entity_id)),
+        services=SimpleNamespace(
+            async_services=lambda: {"notify": notify_services or {}}
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    ("entity_id", "expected"),
+    [
+        ("sensor.garden_temp", "sensor.garden_temp"),
+        ("  binary_sensor.door  ", "binary_sensor.door"),
+    ],
+)
+def test_validate_entity_id_accepts_valid_values(entity_id: str, expected: str) -> None:
+    """Entity IDs should be normalized for valid domain/object pairs."""
+    assert validate_entity_id(entity_id) == expected
+
+
+@pytest.mark.parametrize(
+    "entity_id",
+    [
+        42,
+        "sensor",
+        "sensor.",
+        ".garden",
+        "Sensor.garden",
+        "sensor.garden-temp",
+    ],
+)
+def test_validate_entity_id_rejects_invalid_values(entity_id: object) -> None:
+    """Entity IDs outside domain.object format should fail validation."""
+    with pytest.raises(ValidationError, match="Invalid entity_id format"):
+        validate_entity_id(entity_id)
+
+
+def test_validate_gps_source_checks_missing_and_unavailable_states() -> None:
+    """GPS source should reject missing entities and unavailable states."""
+    hass = _build_hass(
+        states={
+            "device_tracker.available": SimpleNamespace(state="home"),
+            "device_tracker.unavailable": SimpleNamespace(state="unavailable"),
+        }
+    )
+
+    assert validate_gps_source(hass, "manual") == "manual"
+    assert validate_gps_source(hass, "webhook") == "webhook"
+    assert (
+        validate_gps_source(hass, "device_tracker.available")
+        == "device_tracker.available"
+    )
+
+    with pytest.raises(ValidationError, match="gps_source_not_found"):
+        validate_gps_source(hass, "device_tracker.missing")
+
+    with pytest.raises(ValidationError, match="gps_source_unavailable"):
+        validate_gps_source(hass, "device_tracker.unavailable")
+
+
+@pytest.mark.parametrize(
+    ("notify_service", "message"),
+    [
+        ("notify", "notify_service_invalid"),
+        ("light.kitchen", "notify_service_invalid"),
+        ("notify.mobile_missing", "notify_service_not_found"),
+    ],
+)
+def test_validate_notify_service_rejects_invalid_targets(
+    notify_service: object,
+    message: str,
+) -> None:
+    """Notify service validator should reject invalid format and unknown targets."""
+    hass = _build_hass(notify_services={"mobile_app": object()})
+
+    with pytest.raises(ValidationError, match=message):
+        validate_notify_service(hass, notify_service)
+
+
+@pytest.mark.parametrize(
+    ("value", "kwargs", "expected"),
+    [
+        (None, {"minimum": 5, "maximum": 20, "clamp": True}, 5),
+        (None, {"minimum": 5, "maximum": 20, "default": 11}, 11),
+        (3, {"minimum": 5, "maximum": 20, "clamp": True}, 5),
+        (30, {"minimum": 5, "maximum": 20, "clamp": True}, 20),
+        (12, {"minimum": 5, "maximum": 20}, 12),
+    ],
+)
+def test_validate_interval_clamp_and_default_branches(
+    value: object,
+    kwargs: dict[str, object],
+    expected: int,
+) -> None:
+    """Interval validator should support defaulting and clamp branches."""
+    assert validate_interval(value, field="interval", **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "minimum", "maximum", "default", "expected"),
+    [
+        ("bad", 1, 10, 4, 4),
+        (50, 1, 10, 4, 10),
+        (-2, -1.5, 2.0, 0.5, -1.5),
+    ],
+)
+def test_clamp_ranges_return_default_or_bounds(
+    value: object,
+    minimum: int | float,
+    maximum: int | float,
+    default: int | float,
+    expected: int | float,
+) -> None:
+    """Clamp helpers should handle coercion failures and bound violations."""
+    if isinstance(default, int):
+        assert (
+            clamp_int_range(
+                value,
+                field="interval",
+                minimum=int(minimum),
+                maximum=int(maximum),
+                default=default,
+            )
+            == expected
+        )
+    else:
+        assert (
+            clamp_float_range(
+                value,
+                field="ratio",
+                minimum=float(minimum),
+                maximum=float(maximum),
+                default=float(default),
+            )
+            == expected
+        )
+
+
+def test_validate_sensor_entity_id_checks_domain_and_device_class() -> None:
+    """Sensor entity validation should enforce domain and class constraints."""
+    state = SimpleNamespace(state="on", attributes={"device_class": "motion"})
+    hass = _build_hass(states={"binary_sensor.door": state})
+
+    assert (
+        validate_sensor_entity_id(
+            hass,
+            "binary_sensor.door",
+            field="door_sensor",
+            domain="binary_sensor",
+            device_classes={"motion", "door"},
+            required=True,
+        )
+        == "binary_sensor.door"
+    )
+
+    with pytest.raises(ValidationError, match="sensor_not_found"):
+        validate_sensor_entity_id(
+            hass,
+            "sensor.door",
+            field="door_sensor",
+            domain="binary_sensor",
+        )
+
+    with pytest.raises(ValidationError, match="sensor_not_found"):
+        validate_sensor_entity_id(
+            hass,
+            "binary_sensor.door",
+            field="door_sensor",
+            device_classes={"humidity"},
+        )

--- a/tests/unit/critical_modules/config_flow/test_exports.py
+++ b/tests/unit/critical_modules/config_flow/test_exports.py
@@ -8,7 +8,6 @@ import pytest
 
 from custom_components.pawcontrol import config_flow, config_flow_main
 
-
 # Validation cluster
 
 

--- a/tests/unit/critical_modules/coordinator/test_error_paths.py
+++ b/tests/unit/critical_modules/coordinator/test_error_paths.py
@@ -17,7 +17,6 @@ from custom_components.pawcontrol.exceptions import (
     ValidationError,
 )
 
-
 # Validation cluster
 
 

--- a/voluptuous/__init__.py
+++ b/voluptuous/__init__.py
@@ -105,7 +105,7 @@ class Schema:
     def __call__(self, value: Any) -> Any:
         return value
 
-    def extend(self, schema: Mapping[Any, Any]) -> "Schema":
+    def extend(self, schema: Mapping[Any, Any]) -> Schema:
         if isinstance(self.schema, Mapping):
             merged = dict(self.schema)
             merged.update(schema)

--- a/yarl.py
+++ b/yarl.py
@@ -20,7 +20,7 @@ class URL:
     def host(self) -> str | None:
         return urlparse(self.raw).hostname
 
-    def join(self, other: "URL") -> "URL":
+    def join(self, other: URL) -> URL:
         return URL(urljoin(self.raw.rstrip("/") + "/", other.raw.lstrip("/")))
 
     def __str__(self) -> str:


### PR DESCRIPTION
### Motivation
- Close coverage gaps in validation helpers prioritized in the hotspot backlog (package 11) by exercising missing branches and error paths. 
- Provide deterministic unit tests that avoid heavy test plugin interactions so CI branch-level coverage can be validated quickly.

### Description
- Added a new test module `tests/components/pawcontrol/test_validation_hotspot_package11.py` containing focused validators tests and a small `hass` stub helper. 
- The suite exercises `validate_entity_id` success and malformed cases, `validate_gps_source` success/missing/unavailable paths, `validate_notify_service` invalid/unknown targets, `validate_interval` defaulting and clamp branches, `clamp_int_range`/`clamp_float_range` fallback and bounds, and `validate_sensor_entity_id` domain/device-class branches. 
- Tests are written to be deterministic and small in scope to align with the repository coverage packaging protocol.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/components/pawcontrol/test_validation_hotspot_package11.py` which completed with `21 passed`.
- Ran `ruff format tests/components/pawcontrol/test_validation_hotspot_package11.py` and `ruff check tests/components/pawcontrol/test_validation_hotspot_package11.py`, both succeeded.
- The targeted execution avoids unrelated test plugin import failures by disabling plugin autoload during this focused run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7bea1987c83319d66c982ccdaf4d3)