### PR TITLE
Add coordinator rejection metrics wrapper coverage

### DIFF
--- a/tests/unit/test_coordinator_tasks.py
+++ b/tests/unit/test_coordinator_tasks.py
@@ -438,6 +438,21 @@ def test_derive_rejection_metrics_handles_missing_summary() -> None:
     assert tasks.derive_rejection_metrics({}) == tasks.default_rejection_metrics()
 
 
+def test_derive_rejection_metrics_wrapper_matches_public_helper() -> None:
+    """Legacy wrapper should delegate to ``derive_rejection_metrics`` unchanged."""
+    summary = {
+        "rejected_call_count": "7",
+        "rejection_breaker_count": "2",
+        "rejection_rate": "0.5",
+        "open_breakers": ["alpha"],
+        "half_open_breakers": [],
+    }
+
+    assert tasks._derive_rejection_metrics(summary) == tasks.derive_rejection_metrics(
+        summary
+    )
+
+
 def test_collect_resilience_diagnostics_persists_summary(monkeypatch) -> None:
     """Collected resilience summaries should persist into runtime performance stats."""
     breaker = SimpleNamespace(


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for a legacy wrapper to lock in backward-compatible behavior for rejection metrics extraction.

### Description
- Add a focused unit test in `tests/unit/test_coordinator_tasks.py` that asserts `_derive_rejection_metrics(summary)` returns the same result as `derive_rejection_metrics(summary)` for a representative payload.

### Testing
- Ran `pytest -q -o addopts='' -p no:hypothesispytest tests/unit/test_coordinator_tasks.py` and the suite passed (`35 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d91c0facb483318a151a436d17a10d)