### PR TITLE
Improve profile selection fallback coverage

### DIFF
--- a/custom_components/pawcontrol/config_flow_profile.py
+++ b/custom_components/pawcontrol/config_flow_profile.py
@@ -61,7 +61,8 @@ def validate_profile_selection(user_input: ProfileSelectionInput) -> str:
     except vol.Invalid as err:  # pragma: no cover - exercised by HA UI
         raise vol.Invalid("invalid_profile") from err
 
-    profile = cast(str, profile_data["entity_profile"])
+    selected_profile = profile_data.get("entity_profile", DEFAULT_PROFILE)
+    profile = cast(str, selected_profile)
     if profile not in ENTITY_PROFILES:
         # This should never happen because of the schema, but keeping this
         # guard makes mypy and future refactors happier.

--- a/tests/unit/test_config_flow_profile.py
+++ b/tests/unit/test_config_flow_profile.py
@@ -18,6 +18,14 @@ def test_validate_profile_selection_accepts_known_profile() -> None:
     )
 
 
+def test_validate_profile_selection_defaults_when_missing() -> None:
+    """Missing profile selections should resolve to the configured default."""
+    assert (
+        config_flow_profile.validate_profile_selection({})
+        == config_flow_profile.DEFAULT_PROFILE
+    )
+
+
 def test_validate_profile_selection_rejects_unknown_profile() -> None:
     """Unknown profiles should raise a normalized voluptuous error."""
     with pytest.raises(vol.Invalid, match="invalid_profile"):


### PR DESCRIPTION
### Motivation
- Prevent a `KeyError` when the schema-normalized `PROFILE_SCHEMA` output lacks `entity_profile` by ensuring validation gracefully falls back to the configured default profile.

### Description
- Replace direct indexing of `profile_data["entity_profile"]` with a safe `profile_data.get("entity_profile", DEFAULT_PROFILE)` in `custom_components/pawcontrol/config_flow_profile.py` and add a focused unit test `test_validate_profile_selection_defaults_when_missing` in `tests/unit/test_config_flow_profile.py` to cover the fallback path.

### Testing
- Ran `pytest -q -n 0 -p no:hypothesispytest tests/unit/test_config_flow_profile.py` and `pytest -q -n 0 -p no:hypothesispytest tests/components/pawcontrol/test_config_flow_profile.py::test_validate_profile_selection_returns_default_when_missing`, and both succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da880fea148331bb35f498facc054b)