### PR TITLE
Increase coverage for enforce_coverage_gates utility

### DIFF
--- a/tests/test_enforce_coverage_gates.py
+++ b/tests/test_enforce_coverage_gates.py
@@ -230,3 +230,101 @@ def test_load_branch_exceptions_rejects_missing_rationale(tmp_path: Path) -> Non
 def test_parse_percent_rejects_invalid_numeric_values() -> None:
     with pytest.raises(SystemExit, match="invalid numeric value"):
         enforce_coverage_gates._parse_percent("not-a-number")
+
+
+def test_coverage_root_requires_existing_report(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit, match="coverage report not found"):
+        enforce_coverage_gates._coverage_root(tmp_path / "missing.xml")
+
+
+def test_module_coverage_percent_requires_line_rate_attribute(tmp_path: Path) -> None:
+    report = tmp_path / "coverage.xml"
+    report.write_text(
+        '<?xml version="1.0" ?>\n'
+        '<coverage line-rate="0.9" branch-rate="0" version="7">\n'
+        '<packages><package name="pawcontrol" line-rate="0" branch-rate="0">\n'
+        '<classes><class filename="custom_components/pawcontrol/coordinator.py" '
+        'branch-rate="1"><lines /></class></classes>\n'
+        "</package></packages></coverage>\n",
+        encoding="utf-8",
+    )
+
+    root = enforce_coverage_gates._coverage_root(report)
+    with pytest.raises(SystemExit, match="missing line-rate"):
+        enforce_coverage_gates._module_coverage_percent(
+            root,
+            "custom_components/pawcontrol/coordinator.py",
+        )
+
+
+def test_load_branch_exceptions_rejects_non_object_entries(tmp_path: Path) -> None:
+    exceptions_file = tmp_path / "exceptions.json"
+    exceptions_file.write_text('["bad-entry"]', encoding="utf-8")
+
+    with pytest.raises(SystemExit, match="JSON objects"):
+        enforce_coverage_gates._load_branch_exceptions(exceptions_file)
+
+
+def test_evaluate_gates_fails_when_branch_exception_floor_is_not_met(
+    tmp_path: Path,
+) -> None:
+    report = _write_coverage_xml(
+        tmp_path,
+        line_rate="0.95",
+        class_rates={
+            "custom_components/pawcontrol/coordinator.py": ("0.95", "0.70"),
+            "custom_components/pawcontrol/config_flow.py": ("0.95", "1"),
+            "custom_components/pawcontrol/services.py": ("0.95", "1"),
+            "custom_components/pawcontrol/data_manager.py": ("0.95", "1"),
+        },
+    )
+    exceptions_file = tmp_path / "exceptions.json"
+    exceptions_file.write_text(
+        '[{"path":"custom_components/pawcontrol/coordinator.py",'
+        '"minimum_branch_percent":"80","rationale":"legacy path"}]',
+        encoding="utf-8",
+    )
+
+    _, failures, notices = enforce_coverage_gates._evaluate_gates(
+        report,
+        exceptions_file,
+        enforce_coverage_gates.DEFAULT_TOTAL_MINIMUM_PERCENT,
+        enforce_coverage_gates.DEFAULT_CRITICAL_MODULE_MINIMUM_PERCENT,
+    )
+
+    assert notices == []
+    assert any("exception floor failed" in failure for failure in failures)
+
+
+def test_main_reports_passed_gates(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    report = _write_coverage_xml(
+        tmp_path,
+        line_rate="0.92",
+        class_rates={
+            "custom_components/pawcontrol/coordinator.py": ("0.95", "1"),
+            "custom_components/pawcontrol/config_flow.py": ("0.95", "1"),
+            "custom_components/pawcontrol/services.py": ("0.95", "1"),
+            "custom_components/pawcontrol/data_manager.py": ("0.95", "1"),
+        },
+    )
+
+    from unittest.mock import patch
+
+    with patch(
+        "sys.argv",
+        [
+            "enforce_coverage_gates.py",
+            "--coverage-xml",
+            str(report),
+            "--exceptions-file",
+            str(tmp_path / "missing-exceptions.json"),
+        ],
+    ):
+        result = enforce_coverage_gates.main()
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "Coverage gates passed." in output


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the coverage-gate enforcement script to exercise previously untested failure and success branches.

### Description
- Added new tests in `tests/test_enforce_coverage_gates.py` that cover missing `coverage.xml` handling, missing `line-rate` on class nodes, invalid non-object branch-exception entries, branch-exception floor failures, and a `main()` success path.
- Tests exercise internal helpers: `_coverage_root`, `_module_coverage_percent`, `_load_branch_exceptions`, and `_evaluate_gates` to validate error messages and notice generation.

### Testing
- Ran `pytest -q -o addopts='' tests/test_enforce_coverage_gates.py` and all tests passed (`16 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8b64ba3148331abcdb13de6741b38)