### PR TITLE
Add coverage for serialize module parent-missing fallback path

### DIFF
--- a/tests/components/pawcontrol/test_utils_serialize.py
+++ b/tests/components/pawcontrol/test_utils_serialize.py
@@ -3,6 +3,9 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 import importlib
+from pathlib import Path
+import runpy
+import sys
 
 import pytest
 
@@ -125,3 +128,25 @@ def test_module_reload_syncs_parent_utils_re_exports() -> None:
         parent.serialize_entity_attributes
         is reloaded_module.serialize_entity_attributes
     )
+
+
+def test_module_reload_skips_re_export_when_parent_module_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Module execution should succeed when the parent utils module is absent."""
+    monkeypatch.delitem(
+        sys.modules,
+        "custom_components.pawcontrol.utils",
+        raising=False,
+    )
+    namespace = runpy.run_path(
+        str(
+            Path(__file__).resolve().parents[3]
+            / "custom_components"
+            / "pawcontrol"
+            / "utils"
+            / "serialize.py"
+        )
+    )
+
+    assert namespace["serialize_datetime"] is not None


### PR DESCRIPTION
### Motivation
- Increase branch coverage for `utils.serialize` by exercising the fallback path when the parent `custom_components.pawcontrol.utils` module is absent from `sys.modules` so module-level re-export logic is validated.

### Description
- Add a unit test `test_module_reload_skips_re_export_when_parent_module_missing` to `tests/components/pawcontrol/test_utils_serialize.py` that removes the parent module from `sys.modules`, executes `serialize.py` via `runpy.run_path`, and asserts the expected exports (no runtime production code changes). 
- Add the required imports: `Path`, `runpy`, and `sys` used by the new test.

### Testing
- Ran `pytest -q -p no:hypothesispytest -n 0 tests/components/pawcontrol/test_utils_serialize.py` and the test file passed.
- Ran `ruff check tests/components/pawcontrol/test_utils_serialize.py` and `ruff format --check tests/components/pawcontrol/test_utils_serialize.py`, both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d8c73da9b08331b7c9c7699a4ee4ae)