### PR TITLE
Increase coverage for health_enhancements scheduling and status logic

### DIFF
--- a/tests/components/pawcontrol/test_health_enhancements.py
+++ b/tests/components/pawcontrol/test_health_enhancements.py
@@ -1,0 +1,189 @@
+"""Coverage tests for enhanced health scheduling and status evaluation."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from custom_components.pawcontrol import health_enhancements as health
+
+
+@pytest.mark.parametrize(
+    ("risk_factors", "expected_extra"),
+    [
+        ([], set()),
+        (["boarding"], {health.VaccinationType.BORDETELLA}),
+        (["tick_area"], {health.VaccinationType.LYME_DISEASE}),
+        (
+            ["boarding", "daycare", "tick_area"],
+            {
+                health.VaccinationType.BORDETELLA,
+                health.VaccinationType.LYME_DISEASE,
+            },
+        ),
+    ],
+)
+def test_generate_vaccination_schedule_tracks_age_and_risk(
+    risk_factors: list[str],
+    expected_extra: set[health.VaccinationType],
+) -> None:
+    """Puppy schedules should include overdue/due-soon doses and risk additions."""
+    birth_date = datetime(2025, 10, 1, tzinfo=UTC)
+    current_date = birth_date + timedelta(weeks=15)
+
+    schedule = health.EnhancedHealthCalculator.generate_vaccination_schedule(
+        birth_date,
+        current_date=current_date,
+        risk_factors=risk_factors,
+    )
+
+    statuses = {record.status for record in schedule}
+    vaccine_types = {record.vaccine_type for record in schedule}
+
+    assert health.HealthEventStatus.OVERDUE in statuses
+    assert health.HealthEventStatus.DUE_SOON in statuses
+    assert expected_extra.issubset(vaccine_types)
+
+
+@pytest.mark.parametrize(
+    ("age_months", "lifestyle_factors", "expected_flea_tick_count"),
+    [
+        (4, [], 0),
+        (4, ["outdoor_frequent"], 4),
+        (12, ["outdoor_frequent"], 4),
+    ],
+)
+def test_generate_deworming_schedule_applies_lifestyle_adjustments(
+    age_months: int,
+    lifestyle_factors: list[str],
+    expected_flea_tick_count: int,
+) -> None:
+    """Deworming schedules should adapt by age segment and lifestyle risk."""
+    current_date = datetime(2026, 4, 1, tzinfo=UTC)
+    birth_date = current_date - timedelta(days=30 * age_months)
+
+    schedule = health.EnhancedHealthCalculator.generate_deworming_schedule(
+        birth_date,
+        current_date=current_date,
+        lifestyle_factors=lifestyle_factors,
+    )
+
+    flea_tick_entries = [
+        record
+        for record in schedule
+        if record.treatment_type is health.DewormingType.FLEA_TICK_PREVENTION
+    ]
+
+    assert len(flea_tick_entries) == expected_flea_tick_count
+    assert any(
+        record.treatment_type is health.DewormingType.HEARTWORM_PREVENTION
+        for record in schedule
+    )
+
+
+def test_update_health_status_builds_alerts_upcoming_care_and_recommendations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Health status should collect overdue items and near-term care reminders."""
+    now = datetime(2026, 4, 1, 8, 0, tzinfo=UTC)
+    monkeypatch.setattr(health.dt_util, "now", lambda: now)
+    monkeypatch.setattr(
+        health,
+        "ensure_local_datetime",
+        lambda value: datetime.fromisoformat(value) if "T" in str(value) else None,
+    )
+
+    profile = health.EnhancedHealthProfile(
+        current_weight=20.5,
+        vaccinations=[
+            health.VaccinationRecord(
+                vaccine_type=health.VaccinationType.RABIES,
+                next_due_date=now - timedelta(days=3),
+            ),
+            health.VaccinationRecord(
+                vaccine_type=health.VaccinationType.DHPP,
+                next_due_date=now + timedelta(days=5),
+            ),
+        ],
+        dewormings=[
+            health.DewormingRecord(
+                treatment_type=health.DewormingType.BROAD_SPECTRUM,
+                next_due_date=now - timedelta(days=2),
+            ),
+            health.DewormingRecord(
+                treatment_type=health.DewormingType.HEARTWORM_PREVENTION,
+                next_due_date=now + timedelta(days=4),
+            ),
+        ],
+        veterinary_appointments=[
+            health.VeterinaryAppointment(
+                appointment_date=now + timedelta(days=10),
+                appointment_type="checkup",
+                purpose="Routine exam",
+            ),
+        ],
+        current_medications=[
+            {"name": "Omega-3", "next_dose": (now + timedelta(hours=1)).isoformat()},
+            {"name": "Invalid", "next_dose": "not-a-datetime"},
+        ],
+    )
+
+    status = health.EnhancedHealthCalculator.update_health_status(profile)
+
+    assert status["overall_score"] == 75
+    assert {alert["type"] for alert in status["priority_alerts"]} == {
+        "vaccination_overdue",
+        "deworming_overdue",
+        "medication_due",
+    }
+    assert {item["type"] for item in status["upcoming_care"]} == {
+        "vaccination_due",
+        "deworming_due",
+        "vet_appointment",
+    }
+    assert status["recommendations"] == [
+        "Schedule initial veterinary checkup to establish baseline health",
+    ]
+
+
+@pytest.mark.parametrize(
+    ("age_months", "conditions", "expected_type", "expected_days"),
+    [
+        (8, [], "puppy_checkup", 30),
+        (36, ["diabetes"], "diabetes_monitoring", 90),
+        (120, ["kidney_disease"], "condition_monitoring", 120),
+    ],
+)
+def test_calculate_next_appointment_recommendation_uses_age_and_conditions(
+    monkeypatch: pytest.MonkeyPatch,
+    age_months: int,
+    conditions: list[str],
+    expected_type: str,
+    expected_days: int,
+) -> None:
+    """Appointment recommendation should switch cadence for chronic conditions."""
+    now = datetime(2026, 4, 1, 12, 0, tzinfo=UTC)
+    monkeypatch.setattr(health.dt_util, "now", lambda: now)
+    monkeypatch.setattr(
+        health,
+        "ensure_local_datetime",
+        lambda value: datetime.fromisoformat(value) if "T" in str(value) else None,
+    )
+
+    profile = health.EnhancedHealthProfile(
+        current_weight=19.0,
+        chronic_conditions=conditions,
+        last_checkup_date=now,
+    )
+
+    recommendation = (
+        health.EnhancedHealthCalculator.calculate_next_appointment_recommendation(
+            profile,
+            dog_age_months=age_months,
+        )
+    )
+
+    assert recommendation["appointment_type"] == expected_type
+    assert recommendation["days_until"] == expected_days
+    assert recommendation["urgency"] == "normal"

