### PR TITLE
Add check-mode no-op coverage for contributor guide sync

### DIFF
--- a/tests/unit/test_sync_contributor_guides.py
+++ b/tests/unit/test_sync_contributor_guides.py
@@ -123,3 +123,22 @@ def test_main_reports_when_already_synced(tmp_path: Path, monkeypatch, capsys) -
     output = capsys.readouterr().out
     assert result == 0
     assert "already match" in output
+
+
+def test_main_check_mode_reports_when_already_synced(
+    tmp_path: Path, monkeypatch, capsys
+) -> None:
+    """Check mode should still return success for already-synced guides."""
+    canonical = tmp_path / "canonical.md"
+    target = tmp_path / "target.md"
+    _write(canonical, "new text\n")
+    _write(target, "<!-- SYNC:START -->\nnew text\n<!-- SYNC:END -->\n")
+    monkeypatch.setattr(sync_contributor_guides, "CANONICAL_SOURCE", canonical)
+    monkeypatch.setattr(sync_contributor_guides, "TARGETS", [target])
+    monkeypatch.setattr("sys.argv", ["sync_contributor_guides.py", "--check"])
+
+    result = sync_contributor_guides.main()
+
+    output = capsys.readouterr().out
+    assert result == 0
+    assert "already match" in output


### PR DESCRIPTION
### Motivation
- Ensure `scripts.sync_contributor_guides.main()` `--check` branch is covered when targets are already synchronized so the no-op check path is tested.

### Description
- Add unit test `test_main_check_mode_reports_when_already_synced` in `tests/unit/test_sync_contributor_guides.py` that invokes `sync_contributor_guides.main()` with `--check` and verifies it returns `0` and emits the existing "already match" message.

### Testing
- Ran `python -m pytest -o addopts='' tests/unit/test_sync_contributor_guides.py` and the file's test suite passed (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da89c51f808331a30415ac5a86a567)