### PR TITLE
Increase services coverage for service-result guard branches

### DIFF
--- a/tests/components/pawcontrol/test_services_error_paths.py
+++ b/tests/components/pawcontrol/test_services_error_paths.py
@@ -18,6 +18,7 @@ from custom_components.pawcontrol.exceptions import (
     HomeAssistantError,
     ServiceValidationError,
 )
+from custom_components.pawcontrol.service_guard import ServiceGuardResult
 
 
 async def _register_services_and_get_handler(
@@ -391,6 +392,48 @@ def test_given_record_service_result_when_rejections_exist_then_include_details(
     result = runtime_data.performance_stats["last_service_result"]
     assert result["details"]["resilience"]["rejected_call_count"] == 2
     assert result["status"] == "error"
+
+
+def test_given_record_service_result_when_performance_stats_missing_then_noop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When runtime performance stats are unavailable the helper should no-op."""
+    runtime_data = SimpleNamespace(performance_stats={"sentinel": True})
+    monkeypatch.setattr(services, "get_runtime_performance_stats", lambda _: None)
+
+    services._record_service_result(
+        runtime_data,
+        service="send_notification",
+        status="error",
+        details={"source": "test"},
+    )
+
+    assert runtime_data.performance_stats == {"sentinel": True}
+
+
+def test_record_service_result_ignores_non_guard_entries() -> None:
+    """Guard metrics should only count ServiceGuardResult entries."""
+    runtime_data = SimpleNamespace(performance_stats={})
+
+    services._record_service_result(
+        runtime_data,
+        service="send_notification",
+        status="success",
+        guard=[
+            ServiceGuardResult(
+                domain="notify",
+                service="mobile_app",
+                executed=False,
+                reason="missing_service",
+            ),
+            "not-a-guard-entry",
+        ],
+    )
+
+    result = runtime_data.performance_stats["last_service_result"]
+    assert result["guard"]["executed"] == 0
+    assert result["guard"]["skipped"] == 1
+    assert result["details"]["guard"]["reasons"]["missing_service"] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
### Motivation
- Close coverage gaps in `services.py` telemetry by exercising early-return branches and guard-aggregation logic in `_record_service_result` so service telemetry remains robust for malformed runtime state or mixed guard sequences.

### Description
- Add import of `ServiceGuardResult` and two tests in `tests/components/pawcontrol/test_services_error_paths.py` that exercise `_record_service_result` behaviour when runtime performance stats cannot be resolved and when the `guard` sequence mixes valid and invalid entries.
- The new tests assert that the helper no-ops when performance stats are unavailable and that only `ServiceGuardResult` items are included in aggregated guard metrics (ignoring non-guard entries).

### Testing
- Ran linting on the modified file with `ruff check tests/components/pawcontrol/test_services_error_paths.py` which passed after minor formatting adjustments. 
- Executed the focused pytest selection with `pytest -q -o addopts='-p no:pytest_cov -p pytest_cov.plugin' tests/components/pawcontrol/test_services_error_paths.py -k 'performance_stats_missing or ignores_non_guard_entries'` and observed `2 passed, 26 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da916dc04483319479a1219008e9e2)