### PR TITLE
Add tests for normalize_language supported-set edge cases

### DIFF
--- a/tests/components/pawcontrol/test_language.py
+++ b/tests/components/pawcontrol/test_language.py
@@ -60,3 +60,22 @@ def test_normalize_language_ignores_blank_supported_entries() -> None:
 
     assert normalize_language("en-GB", supported=supported, default="fr") == "en"
     assert normalize_language("it", supported=supported, default="fr") == "fr"
+
+
+def test_normalize_language_accepts_values_when_supported_missing() -> None:
+    """Without a supported set, normalized values should pass through."""
+    assert normalize_language("  ES-mx  ", supported=None, default="en") == "es"
+
+
+def test_normalize_language_rejects_language_not_in_normalized_supported_set() -> None:
+    """Normalized supported values should enforce the fallback when unmatched."""
+    supported = {" _ ", "DE_de"}
+
+    assert normalize_language("pt-BR", supported=supported, default="en-US") == "en"
+
+
+def test_normalize_language_handles_none_entries_inside_supported_collection() -> None:
+    """Non-string supported entries that normalize empty should be ignored."""
+    supported: set[str | None] = {None, "fr-FR"}
+
+    assert normalize_language("fr-CA", supported=supported, default="en") == "fr"


### PR DESCRIPTION
### Motivation
- Increase branch coverage around `normalize_language` handling for edge cases in the `supported` collection so language-selection behavior is well-specified.

### Description
- Add three focused tests in `tests/components/pawcontrol/test_language.py` that cover pass-through behavior when `supported` is `None`, fallback behavior when the normalized input is not present in the normalized `supported` set, and robustness when `supported` contains `None` entries.
- Adjusted the new test name to satisfy linting constraints (line-length) and keep the assertions behavior-focused on normalized outcomes.

### Testing
- Ran `ruff check tests/components/pawcontrol/test_language.py` which passed without errors.
- Ran `pytest -o addopts='' tests/components/pawcontrol/test_language.py -q` and observed `12 passed` for the file-level test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da880fea148331bb35f498facc054b)