### PR TITLE
test: increase validation helper coverage for edge inputs

### DIFF
--- a/tests/components/pawcontrol/test_validation_core_helpers.py
+++ b/tests/components/pawcontrol/test_validation_core_helpers.py
@@ -152,6 +152,16 @@ def test_validate_time_window_uses_defaults_and_required_constraints() -> None:
         )
 
 
+def test_validate_time_window_accepts_native_time_objects() -> None:
+    """Native ``datetime.time`` inputs should be serialized without errors."""
+    assert validate_time_window(
+        dt_time(6, 5),
+        dt_time(22, 45),
+        start_field="start",
+        end_field="end",
+    ) == ("06:05:00", "22:45:00")
+
+
 def test_validate_name_and_float_constraint_helpers() -> None:
     """Name and float coercion helpers should normalize and map constraints."""
     assert validate_name("  Buddy  ") == "Buddy"
@@ -224,3 +234,17 @@ def test_validate_dog_name_rejects_length_and_type_errors() -> None:
 
     with pytest.raises(ValidationError, match="dog_name_too_long"):
         validate_dog_name("A" * 65)
+
+
+def test_validate_dog_name_rejects_untrimmed_payload_exceeding_max_length() -> None:
+    """Inputs exceeding max length before trimming should still fail deterministically."""
+    with pytest.raises(ValidationError, match="dog_name_too_long"):
+        validate_dog_name(f"{'A' * 63}   ")
+
+
+def test_validate_notification_targets_treats_bytes_payload_as_scalar() -> None:
+    """Byte payloads should go through the scalar fallback and be marked invalid."""
+    parsed = validate_notification_targets(b"push", enum_type=_Target)
+
+    assert parsed.targets == []
+    assert parsed.invalid == ["b'push'"]


### PR DESCRIPTION
### Motivation

- Improve unit test coverage for core validation helpers that are exercised in high-frequency and user-facing flows. 
- Target deterministic edge cases that previously lacked explicit assertions (native `datetime.time` inputs, untrimmed oversized names, and byte payloads for notification targets).

### Description

- Added `test_validate_time_window_accepts_native_time_objects` in `tests/components/pawcontrol/test_validation_core_helpers.py` to assert `validate_time_window` accepts `datetime.time` and returns normalized ISO time strings. 
- Added `test_validate_dog_name_rejects_untrimmed_payload_exceeding_max_length` to verify `validate_dog_name` deterministically rejects inputs that exceed max length even when padded with whitespace. 
- Added `test_validate_notification_targets_treats_bytes_payload_as_scalar` to assert `validate_notification_targets` treats `bytes` payloads as scalar fallbacks and records them as invalid targets.

### Testing

- Ran `pytest tests/components/pawcontrol/test_validation_core_helpers.py` which initially failed during terminal summary due to an unrelated Hypothesis plugin/import mismatch (`ModuleNotFoundError: hypothesis.internal`). 
- Verified the updated tests successfully with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -o addopts='' tests/components/pawcontrol/test_validation_core_helpers.py`, producing `17 passed` for the modified test file. 
- No production code was modified; only test coverage was extended and validated with the commands above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da89c51f808331a30415ac5a86a567)