### PR TITLE
Increase data manager coverage for overflowing history timestamps

### DIFF
--- a/tests/unit/test_data_manager_additional_coverage.py
+++ b/tests/unit/test_data_manager_additional_coverage.py
@@ -98,3 +98,24 @@ async def test_async_get_module_history_filters_sorts_and_limits() -> None:
 
     assert await manager.async_get_module_history("unknown", "buddy") == []
     assert await manager.async_get_module_history("health", "missing") == []
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_get_module_history_handles_unix_timestamp_overflow() -> None:
+    """History sorting should tolerate overflowing numeric timestamps."""
+    manager = object.__new__(PawControlDataManager)
+
+    manager._dog_profiles = {
+        "buddy": SimpleNamespace(
+            walk_history=[
+                {"end_time": 1e20, "distance": 1.0},
+                {"end_time": 1_700_000_000, "distance": 2.0},
+                {"end_time": "2024-01-01T00:00:00+00:00", "distance": 3.0},
+            ]
+        )
+    }
+
+    history = await manager.async_get_module_history("walk", "buddy")
+
+    assert [entry["distance"] for entry in history] == [3.0, 2.0, 1.0]


### PR DESCRIPTION
### Motivation
- Add targeted coverage for a defensive sorting branch in `PawControlDataManager.async_get_module_history` to ensure mixed timestamp formats (including overflowing numeric timestamps) do not crash sorting logic.

### Description
- Add `test_async_get_module_history_handles_unix_timestamp_overflow` to `tests/unit/test_data_manager_additional_coverage.py` which injects mixed `walk_history` entries (overflowing numeric timestamp, valid Unix timestamp, and ISO8601 string) and asserts deterministic newest-first ordering.

### Testing
- Ran `python -m pytest -q -o addopts='' tests/unit/test_data_manager_additional_coverage.py` and the test suite passed (`4 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9315495c833183b4670555209257)