### PR TITLE
Increase http_client coverage for session validation edge cases

### DIFF
--- a/tests/components/pawcontrol/test_http_client.py
+++ b/tests/components/pawcontrol/test_http_client.py
@@ -36,6 +36,20 @@ class _ClosedValidSession(_ValidSession):
     closed = True
 
 
+class _SessionUsingPrivateRequestFallback:
+    closed = False
+
+    def request(self, *_args, **_kwargs):
+        return None
+
+    async def _request(self, *_args, **_kwargs):
+        return None
+
+
+class _SessionWithNonBooleanClosed(_ValidSession):
+    closed = "yes"
+
+
 def test_ensure_shared_client_session_rejects_none() -> None:
     with pytest.raises(ValueError, match="received None"):
         ensure_shared_client_session(None, owner="test")
@@ -69,5 +83,19 @@ def test_ensure_shared_client_session_rejects_closed_sessions() -> None:
 
 def test_ensure_shared_client_session_accepts_valid_session() -> None:
     session = _ValidSession()
+
+    assert ensure_shared_client_session(session, owner="test") is session
+
+
+def test_ensure_shared_client_session_accepts_private_request_fallback() -> None:
+    """aiohttp-like sessions may expose the coroutine on ``_request`` only."""
+    session = _SessionUsingPrivateRequestFallback()
+
+    assert ensure_shared_client_session(session, owner="test") is session
+
+
+def test_ensure_shared_client_session_ignores_non_boolean_closed_flag() -> None:
+    """Non-boolean ``closed`` attributes should not force a false positive."""
+    session = _SessionWithNonBooleanClosed()
 
     assert ensure_shared_client_session(session, owner="test") is session


### PR DESCRIPTION
### Motivation
- Exercise previously untested branches in `ensure_shared_client_session` to improve branch coverage for session validation edge cases.
- Specifically target the aiohttp-style private `_request` coroutine fallback and non-boolean `closed` attribute handling.

### Description
- Add `_SessionUsingPrivateRequestFallback` and `_SessionWithNonBooleanClosed` test doubles to `tests/components/pawcontrol/test_http_client.py`.
- Add `test_ensure_shared_client_session_accepts_private_request_fallback` which verifies a sync `request` with an async `_request` fallback is accepted.
- Add `test_ensure_shared_client_session_ignores_non_boolean_closed_flag` which verifies non-boolean `closed` attributes do not cause false-positive closed-session errors.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts='' tests/components/pawcontrol/test_http_client.py -q` and observed `8 passed`.
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -o addopts='' -p pytest_cov tests/components/pawcontrol/test_http_client.py --cov=custom_components/pawcontrol/http_client.py --cov-report=term-missing` and the test run completed successfully with all tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8ba397f3883319fa6dec92ddaae6c)