### PR TITLE
Add branch-focused tests for config_flow_profile helpers

### DIFF
--- a/tests/components/pawcontrol/test_config_flow_profile_helpers_extra.py
+++ b/tests/components/pawcontrol/test_config_flow_profile_helpers_extra.py
@@ -1,0 +1,75 @@
+"""Additional branch coverage for config flow profile helpers."""
+
+import pytest
+import voluptuous as vol
+
+import custom_components.pawcontrol.config_flow_profile as profile_helpers
+
+
+def test_validate_profile_selection_requires_entity_profile_key() -> None:
+    """Missing profile input should raise the shared invalid marker."""
+    with pytest.raises(KeyError, match="entity_profile"):
+        profile_helpers.validate_profile_selection({})
+
+
+def test_coerce_str_and_title_helpers_fall_back_for_non_strings() -> None:
+    """Helper functions should safely coerce non-string metadata values."""
+    assert profile_helpers._coerce_str("ok") == "ok"
+    assert profile_helpers._coerce_str(5, fallback="fallback") == "fallback"
+
+    assert profile_helpers._get_profile_title("guardian", None) == "Guardian"
+    assert (
+        profile_helpers._get_profile_title("guardian", {"name": 10})
+        == "Guardian"
+    )
+
+
+def test_get_profile_selector_options_omits_optional_label_parts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Options should only include max-entities and description when usable."""
+    monkeypatch.setattr(
+        profile_helpers,
+        "ENTITY_PROFILES",
+        {
+            "minimal": {"name": "Minimal", "max_entities": "not-an-int"},
+            "with_desc": {
+                "name": "Detailed",
+                "max_entities": 4,
+                "description": "Great for testing",
+            },
+        },
+    )
+
+    options = profile_helpers.get_profile_selector_options()
+    assert options == [
+        {"value": "minimal", "label": "Minimal"},
+        {
+            "value": "with_desc",
+            "label": "Detailed - 4 entities per dog - Great for testing",
+        },
+    ]
+
+
+def test_build_profile_summary_text_handles_missing_recommendation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Summary lines should degrade gracefully when recommendation is absent."""
+    monkeypatch.setattr(
+        profile_helpers,
+        "ENTITY_PROFILES",
+        {
+            "minimal": {"name": "Minimal", "description": "No extras"},
+            "advanced": {
+                "name": "Advanced",
+                "description": "All controls",
+                "recommended_for": "power users",
+            },
+        },
+    )
+
+    summary = profile_helpers.build_profile_summary_text().splitlines()
+    assert summary[0] == "Minimal: No extras"
+    assert summary[1] == (
+        "Advanced: All controls You should pick this when you want power users."
+    )


### PR DESCRIPTION
### Motivation
- Increase branch coverage for the `config_flow_profile` helper utilities to ensure edge cases in profile selection and label/summary generation are exercised.
- Cover input-validation and metadata fallback paths that are important for the config/options flow UI.

### Description
- Add `tests/components/pawcontrol/test_config_flow_profile_helpers_extra.py` which exercises missing `entity_profile` input handling, `_coerce_str` and `_get_profile_title` fallbacks, selector label composition when optional metadata is absent, and summary text generation when `recommended_for` is missing or present.
- This change only adds tests and does not modify production code or runtime behavior.

### Testing
- Ran the targeted test file with `pytest -q -p no:hypothesispytest tests/components/pawcontrol/test_config_flow_profile_helpers_extra.py` and the tests passed.
- The new test file was committed as `tests/components/pawcontrol/test_config_flow_profile_helpers_extra.py`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c73da9b08331b7c9c7699a4ee4ae)