### PR TITLE
Add tests to increase coverage for legacy exception guard

### DIFF
--- a/tests/unit/test_check_legacy_exception_syntax.py
+++ b/tests/unit/test_check_legacy_exception_syntax.py
@@ -1,0 +1,85 @@
+"""Tests for scripts.check_legacy_exception_syntax."""
+
+from argparse import Namespace
+from pathlib import Path
+
+from scripts import check_legacy_exception_syntax as module
+
+
+def test_find_legacy_handlers_detects_python2_multi_exception(tmp_path: Path) -> None:
+    """Legacy comma-separated handlers should be reported with line numbers."""
+    source = tmp_path / "legacy_sample.py"
+    source.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    pass",
+                "except ValueError, TypeError:",
+                "    pass",
+                "except (ValueError, TypeError):",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert module._find_legacy_handlers(source) == [3]
+
+
+def test_main_skips_missing_paths_and_succeeds(
+    monkeypatch: object, capsys: object
+) -> None:
+    """Missing paths should be skipped without failing the guard."""
+    monkeypatch.setattr(module, "_parse_args", lambda: Namespace(paths=["missing.py"]))
+
+    assert module.main() == 0
+    output = capsys.readouterr().out
+    assert "Skipping missing path" in output
+    assert "No legacy multi-exception syntax found." in output
+
+
+def test_main_reports_findings_for_single_file(
+    tmp_path: Path, monkeypatch: object, capsys: object
+) -> None:
+    """A Python file path should be scanned directly and fail when syntax is present."""
+    source = tmp_path / "legacy_handler.py"
+    source.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    pass",
+                "except TypeError, ValueError:",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "_parse_args", lambda: Namespace(paths=[str(source)]))
+
+    assert module.main() == 1
+    output = capsys.readouterr().out
+    assert "Legacy Python 2 multi-exception syntax detected:" in output
+    assert f"{source}:3" in output
+
+
+def test_main_handles_directory_with_no_findings(
+    tmp_path: Path, monkeypatch: object, capsys: object
+) -> None:
+    """Directory scans should pass when all handlers use Python 3 tuple syntax."""
+    source = tmp_path / "modern_handler.py"
+    source.write_text(
+        "\n".join(
+            [
+                "try:",
+                "    pass",
+                "except (TypeError, ValueError):",
+                "    pass",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "_parse_args", lambda: Namespace(paths=[str(tmp_path)]))
+
+    assert module.main() == 0
+    output = capsys.readouterr().out
+    assert "No legacy multi-exception syntax found." in output


### PR DESCRIPTION
### Motivation
- Increase unit test coverage for the legacy Python 2 multi-exception handler detection implemented in `scripts/check_legacy_exception_syntax.py`.
- Ensure the guard behaves correctly for file and directory inputs and that missing paths are skipped without failing CI.

### Description
- Add a new test module `tests/unit/test_check_legacy_exception_syntax.py` that exercises `_find_legacy_handlers` and `main()` paths.
- Verify detection of comma-separated legacy handlers (e.g. `except A, B:`) and ignore modern tuple syntax (e.g. `except (A, B):`).
- Cover `main()` behavior for missing paths (skip + success), direct file scanning that reports findings (failure), and directory scans with no findings (success).

### Testing
- Ran `pytest -q -o addopts='' tests/unit/test_check_legacy_exception_syntax.py` and all tests passed (`4 passed`).
- Ran `ruff check tests/unit/test_check_legacy_exception_syntax.py` and the file passed linting with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da916dc04483319479a1219008e9e2)