### PR TITLE
Increase services helper test coverage for validation and normalization branches

### DIFF
--- a/tests/components/pawcontrol/test_services_helpers.py
+++ b/tests/components/pawcontrol/test_services_helpers.py
@@ -180,8 +180,18 @@ def test_coerce_service_bool_true_values(value: object) -> None:
     assert services._coerce_service_bool(value, field="enabled") is True
 
 
+@pytest.mark.parametrize("value", ["  TRUE ", "Enabled", " On "])
+def test_coerce_service_bool_true_string_normalization(value: object) -> None:
+    assert services._coerce_service_bool(value, field="enabled") is True
+
+
 @pytest.mark.parametrize("value", [False, "off", "disable", "0", 0])
 def test_coerce_service_bool_false_values(value: object) -> None:
+    assert services._coerce_service_bool(value, field="enabled") is False
+
+
+@pytest.mark.parametrize("value", ["  FALSE ", "Disabled", " Off "])
+def test_coerce_service_bool_false_string_normalization(value: object) -> None:
     assert services._coerce_service_bool(value, field="enabled") is False
 
 
@@ -288,6 +298,64 @@ def test_format_text_validation_error_variants(  # noqa: F811
     message: str,
 ) -> None:
     assert services._format_text_validation_error(error) == message
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(2.0, "2"), (2.5, "2.5"), ("3.0", "3.0")],
+)
+def test_format_numeric_value_preserves_stable_text(
+    value: object,
+    expected: str,
+) -> None:
+    assert services._format_numeric_value(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("error", "unit", "expected"),
+    [
+        (
+            ValidationError(
+                "geofence_radius",
+                constraint="geofence_radius_required",
+            ),
+            None,
+            "geofence_radius is required",
+        ),
+        (
+            ValidationError(
+                "geofence_radius",
+                constraint="geofence_radius_not_numeric",
+            ),
+            None,
+            "geofence_radius must be a number",
+        ),
+        (
+            ValidationError(
+                "gps_update_interval",
+                constraint="gps_update_interval_not_numeric",
+            ),
+            None,
+            "gps_update_interval must be a whole number",
+        ),
+        (
+            ValidationError(
+                "gps_accuracy",
+                constraint="gps_accuracy_out_of_range",
+                min_value=5,
+                max_value=50,
+            ),
+            None,
+            "gps_accuracy must be between 5 and 50",
+        ),
+    ],
+)
+def test_format_gps_validation_error_additional_constraints(
+    error: ValidationError,
+    unit: str | None,
+    expected: str,
+) -> None:
+    assert services._format_gps_validation_error(error, unit=unit) == expected
 
 
 def test_normalise_context_identifier_handles_bad_string_conversion() -> None:


### PR DESCRIPTION
### Motivation
- Improve branch-level coverage for service helper utilities without changing runtime behavior.
- Exercise string normalization and numeric formatting edge cases in service validation helpers.
- Cover additional GPS validation error branches to reduce uncovered decision paths in `services.py`.

### Description
- Add parametrized tests for `_coerce_service_bool` to cover trimmed and mixed-case true/false string variants in `tests/components/pawcontrol/test_services_helpers.py`.
- Add `test_format_numeric_value_preserves_stable_text` to assert stable textual rendering for integer-like floats, fractional floats, and numeric strings.
- Add `test_format_gps_validation_error_additional_constraints` to cover required, non-numeric, and out-of-range GPS/geofence validation branches.
- Changes are limited to the test module and do not alter production code.

### Testing
- Ran `pytest -q -o addopts='' tests/components/pawcontrol/test_services_helpers.py` and all tests passed (78 passed).
- No additional automated test failures were observed when executing the focused test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b2586f10833192de52b664913c69)