### PR TITLE
tests: increase setup validation coverage for empty dogs and unknown-module warnings

### DIFF
--- a/tests/test_setup_validation_coverage.py
+++ b/tests/test_setup_validation_coverage.py
@@ -121,3 +121,33 @@ def test_extract_enabled_modules_skips_missing_modules_key() -> None:
     dogs_config = [{"dog_id": "buddy", "dog_name": "Buddy"}]
 
     assert validation._extract_enabled_modules(dogs_config) == frozenset()
+
+
+@pytest.mark.asyncio
+async def test_validate_dogs_config_defaults_when_key_missing(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Missing dogs key should default to an empty validated configuration."""
+    entry = SimpleNamespace(data={}, entry_id="entry-missing")
+
+    with caplog.at_level("DEBUG"):
+        dogs = await validation._async_validate_dogs_config(entry)
+
+    assert dogs == []
+    assert "No dogs configured for entry entry-missing" in caplog.text
+
+
+def test_extract_enabled_modules_deduplicates_unknown_module_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unknown module warnings should remain stable across multiple dog payloads."""
+    dogs_config = [
+        {"dog_id": "buddy", "modules": {"unknown_mod": True, "gps": True}},
+        {"dog_id": "luna", "modules": {"unknown_mod": True}},
+    ]
+
+    with caplog.at_level("WARNING"):
+        enabled = validation._extract_enabled_modules(dogs_config)
+
+    assert enabled == frozenset({"gps"})
+    assert caplog.text.count("Ignoring unknown PawControl modules: unknown_mod") == 1


### PR DESCRIPTION
### Motivation

- Improve branch coverage for setup validation helpers by exercising the code paths where the `dogs` key is absent and when unknown modules appear across multiple dog payloads.

### Description

- Added an async regression test `test_validate_dogs_config_defaults_when_key_missing` to validate `_async_validate_dogs_config` returns an empty list and emits the expected debug log when `dogs` is missing from the entry data.
- Added `test_extract_enabled_modules_deduplicates_unknown_module_warnings` to ensure `_extract_enabled_modules` captures valid modules while deduplicating warnings for unknown modules across multiple dog payloads.
- Changes are limited to `tests/test_setup_validation_coverage.py` and add focused assertions for logging and returned values.

### Testing

- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/test_setup_validation_coverage.py` and the suite completed successfully with `10 passed in 0.30s`.
- The new tests exercise the targeted branches and passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b024c7b88331b049293207276705)