### PR TITLE
Add tests for CacheRepairAggregate mapping protocol coverage

### DIFF
--- a/tests/components/pawcontrol/test_types_coverage.py
+++ b/tests/components/pawcontrol/test_types_coverage.py
@@ -510,6 +510,21 @@ def test_cache_repair_aggregate_to_mapping_omits_empty_optional_sections() -> No
     }
 
 
+def test_cache_repair_aggregate_mapping_protocol_helpers() -> None:
+    """Mapping protocol dunder methods should proxy to ``to_mapping`` output."""
+    aggregate = types.CacheRepairAggregate(
+        total_caches=3,
+        anomaly_count=1,
+        severity="minor",
+        generated_at="2026-03-02T00:00:00+00:00",
+        caches_with_errors=["cache_a"],
+    )
+
+    assert aggregate["severity"] == "minor"
+    assert list(iter(aggregate)) == list(aggregate.to_mapping())
+    assert len(aggregate) == len(aggregate.to_mapping())
+
+
 def test_ensure_dog_options_entry_prefers_payload_dog_id_and_normalizes_notifications() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Exercise and increase coverage for `CacheRepairAggregate` mapping-protocol helpers so the `__getitem__`, `__iter__`, and `__len__` dunder paths are validated.

### Description
- Add `test_cache_repair_aggregate_mapping_protocol_helpers` to `tests/components/pawcontrol/test_types_coverage.py` which constructs a `CacheRepairAggregate` and asserts its `__getitem__`, `__iter__`, and `__len__` behavior matches the output of `to_mapping()`.

### Testing
- Ran `python -m pytest -o addopts='' tests/components/pawcontrol/test_types_coverage.py`, and the file's test suite passed (`42 passed`, run completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d948f2c61883318a73be6f3082bb51)