### PR TITLE
Increase utils serialization coverage for lazy exports

### DIFF
--- a/tests/components/pawcontrol/test_utils_serialize.py
+++ b/tests/components/pawcontrol/test_utils_serialize.py
@@ -150,3 +150,26 @@ def test_module_reload_skips_re_export_when_parent_module_missing(
     )
 
     assert namespace["serialize_datetime"] is not None
+
+
+def test_utils_package_getattr_resolves_serialize_helpers() -> None:
+    """Utils package should lazily expose serialize helpers via __getattr__."""
+    utils_module = importlib.import_module("custom_components.pawcontrol.utils")
+    serialize_module = importlib.import_module(
+        "custom_components.pawcontrol.utils.serialize"
+    )
+
+    assert utils_module.__getattr__("serialize_datetime") is (
+        serialize_module.serialize_datetime
+    )
+    assert utils_module.__getattr__("serialize_timedelta") is (
+        serialize_module.serialize_timedelta
+    )
+
+
+def test_utils_package_getattr_raises_for_unknown_attributes() -> None:
+    """Utils package should raise AttributeError for unsupported names."""
+    utils_module = importlib.import_module("custom_components.pawcontrol.utils")
+
+    with pytest.raises(AttributeError, match="not_a_real_export"):
+        utils_module.__getattr__("not_a_real_export")


### PR DESCRIPTION
### Motivation
- Add focused unit coverage for the lazy export path in the `custom_components.pawcontrol.utils` package to ensure `serialize` helpers are resolved correctly and unknown names raise predictable errors.

### Description
- Added two tests to `tests/components/pawcontrol/test_utils_serialize.py` that assert `custom_components.pawcontrol.utils.__getattr__` resolves `serialize_datetime`/`serialize_timedelta` to the implementations in `custom_components.pawcontrol.utils.serialize` and that unknown attributes raise `AttributeError`.

### Testing
- Ran the focused test file with: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q -p pytest_cov -o addopts='' tests/components/pawcontrol/test_utils_serialize.py --cov=custom_components/pawcontrol/utils/__init__.py --cov=custom_components/pawcontrol/utils/serialize.py --cov-branch --cov-report=term-missing`, and all tests passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da880fea148331bb35f498facc054b)