### PR TITLE
tests: add coverage for coordinate validation error branches

### DIFF
--- a/tests/unit/test_validation_helpers_module.py
+++ b/tests/unit/test_validation_helpers_module.py
@@ -96,3 +96,14 @@ def test_safe_validate_interval_returns_default_on_validation_errors() -> None:
         )
         == 15
     )
+
+
+def test_format_coordinate_validation_error_out_of_range_without_bounds() -> None:
+    error = ValidationError("gps_latitude", "bad", "coordinate_out_of_range")
+
+    assert format_coordinate_validation_error(error) == "gps latitude is out of range"
+
+
+def test_validate_service_coordinates_raises_for_non_numeric_longitude() -> None:
+    with pytest.raises(ServiceValidationError, match="longitude must be a number"):
+        validate_service_coordinates(45.0, "west")


### PR DESCRIPTION
### Motivation
- Increase branch coverage for coordinate validation helpers and verify user-facing error messages for out-of-range and non-numeric inputs.

### Description
- Add two unit tests to `tests/unit/test_validation_helpers_module.py` that verify `format_coordinate_validation_error` falls back to a plain "out of range" message when no bounds are present and that `validate_service_coordinates` raises a `ServiceValidationError` for a non-numeric longitude.

### Testing
- Ran `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/unit/test_validation_helpers_module.py` which succeeded (`10 passed`).
- Ran `ruff format tests/unit/test_validation_helpers_module.py` and `ruff check tests/unit/test_validation_helpers_module.py` which both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c0facb483318a151a436d17a10d)