### PR TITLE
tests: cover non-finite module history timestamps

### DIFF
--- a/tests/components/pawcontrol/test_data_manager_export_coverage.py
+++ b/tests/components/pawcontrol/test_data_manager_export_coverage.py
@@ -363,3 +363,39 @@ async def test_async_export_data_all_allow_partial_still_surfaces_manifest_io_fa
 
     with pytest.raises(OSError, match="manifest read-only"):
         await manager.async_export_data("buddy", "all", allow_partial=True)
+
+
+@pytest.mark.asyncio
+async def test_async_get_module_history_handles_infinite_numeric_timestamps(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    """Non-finite numeric timestamps should be tolerated during history sorting."""
+    manager = await _create_manager(mock_hass, tmp_path)
+    manager._dog_profiles["buddy"].health_history = [
+        {"timestamp": float("inf"), "status": "future"},
+        {"timestamp": "2026-01-05T07:30:00+00:00", "status": "ok"},
+    ]
+
+    history = await manager.async_get_module_history("health", "buddy")
+
+    assert len(history) == 2
+    assert {entry["status"] for entry in history} == {"future", "ok"}
+
+
+@pytest.mark.asyncio
+async def test_async_get_module_history_handles_nan_numeric_timestamps(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    """NaN timestamps should fall back to an empty sort key instead of crashing."""
+    manager = await _create_manager(mock_hass, tmp_path)
+    manager._dog_profiles["buddy"].health_history = [
+        {"timestamp": float("nan"), "status": "unknown"},
+        {"timestamp": "2026-01-05T07:30:00+00:00", "status": "ok"},
+    ]
+
+    history = await manager.async_get_module_history("health", "buddy")
+
+    assert len(history) == 2
+    assert {entry["status"] for entry in history} == {"unknown", "ok"}


### PR DESCRIPTION
### Motivation
- Close a coverage gap in `custom_components/pawcontrol/data_manager.py` by exercising branches in `async_get_module_history` that encounter non-finite numeric timestamps (e.g. `inf`, `nan`).

### Description
- Add two async tests to `tests/components/pawcontrol/test_data_manager_export_coverage.py` that verify `PawControlDataManager.async_get_module_history` tolerates `float('inf')` and `float('nan')` timestamps and still returns the expected entries. 
- This PR only adds tests and does not change production code or runtime behavior.

### Testing
- Ran the focused test selection with `pytest -q -o addopts='' tests/components/pawcontrol/test_data_manager_export_coverage.py -k 'infinite_numeric_timestamps or nan_numeric_timestamps'`, which passed (`2 passed`).
- Running the entire test file with `pytest -q -o addopts='' tests/components/pawcontrol/test_data_manager_export_coverage.py` in this environment exposed unrelated file-IO expectations that caused other tests in the file to fail, so the PR contains only the targeted passing tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9315495c833183b4670555209257)