### PR TITLE
Increase compat coverage and add Hypothesis observability shim

### DIFF
--- a/hypothesis/internal/__init__.py
+++ b/hypothesis/internal/__init__.py
@@ -1,0 +1,1 @@
+"""Internal compatibility modules for the local Hypothesis shim."""

--- a/hypothesis/internal/observability.py
+++ b/hypothesis/internal/observability.py
@@ -1,0 +1,3 @@
+"""Observability compatibility state used by pytest's Hypothesis plugin."""
+
+_WROTE_TO: set[str] = set()

--- a/tests/components/pawcontrol/test_compat_coverage.py
+++ b/tests/components/pawcontrol/test_compat_coverage.py
@@ -94,3 +94,46 @@ def test_build_subentries_normalizes_defaults_and_raw_values() -> None:
     assert second.subentry_type == "dog"
     assert second.title == "Bravo"
     assert second.unique_id == "42"
+
+
+def test_notify_callbacks_ignores_callback_failures() -> None:
+    """Callback fanout should continue even if one callback raises."""
+    events: list[dict[str, type[Exception]]] = []
+
+    def _capture(mapping: dict[str, type[Exception]]) -> None:
+        events.append(mapping)
+
+    def _explode(_: dict[str, type[Exception]]) -> None:
+        raise RuntimeError("boom")
+
+    unregister_capture = compat.register_exception_rebind_callback(_capture)
+    compat._EXCEPTION_REBIND_CALLBACKS.append(_explode)
+
+    compat._notify_exception_callbacks()
+
+    assert events
+    compat._EXCEPTION_REBIND_CALLBACKS.remove(_explode)
+    unregister_capture()
+
+
+def test_bind_exception_alias_skips_when_source_missing() -> None:
+    """Alias binding should leave target untouched when source key is absent."""
+    module_name = "test_bind_exception_alias_missing_source"
+    module = ModuleType(module_name)
+    module.AliasError = RuntimeError
+    sys.modules[module_name] = module
+
+    unregister = compat.bind_exception_alias(
+        "ConfigEntryError",
+        module=module,
+        attr="AliasError",
+    )
+
+    callbacks = list(compat._EXCEPTION_REBIND_CALLBACKS)
+    assert callbacks
+
+    callbacks[-1]({})
+    assert module.AliasError is compat.ConfigEntryError
+
+    unregister()
+    sys.modules.pop(module_name, None)


### PR DESCRIPTION
### Motivation
- Improve branch/path coverage for the compatibility helpers in `custom_components/pawcontrol.compat` and stop pytest's Hypothesis terminal-summary hook from crashing against the repository's local Hypothesis shim.

### Description
- Add focused tests to `tests/components/pawcontrol/test_compat_coverage.py` that exercise exception-callback fanout resilience and alias-binding behavior when source mappings are missing.
- Add a minimal internal Hypothesis compatibility module at `hypothesis/internal/observability.py` that exposes `_WROTE_TO` so the `_hypothesis_pytestplugin` terminal-summary hook no longer fails.
- Adjust the new test to avoid letting a registered callback raise during registration by appending a failing callback to `compat._EXCEPTION_REBIND_CALLBACKS` so `compat._notify_exception_callbacks()` can be asserted to continue on error.

### Testing
- Ran `ruff format` and `ruff check` on the changed files and they succeeded.
- Ran `pytest -q -n0 tests/components/pawcontrol/test_compat_coverage.py` and the suite passed (7 tests).
- Ran coverage against `custom_components/pawcontrol/compat.py` with `pytest -n0 tests/components/pawcontrol/test_compat_coverage.py --cov=custom_components/pawcontrol/compat.py --cov-branch --cov-report=term-missing` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da916dc04483319479a1219008e9e2)