### PR TITLE
Increase data manager coverage for partial export error handling

### DIFF
--- a/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
+++ b/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
@@ -224,6 +224,35 @@ async def test_async_generate_report_tolerates_adapter_exceptions_and_persists(
     assert '"report_type": "weekly"' in reports_dump
 
 
+@pytest.mark.asyncio
+async def test_async_export_data_all_allow_partial_captures_homeassistant_and_io_errors(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    manager = await _create_manager(mock_hass, tmp_path)
+    manager._dog_profiles["buddy"].feeding_history = [
+        {"timestamp": "2026-01-02T08:00:00+00:00", "portion_size": 10.0},
+    ]
+    manager._get_runtime_data = lambda: SimpleNamespace(  # type: ignore[method-assign]
+        gps_geofence_manager=SimpleNamespace(
+            async_export_routes=AsyncMock(side_effect=OSError("disk offline")),
+        ),
+    )
+
+    manifest_path = await manager.async_export_data(
+        "buddy",
+        "all",
+        allow_partial=True,
+    )
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload["data_type"] == "all"
+    assert "feeding" in payload["exports"]
+    assert "walks" in payload["exports"]
+    assert payload["errors"]["garden"] == "Garden manager not available for export"
+    assert payload["errors"]["routes"].startswith("I/O error: disk offline")
+
+
 def test_cache_repair_summary_classifies_normal_corrupt_and_error_states(
     mock_hass: object,
     tmp_path: Path,


### PR DESCRIPTION
### Motivation
- Close a coverage gap in `PawControlDataManager.async_export_data` by exercising the `data_type="all"` + `allow_partial=True` path that needs to capture mixed failures from adapters and I/O and surface them in the manifest.

### Description
- Add `test_async_export_data_all_allow_partial_captures_homeassistant_and_io_errors` to `tests/components/pawcontrol/test_data_manager_targeted_matrix.py` which simulates a missing garden manager (`HomeAssistantError`) and an I/O error from the GPS routes adapter (`OSError`) while asserting the manifest records both successful exports and per-export errors.

### Testing
- Ran `pytest -q tests/components/pawcontrol/test_data_manager_targeted_matrix.py -p no:hypothesispytest -n 0` and the test suite passed.
- Ran `ruff check tests/components/pawcontrol/test_data_manager_targeted_matrix.py` and `ruff format --check tests/components/pawcontrol/test_data_manager_targeted_matrix.py` and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c43eeb148331a55d7415b48fb9f5)