### PR TITLE
tests: increase services validation branch coverage

### DIFF
--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -224,6 +224,50 @@ def test_format_expires_in_hours_error_boundary_cases() -> None:
     )
 
 
+def test_format_expires_in_hours_error_out_of_range_without_bounds() -> None:
+    """Out-of-range errors without explicit bounds should stay user friendly."""
+    error = services.ValidationError(
+        field="expires_in_hours",
+        value=999,
+        constraint="expires_in_hours_out_of_range",
+    )
+
+    assert (
+        services._format_expires_in_hours_error(error)
+        == "expires_in_hours is out of range"
+    )
+
+
+def test_format_expires_in_hours_error_not_numeric_constraint() -> None:
+    """Dedicated numeric constraint should force the numeric validation text."""
+    error = services.ValidationError(
+        field="expires_in_hours",
+        value="invalid",
+        constraint="expires_in_hours_not_numeric",
+    )
+
+    assert (
+        services._format_expires_in_hours_error(error)
+        == "expires_in_hours must be a number"
+    )
+
+
+def test_format_gps_validation_error_for_interval_range_branch() -> None:
+    """Range constraints should include bounds and units for interval validation."""
+    error = services.ValidationError(
+        field="gps_update_interval",
+        value=0,
+        constraint="gps_update_interval_out_of_range",
+        min_value=5,
+        max_value=3600,
+    )
+
+    assert (
+        services._format_gps_validation_error(error, unit="s")
+        == "gps_update_interval must be between 5 and 3600s"
+    )
+
+
 @pytest.mark.parametrize(
     ("value", "expected"),
     [


### PR DESCRIPTION
### Motivation
- Close coverage gaps in `custom_components/pawcontrol/services.py` formatting helpers by exercising edge-case branches in service validation message formatting.

### Description
- Add three focused unit tests to `tests/unit/test_services.py` covering `_format_expires_in_hours_error` for an out-of-range case without explicit bounds and the explicit `expires_in_hours_not_numeric` constraint, and `_format_gps_validation_error` for the `gps_update_interval_out_of_range` branch with unit suffix formatting.
- Change is tests-only; no runtime or integration code was modified.

### Testing
- Ran formatting and lint: `ruff format tests/unit/test_services.py` and `ruff check tests/unit/test_services.py` which succeeded.
- Ran the targeted pytest selection: `pytest -q tests/unit/test_services.py -o addopts='' -k 'out_of_range_without_bounds or not_numeric_constraint or interval_range_branch'` and the new tests passed.
- Ran the full test module: `pytest -q tests/unit/test_services.py -o addopts=''` which showed 4 pre-existing failures in unrelated schema tests; the failures are not caused by the added tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c2e68d788331ab8efb9944ec6357)