### PR TITLE
Increase module adapter cache branch coverage

### DIFF
--- a/tests/components/pawcontrol/test_module_adapters_helpers.py
+++ b/tests/components/pawcontrol/test_module_adapters_helpers.py
@@ -100,6 +100,24 @@ def test_expiring_cache_cleanup_and_clear(monkeypatch) -> None:
     assert cache.metadata() == {"ttl_seconds": 10.0}
 
 
+def test_expiring_cache_cleanup_reports_last_cleanup_when_nothing_expires(
+    monkeypatch,
+) -> None:
+    start = datetime(2026, 1, 1, tzinfo=UTC)
+    monkeypatch.setattr(module_adapters, "dt_util", _FrozenTime(start))
+    cache = _ExpiringCache[str](ttl=timedelta(seconds=10))
+    cache.set("fresh", "value")
+
+    expired = cache.cleanup(start + timedelta(seconds=5))
+
+    assert expired == 0
+    assert cache.metadata() == {
+        "ttl_seconds": 10.0,
+        "last_cleanup": start + timedelta(seconds=5),
+        "last_expired_count": 0,
+    }
+
+
 def test_expiring_cache_get_evicts_expired_entries(monkeypatch) -> None:
     start = datetime(2026, 1, 1, tzinfo=UTC)
     cache = _ExpiringCache[str](ttl=timedelta(seconds=5))
@@ -152,6 +170,22 @@ def test_base_module_adapter_snapshot_sets_ttl_metadata(monkeypatch) -> None:
         "stats": {"entries": 1, "hits": 0, "misses": 0, "hit_rate": 0.0},
         "metadata": {"ttl_seconds": 30.0},
     }
+
+
+def test_base_module_adapter_snapshot_keeps_existing_ttl_metadata(monkeypatch) -> None:
+    adapter = _DummyAdapter(ttl=timedelta(seconds=30))
+    assert adapter._cache is not None
+
+    monkeypatch.setattr(
+        module_adapters._ExpiringCache,
+        "snapshot",
+        lambda self: {
+            "stats": {"entries": 1, "hits": 0, "misses": 0, "hit_rate": 0.0},
+            "metadata": {"ttl_seconds": 5.0},
+        },
+    )
+
+    assert adapter.cache_snapshot()["metadata"]["ttl_seconds"] == 5.0
 
 
 def test_normalise_health_alert_defaults_and_details() -> None:


### PR DESCRIPTION
### Motivation
- Ensure branch coverage and prevent regressions by testing metadata updates in the module adapter caches for edge conditions that were previously unverified.

### Description
- Added `test_expiring_cache_cleanup_reports_last_cleanup_when_nothing_expires` to `tests/components/pawcontrol/test_module_adapters_helpers.py` which asserts `_ExpiringCache.cleanup()` records `last_cleanup` and `last_expired_count` when no entries expire.
- Added `test_base_module_adapter_snapshot_keeps_existing_ttl_metadata` to `tests/components/pawcontrol/test_module_adapters_helpers.py` which asserts `_BaseModuleAdapter.cache_snapshot()` preserves `ttl_seconds` supplied by the underlying cache metadata.

### Testing
- Ran the targeted test selection with plugin autoload disabled using `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -o addopts='' tests/components/pawcontrol/test_module_adapters_helpers.py -k 'cleanup_reports_last_cleanup or keeps_existing_ttl_metadata'` and the two new tests passed (2 passed, 27 deselected).
- Running the full test file without disabling plugin autoload exposed environment-specific failures (aiohttp `ClientSession` async-context behaviour and a missing Hypothesis internal import) that are unrelated to these patches.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da867c1e508331b7f0c6b94177e9b9)