--- a/tests/components/pawcontrol/test_manager_compliance.py
+++ b/tests/components/pawcontrol/test_manager_compliance.py
@@ -1,7 +1,5 @@
 """Coverage tests for manager_compliance helpers."""
 
-from __future__ import annotations
-
 import logging
 
 from custom_components.pawcontrol.base_manager import BaseManager
@@ -88,7 +86,9 @@ def test_validate_manager_compliance_accepts_instance_and_reports_issues() -> No
     assert report.manager_name == 5
     assert report.is_compliant is False
     assert any("Missing required method" in issue.message for issue in report.issues)
-    assert any(issue.message == "MANAGER_NAME must be a string" for issue in report.issues)
+    assert any(
+        issue.message == "MANAGER_NAME must be a string" for issue in report.issues
+    )
 
 
 def test_validate_all_managers_and_summary_for_mixed_reports() -> None:

--- a/tests/components/pawcontrol/test_validation_hotspot_package11.py
+++ b/tests/components/pawcontrol/test_validation_hotspot_package11.py
@@ -252,7 +252,9 @@ def test_validate_sensor_entity_id_rejects_unavailable_and_non_string_values() -
     """Unavailable and malformed sensor IDs should fail with not-found constraints."""
     hass = _build_hass(
         states={
-            "binary_sensor.unknown_state": SimpleNamespace(state="unknown", attributes={}),
+            "binary_sensor.unknown_state": SimpleNamespace(
+                state="unknown", attributes={}
+            ),
             "binary_sensor.unavailable_state": SimpleNamespace(
                 state="unavailable",
                 attributes={},

--- a/tests/components/pawcontrol/test_weather_translations.py
+++ b/tests/components/pawcontrol/test_weather_translations.py
@@ -155,7 +155,9 @@ async def test_async_get_weather_translations_prefers_requested_then_fallback() 
 
 def test_weather_translation_key_helpers_prefix_component_fragments() -> None:
     """Key helper utilities should generate stable translation key fragments."""
-    assert _weather_alert_title_key("storm_warning") == "weather_alert_storm_warning_title"
+    assert (
+        _weather_alert_title_key("storm_warning") == "weather_alert_storm_warning_title"
+    )
     assert _weather_alert_message_key("storm_warning") == (
         "weather_alert_storm_warning_message"
     )


### PR DESCRIPTION
### Motivation
- Close coverage gaps in `custom_components/pawcontrol/health_enhancements.py` by exercising vaccination/deworming schedule branches and health-status aggregation logic.
- Validate appointment recommendation behavior across age segments and chronic-condition adjustments to prevent regressions in cadence logic.

### Description
- Add `tests/components/pawcontrol/test_health_enhancements.py` with parametrized tests for puppy vaccination schedule generation including risk-factor branches and expected status flags.
- Add tests for deworming schedule generation that cover puppy vs adult flows and `outdoor_frequent` lifestyle adjustments (flea/tick entries and heartworm prevention presence).
- Add an end-to-end `update_health_status` test that asserts `overall_score`, `priority_alerts`, `upcoming_care`, and `recommendations` for a realistic profile including vaccinations, dewormings, appointments, and medication reminders.
- Add tests for `calculate_next_appointment_recommendation` covering puppy, adult, and senior/chronic-condition cadence changes and expected `days_until`/`urgency` values.

### Testing
- Ran `ruff check tests/components/pawcontrol/test_health_enhancements.py` and `ruff format --check tests/components/pawcontrol/test_health_enhancements.py` which passed after formatting fixes.
- Executed `pytest -q -p no:hypothesispytest tests/components/pawcontrol/test_health_enhancements.py` and the new test suite passed.
- Note: in this environment pytest was run with `-p no:hypothesispytest` because a local `hypothesis/` package in the repository shadows the third-party Hypothesis plugin import path, so the plugin is disabled to avoid import conflicts.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c0facb483318a151a436d17a10d)