### PR TITLE
tests: increase cache coverage for access tracking and decorator key stability

### DIFF
--- a/tests/components/pawcontrol/test_cache.py
+++ b/tests/components/pawcontrol/test_cache.py
@@ -289,20 +289,22 @@ def test_cache_entry_ttl_remaining_is_never_negative() -> None:
     assert entry.ttl_remaining == 0.0
 
 
-def test_cache_entry_mark_accessed_tracks_hits_and_timestamp() -> None:
+def test_cache_entry_mark_accessed_tracks_hits_and_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Marking access should increment hits and refresh last-access time."""
+    monkeypatch.setattr(time, "time", lambda: 100.0)
     entry = cache_module.CacheEntry(
         value="fresh",
-        timestamp=time.time(),
+        timestamp=50.0,
         ttl_seconds=30.0,
-        last_access=1.0,
     )
 
-    before = entry.last_access
+    monkeypatch.setattr(time, "time", lambda: 200.0)
     entry.mark_accessed()
 
     assert entry.hit_count == 1
-    assert entry.last_access >= before
+    assert entry.last_access == 200.0
 
 
 @pytest.mark.asyncio

--- a/tests/components/pawcontrol/test_cache.py
+++ b/tests/components/pawcontrol/test_cache.py
@@ -289,6 +289,22 @@ def test_cache_entry_ttl_remaining_is_never_negative() -> None:
     assert entry.ttl_remaining == 0.0
 
 
+def test_cache_entry_mark_accessed_tracks_hits_and_timestamp() -> None:
+    """Marking access should increment hits and refresh last-access time."""
+    entry = cache_module.CacheEntry(
+        value="fresh",
+        timestamp=time.time(),
+        ttl_seconds=30.0,
+        last_access=1.0,
+    )
+
+    before = entry.last_access
+    entry.mark_accessed()
+
+    assert entry.hit_count == 1
+    assert entry.last_access >= before
+
+
 @pytest.mark.asyncio
 async def test_persistent_cache_load_failure_marks_cache_loaded(
     monkeypatch: pytest.MonkeyPatch,
@@ -316,6 +332,28 @@ async def test_persistent_cache_save_failure_is_swallowed(
     await persistent.async_save()
 
     assert persistent.get_stats().size == 1
+
+
+@pytest.mark.asyncio
+async def test_cached_decorator_kwargs_order_uses_stable_cache_key(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Keyword order should not create duplicate cache entries."""
+    monkeypatch.setattr(cache_module, "Store", _FakeStore)
+    cache = cache_module.TwoLevelCache[int](hass=object(), name="paw")
+    calls: list[tuple[int, int]] = []
+
+    @cache_module.cached(cache, "stable-key", ttl=15)
+    async def combine(*, left: int, right: int) -> int:
+        calls.append((left, right))
+        return left + right
+
+    first = await combine(left=2, right=5)
+    second = await combine(right=5, left=2)
+
+    assert first == 7
+    assert second == 7
+    assert calls == [(2, 5)]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_check_legacy_exception_syntax.py
+++ b/tests/unit/test_check_legacy_exception_syntax.py
@@ -10,16 +10,14 @@ def test_find_legacy_handlers_detects_python2_multi_exception(tmp_path: Path) ->
     """Legacy comma-separated handlers should be reported with line numbers."""
     source = tmp_path / "legacy_sample.py"
     source.write_text(
-        "\n".join(
-            [
-                "try:",
-                "    pass",
-                "except ValueError, TypeError:",
-                "    pass",
-                "except (ValueError, TypeError):",
-                "    pass",
-            ]
-        ),
+        "\n".join([
+            "try:",
+            "    pass",
+            "except ValueError, TypeError:",
+            "    pass",
+            "except (ValueError, TypeError):",
+            "    pass",
+        ]),
         encoding="utf-8",
     )
 
@@ -44,14 +42,12 @@ def test_main_reports_findings_for_single_file(
     """A Python file path should be scanned directly and fail when syntax is present."""
     source = tmp_path / "legacy_handler.py"
     source.write_text(
-        "\n".join(
-            [
-                "try:",
-                "    pass",
-                "except TypeError, ValueError:",
-                "    pass",
-            ]
-        ),
+        "\n".join([
+            "try:",
+            "    pass",
+            "except TypeError, ValueError:",
+            "    pass",
+        ]),
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "_parse_args", lambda: Namespace(paths=[str(source)]))
@@ -68,14 +64,12 @@ def test_main_handles_directory_with_no_findings(
     """Directory scans should pass when all handlers use Python 3 tuple syntax."""
     source = tmp_path / "modern_handler.py"
     source.write_text(
-        "\n".join(
-            [
-                "try:",
-                "    pass",
-                "except (TypeError, ValueError):",
-                "    pass",
-            ]
-        ),
+        "\n".join([
+            "try:",
+            "    pass",
+            "except (TypeError, ValueError):",
+            "    pass",
+        ]),
         encoding="utf-8",
     )
     monkeypatch.setattr(module, "_parse_args", lambda: Namespace(paths=[str(tmp_path)]))


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the cache helpers by validating access-tracking on cache entries and ensuring the async `cached()` decorator generates a stable cache key when kwargs are reordered.

### Description
- Add two focused tests in `tests/components/pawcontrol/test_cache.py`: one verifying `CacheEntry.mark_accessed()` increments `hit_count` and refreshes `last_access`, and one ensuring `cached()` uses a stable key for equivalent keyword-argument orderings to avoid duplicate execution.

### Testing
- Ran `pytest -q tests/components/pawcontrol/test_cache.py` which completed successfully (all tests in the module passed). 
- Ran `ruff check tests/components/pawcontrol/test_cache.py` which returned no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9315495c833183b4670555209257)