### PR TITLE
Add tests for translation_helpers cache and async fallback branches

### DIFF
--- a/tests/components/pawcontrol/test_health_enhancements.py
+++ b/tests/components/pawcontrol/test_health_enhancements.py
@@ -1,7 +1,5 @@
 """Coverage tests for enhanced health scheduling and status evaluation."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 
 import pytest

--- a/tests/unit/test_translation_helpers_cache_additional.py
+++ b/tests/unit/test_translation_helpers_cache_additional.py
@@ -73,7 +73,9 @@ async def test_async_get_component_translations_uses_bundled_fallback_on_excepti
 
 @pytest.mark.asyncio
 @pytest.mark.unit
-async def test_async_get_component_translation_lookup_reuses_same_mapping_for_en() -> None:
+async def test_async_get_component_translation_lookup_reuses_same_mapping_for_en() -> (
+    None
+):
     hass = SimpleNamespace(data={})
 
     first = await helpers.async_get_component_translations(hass, "en")

--- a/tests/unit/test_translation_helpers_cache_additional.py
+++ b/tests/unit/test_translation_helpers_cache_additional.py
@@ -1,0 +1,95 @@
+"""Additional coverage tests for translation helper cache and async fallback paths."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.pawcontrol import translation_helpers as helpers
+
+
+@pytest.mark.unit
+def test_get_translation_cache_initializes_invalid_hass_data() -> None:
+    hass = SimpleNamespace(data="invalid")
+
+    cache = helpers._get_translation_cache(hass)
+
+    assert isinstance(cache, dict)
+    assert helpers.DOMAIN in hass.data
+    assert hass.data[helpers.DOMAIN]["translations"] is cache
+
+
+@pytest.mark.unit
+def test_resolve_translation_legacy_key_fallback() -> None:
+    full_key = helpers.component_translation_key("walk_status")
+
+    resolved = helpers.resolve_translation(
+        {"walk_status": "Walk status"},
+        {},
+        full_key,
+    )
+
+    assert resolved == "Walk status"
+
+
+@pytest.mark.unit
+def test_load_bundled_component_translations_cached_ignores_non_string_values(
+    tmp_path,
+) -> None:
+    translations_dir = tmp_path / "translations"
+    translations_dir.mkdir()
+    (translations_dir / "en.json").write_text(
+        '{"common": {"valid": "yes", "invalid": 5, "other": null}}',
+        encoding="utf-8",
+    )
+
+    helpers._load_bundled_component_translations.cache_clear()
+    resolved = helpers._load_bundled_component_translations_cached("en", str(tmp_path))
+
+    assert resolved == {helpers.component_translation_key("valid"): "yes"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_async_get_component_translations_uses_bundled_fallback_on_exception(
+    monkeypatch,
+) -> None:
+    hass = SimpleNamespace(data={})
+
+    async def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(helpers, "async_get_translations", _raise)
+    monkeypatch.setattr(
+        helpers,
+        "_load_bundled_component_translations",
+        lambda _lang: {helpers.component_translation_key("status"): "OK"},
+    )
+
+    resolved = await helpers.async_get_component_translations(hass, "de")
+
+    assert resolved == {helpers.component_translation_key("status"): "OK"}
+    assert hass.data[helpers.DOMAIN]["translations"]["de"] == resolved
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_async_get_component_translation_lookup_reuses_same_mapping_for_en() -> None:
+    hass = SimpleNamespace(data={})
+
+    first = await helpers.async_get_component_translations(hass, "en")
+    second, fallback = await helpers.async_get_component_translation_lookup(hass, "en")
+
+    assert second == first
+    assert fallback is second
+
+
+@pytest.mark.asyncio
+@pytest.mark.unit
+async def test_async_preload_component_translations_populates_all_languages() -> None:
+    hass = SimpleNamespace(data={})
+
+    await helpers.async_preload_component_translations(hass, ["de", "en", None])
+
+    cache = hass.data[helpers.DOMAIN]["translations"]
+    assert "de" in cache
+    assert "en" in cache


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for `translation_helpers` by exercising cache initialization, legacy-key resolution, bundled translation parsing, and async fallback paths that can occur when Home Assistant translation APIs fail.

### Description
- Add `tests/unit/test_translation_helpers_cache_additional.py` with tests for `_get_translation_cache` initialization when `hass.data` is malformed, `resolve_translation` legacy-key fallback, `_load_bundled_component_translations_cached` filtering of non-string values, `async_get_component_translations` fallback on exception, `async_get_component_translation_lookup` identity behavior for English, and `async_preload_component_translations` cache population.
- No production code changes were made; this is a test-only PR.

### Testing
- Ran `python -m pytest -o addopts='' -q tests/unit/test_translation_helpers_cache_additional.py` and the new test module completed successfully with `6 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d948f2c61883318a73be6f3082bb51)