### PR TITLE
Increase validation coverage for sensor entity ID edge paths

### DIFF
--- a/tests/components/pawcontrol/test_validation_hotspot_package11.py
+++ b/tests/components/pawcontrol/test_validation_hotspot_package11.py
@@ -224,6 +224,64 @@ def test_validate_sensor_entity_id_checks_domain_and_device_class() -> None:
         )
 
 
+def test_validate_sensor_entity_id_optional_and_required_empty_paths() -> None:
+    """Empty sensor IDs should respect required flag and custom constraints."""
+    hass = _build_hass()
+
+    assert (
+        validate_sensor_entity_id(
+            hass,
+            None,
+            field="door_sensor",
+            required=False,
+        )
+        is None
+    )
+
+    with pytest.raises(ValidationError, match="door_sensor_required"):
+        validate_sensor_entity_id(
+            hass,
+            "   ",
+            field="door_sensor",
+            required=True,
+            required_constraint="door_sensor_required",
+        )
+
+
+def test_validate_sensor_entity_id_rejects_unavailable_and_non_string_values() -> None:
+    """Unavailable and malformed sensor IDs should fail with not-found constraints."""
+    hass = _build_hass(
+        states={
+            "binary_sensor.unknown_state": SimpleNamespace(state="unknown", attributes={}),
+            "binary_sensor.unavailable_state": SimpleNamespace(
+                state="unavailable",
+                attributes={},
+            ),
+        }
+    )
+
+    with pytest.raises(ValidationError, match="sensor_not_found"):
+        validate_sensor_entity_id(
+            hass,
+            123,
+            field="door_sensor",
+        )
+
+    with pytest.raises(ValidationError, match="sensor_not_found"):
+        validate_sensor_entity_id(
+            hass,
+            "binary_sensor.unknown_state",
+            field="door_sensor",
+        )
+
+    with pytest.raises(ValidationError, match="sensor_not_found"):
+        validate_sensor_entity_id(
+            hass,
+            "binary_sensor.unavailable_state",
+            field="door_sensor",
+        )
+
+
 @pytest.mark.parametrize(
     ("value", "kwargs", "expected"),
     [


### PR DESCRIPTION
### Motivation
- Close coverage gaps in the validation hotspot by exercising edge branches in `validate_sensor_entity_id` related to optional/required empty inputs and unavailable or malformed entity IDs.

### Description
- Add `test_validate_sensor_entity_id_optional_and_required_empty_paths` to assert `required=False` returns `None` and a custom `required_constraint` is raised for empty inputs. 
- Add `test_validate_sensor_entity_id_rejects_unavailable_and_non_string_values` to assert non-string inputs and `unknown`/`unavailable` entity states raise the `sensor_not_found` constraint. 
- Changes are limited to `tests/components/pawcontrol/test_validation_hotspot_package11.py` to follow the coverage-package workflow for `validation.py` hotspots.

### Testing
- Ran `pytest -o addopts='' tests/components/pawcontrol/test_validation_hotspot_package11.py -q` and the test file passed with `35 passed` in `0.17s`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9199561088331aa8c05235e6a9307)