### PR TITLE
Add cache repair aggregate type coverage tests

### DIFF
--- a/tests/components/pawcontrol/test_types_coverage.py
+++ b/tests/components/pawcontrol/test_types_coverage.py
@@ -182,23 +182,21 @@ def test_ensure_gps_payload_float_and_timestamp_normalisation() -> None:
 
 def test_ensure_gps_route_snapshot_filters_invalid_points_and_optional_fields() -> None:
     """Route snapshots should keep only valid point mappings and numeric options."""
-    snapshot = types.ensure_gps_route_snapshot(
-        {
-            "id": "route-1",
-            "name": "",
-            "active": 1,
-            "points": [
-                {"latitude": "52.5", "longitude": "13.4", "altitude": "45"},
-                {"latitude": "bad", "longitude": "13.5"},
-                "invalid-point",
-                {"latitude": 53.0, "longitude": 13.6, "speed": "3.1"},
-            ],
-            "distance": "2.75",
-            "duration": "42",
-            "end_time": " 2025-01-02T04:05:06+00:00 ",
-            "last_point_time": "",
-        }
-    )
+    snapshot = types.ensure_gps_route_snapshot({
+        "id": "route-1",
+        "name": "",
+        "active": 1,
+        "points": [
+            {"latitude": "52.5", "longitude": "13.4", "altitude": "45"},
+            {"latitude": "bad", "longitude": "13.5"},
+            "invalid-point",
+            {"latitude": 53.0, "longitude": 13.6, "speed": "3.1"},
+        ],
+        "distance": "2.75",
+        "duration": "42",
+        "end_time": " 2025-01-02T04:05:06+00:00 ",
+        "last_point_time": "",
+    })
 
     assert snapshot is not None
     assert snapshot["active"] is True
@@ -213,18 +211,18 @@ def test_ensure_gps_route_snapshot_filters_invalid_points_and_optional_fields() 
     assert "last_point_time" not in snapshot
 
 
-def test_ensure_gps_payload_removes_invalid_current_route_and_keeps_active_route() -> None:
-    """Payload normalisation should drop invalid current routes and build active routes."""
-    payload = types.ensure_gps_payload(
-        {
-            "current_route": [],
-            "active_route": {
-                "id": "walk-1",
-                "points": [{"latitude": 50, "longitude": 8}],
-            },
-            "status": None,
-        }
-    )
+def test_ensure_gps_payload_removes_invalid_current_route_and_keeps_active_route() -> (
+    None
+):
+    """Payload normalisation should drop invalid and build active routes."""
+    payload = types.ensure_gps_payload({
+        "current_route": [],
+        "active_route": {
+            "id": "walk-1",
+            "points": [{"latitude": 50, "longitude": 8}],
+        },
+        "status": None,
+    })
 
     assert payload is not None
     assert "current_route" not in payload
@@ -235,13 +233,11 @@ def test_ensure_gps_payload_removes_invalid_current_route_and_keeps_active_route
 
 def test_ensure_gps_payload_null_satellites_and_trimmed_last_seen() -> None:
     """Explicit satellite nulls and blank timestamps should normalize consistently."""
-    payload = types.ensure_gps_payload(
-        {
-            "satellites": None,
-            "last_seen": "   ",
-            "latitude": "48.1",
-        }
-    )
+    payload = types.ensure_gps_payload({
+        "satellites": None,
+        "last_seen": "   ",
+        "latitude": "48.1",
+    })
 
     assert payload is not None
     assert payload["satellites"] is None
@@ -396,3 +392,60 @@ def test_validate_dog_weight_for_size_ranges(
 ) -> None:
     """Weight validation should enforce known ranges and ignore unknown sizes."""
     assert types.validate_dog_weight_for_size(weight, size) is expected
+
+
+def test_cache_repair_aggregate_from_mapping_coerces_totals_and_collections() -> None:
+    """Aggregate parsing should normalize totals and mixed collection payloads."""
+    aggregate = types.CacheRepairAggregate.from_mapping({
+        "total_caches": "7.0",
+        "anomaly_count": True,
+        "severity": "high",
+        "generated_at": "2026-03-01T00:00:00+00:00",
+        "caches_with_errors": ("cache_a", "cache_b", 1),
+        "caches_with_override_flags": {"cache_c", "cache_d", 4},
+        "totals": {
+            "entries": "15.9",
+            "hits": 8,
+            "misses": False,
+            "expired_entries": "bad",
+            "active_override_flags": "3",
+            "overall_hit_rate": "0.73",
+        },
+        "issues": [{"cache": "cache_a", "reason": "expired"}, "invalid"],
+    })
+
+    assert aggregate.total_caches == 7
+    assert aggregate.anomaly_count == 1
+    assert aggregate.caches_with_errors == ["cache_a", "cache_b"]
+    assert sorted(aggregate.caches_with_override_flags or []) == [
+        "cache_c",
+        "cache_d",
+    ]
+    assert aggregate.totals is not None
+    assert aggregate.totals.entries == 15
+    assert aggregate.totals.misses == 0
+    assert aggregate.totals.expired_entries == 0
+    assert aggregate.totals.active_override_flags == 3
+    assert aggregate.totals.overall_hit_rate == 0.73
+    assert aggregate.issues == [{"cache": "cache_a", "reason": "expired"}]
+
+
+def test_cache_repair_aggregate_to_mapping_omits_empty_optional_sections() -> None:
+    """Mapping export should keep required fields and skip empty optional payloads."""
+    aggregate = types.CacheRepairAggregate(
+        total_caches=0,
+        anomaly_count=0,
+        severity="normal",
+        generated_at="2026-03-01T00:00:00+00:00",
+        caches_with_low_hit_rate=[],
+        issues=[],
+    )
+
+    exported = aggregate.to_mapping()
+
+    assert exported == {
+        "total_caches": 0,
+        "anomaly_count": 0,
+        "severity": "normal",
+        "generated_at": "2026-03-01T00:00:00+00:00",
+    }


### PR DESCRIPTION
### Motivation

- Improve branch and line coverage for `custom_components/pawcontrol/types.py` by exercising `CacheRepairAggregate` parsing and export branches.  
- Targeted tests keep scope narrow to a single test module to satisfy the repository coverage package execution protocol.  
- Verify defensive coercion and optional-section omission logic without changing runtime code.

### Description

- Added `test_cache_repair_aggregate_from_mapping_coerces_totals_and_collections` to `tests/components/pawcontrol/test_types_coverage.py` to validate integer/float/bool coercion, tuple/set filtering, totals parsing, overall hit rate coercion, and issues filtering.  
- Added `test_cache_repair_aggregate_to_mapping_omits_empty_optional_sections` to ensure `to_mapping()` omits empty optional collections while preserving required fields.  
- Reformatted a nearby test helper call for line-length compliance so linting passes (`ruff format` applied to the test file).

### Testing

- Ran `ruff check tests/components/pawcontrol/test_types_coverage.py` and fixed formatting issues; the check passed.  
- Executed the focused test run with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/components/pawcontrol/test_types_coverage.py -p xdist.plugin -p pytest_asyncio -n 0 -q` and the added tests passed.  
- No runtime integration code was modified and only the single test module was changed to increase coverage in a traceable, low-risk way.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b4bbf5c88331aa869b124b14cbb8)