### PR TITLE
test: increase services helper coverage for expires-in-hours formatting

### DIFF
--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -260,6 +260,43 @@ def test_coerce_service_bool_rejects_numeric_non_boolean_values() -> None:
 
 
 @pytest.mark.parametrize(
+    ("min_value", "max_value", "expected"),
+    [
+        (
+            1.5,
+            3.5,
+            "expires_in_hours must be between 1.5 and 3.5",
+        ),
+        (
+            None,
+            None,
+            "expires_in_hours is out of range",
+        ),
+    ],
+)
+def test_format_expires_in_hours_error_out_of_range_variants(
+    min_value: float | None,
+    max_value: float | None,
+    expected: str,
+) -> None:
+    """Out-of-range expiry errors should render all supported bound combinations."""
+    error = services.ValidationError(
+        field="expires_in_hours",
+        value=0.5,
+        constraint="expires_in_hours_out_of_range",
+        min_value=min_value,
+        max_value=max_value,
+    )
+
+    assert services._format_expires_in_hours_error(error) == expected
+
+
+def test_format_numeric_value_preserves_non_integral_float_text() -> None:
+    """Numeric formatter should keep decimal precision when needed."""
+    assert services._format_numeric_value(2.75) == "2.75"
+
+
+@pytest.mark.parametrize(
     ("schema", "payload"),
     [
         (


### PR DESCRIPTION
### Motivation
- Cover edge cases in service helper formatting logic to improve deterministic unit coverage for expiry error messages and numeric formatting.

### Description
- Add a parameterized unit test `test_format_expires_in_hours_error_out_of_range_variants` in `tests/unit/test_services.py` to assert `_format_expires_in_hours_error` renders both bounded and unbounded out-of-range messages.
- Add `test_format_numeric_value_preserves_non_integral_float_text` in `tests/unit/test_services.py` to verify `_format_numeric_value` preserves decimal precision for non-integral floats.

### Testing
- Ran the focused tests with `pytest -q -o addopts='' tests/unit/test_services.py::test_format_expires_in_hours_error_out_of_range_variants tests/unit/test_services.py::test_format_numeric_value_preserves_non_integral_float_text tests/unit/test_services.py::test_coerce_service_bool_rejects_numeric_non_boolean_values` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8bcbb2a648331aa15cd6be9374ba4)