### PR TITLE
test: add config flow monitor coverage for exception path

### DIFF
--- a/tests/unit/test_config_flow_monitor.py
+++ b/tests/unit/test_config_flow_monitor.py
@@ -92,3 +92,29 @@ async def test_timed_operation_warns_for_slow_operations(
             pass
 
     assert "Slow config flow operation: discovery took 3.50s" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_timed_operation_records_duration_when_block_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Timed operations should record durations even when the wrapped block fails."""
+    from custom_components.pawcontrol import config_flow_monitor as monitor_module
+
+    monitor_module.config_flow_monitor = ConfigFlowPerformanceMonitor()
+    timeline = [20.0, 20.25]
+
+    def fake_monotonic() -> float:
+        if timeline:
+            return timeline.pop(0)
+        return 20.25
+
+    monkeypatch.setattr(monitor_module.time, "monotonic", fake_monotonic)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        async with timed_operation("failing-step"):
+            raise RuntimeError("boom")
+
+    stats = monitor_module.config_flow_monitor.get_stats()
+    assert stats["operations"]["failing-step"]["count"] == 1
+    assert stats["operations"]["failing-step"]["avg_time"] == pytest.approx(0.25)


### PR DESCRIPTION
### Motivation
- Improve branch coverage for `timed_operation` by exercising the `finally` path when the wrapped async block raises an exception so timing metrics are still persisted.

### Description
- Add `test_timed_operation_records_duration_when_block_raises` to `tests/unit/test_config_flow_monitor.py` which patches `time.monotonic`, raises a `RuntimeError` inside the `async with timed_operation(...)` block, and asserts the operation metrics (`count` and `avg_time`) were recorded while the original exception propagates.

### Testing
- Ran `pytest -q -o addopts='' tests/unit/test_config_flow_monitor.py` and the suite passed (`5 passed`).
- Ran `ruff check tests/unit/test_config_flow_monitor.py` with no lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d948f2c61883318a73be6f3082bb51)