### PR TITLE
Increase API validator test coverage for retry and degraded health branches

### DIFF
--- a/tests/test_api_validator.py
+++ b/tests/test_api_validator.py
@@ -421,3 +421,61 @@ def test_extract_helpers_cover_supported_shapes() -> None:
     assert _extract_capabilities({"capabilities": []}) == []
     assert _extract_capabilities({"capabilities": "flat"}) is None
     assert _extract_capabilities(["invalid"]) is None
+
+
+@pytest.mark.asyncio
+async def test_test_endpoint_reachability_uses_default_ssl_options(hass) -> None:
+    """Reachability checks should avoid passing ssl when verification is enabled."""
+    session = _SequentialGetSession([_MockResponse(204)])
+    validator = APIValidator(hass, session, verify_ssl=True)
+
+    assert await validator._test_endpoint_reachability("https://example.com") is True
+    assert session.calls[0][1] == {"allow_redirects": True}
+
+
+@pytest.mark.asyncio
+async def test_test_authentication_retries_until_success(hass) -> None:
+    """Authentication should continue across endpoint errors until one succeeds."""
+    session = _SequentialGetSession([
+        aiohttp.ClientError("first failed"),
+        _MockResponse(204, {"version": "2.0", "capabilities": []}),
+    ])
+    validator = APIValidator(hass, session)
+
+    result = await validator._test_authentication("https://example.com", "token")
+
+    assert result == {
+        "authenticated": True,
+        "api_version": "2.0",
+        "capabilities": [],
+    }
+    assert len(session.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_async_test_api_health_returns_degraded_when_validation_not_valid(
+    hass,
+    mock_session,
+) -> None:
+    """Health checks should remain degraded when endpoint is reachable but invalid."""
+    validator = APIValidator(hass, mock_session)
+    validator.async_validate_api_connection = AsyncMock(  # type: ignore[method-assign]
+        return_value=type(
+            "Result",
+            (),
+            {
+                "valid": False,
+                "reachable": True,
+                "authenticated": False,
+                "response_time_ms": 10.0,
+                "error_message": "partial",
+                "api_version": None,
+                "capabilities": None,
+            },
+        )()
+    )
+
+    health = await validator.async_test_api_health("https://example.com")
+
+    assert health["status"] == "degraded"
+    assert health["reachable"] is True


### PR DESCRIPTION
### Motivation
- Close coverage gaps in the API validation helpers by exercising the reachability SSL default, authentication retry path, and the `degraded` health mapping.

### Description
- Add three tests to `tests/test_api_validator.py`: `test_test_endpoint_reachability_uses_default_ssl_options`, `test_test_authentication_retries_until_success`, and `test_async_test_api_health_returns_degraded_when_validation_not_valid`.
- The new tests exercise `_test_endpoint_reachability`, `_test_authentication`, and `async_test_api_health` using the existing `_SequentialGetSession` and `_MockResponse` test doubles.
- Reformat the updated test file with `ruff format` to satisfy linting rules.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/test_api_validator.py` and all tests passed (`22 passed`).
- Ran `ruff format tests/test_api_validator.py` and `ruff check tests/test_api_validator.py`, and formatting/lint checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b024c7b88331b049293207276705)