### PR TITLE
Increase error classification test coverage for explicit mappings

### DIFF
--- a/tests/components/pawcontrol/test_error_classification_coverage.py
+++ b/tests/components/pawcontrol/test_error_classification_coverage.py
@@ -45,3 +45,19 @@ def test_classify_error_reason_handles_exception_error_and_unknown_reason() -> N
     """Unknown reasons with exception objects should still use error hints."""
     error = ConnectionError("Device offline")
     assert classify_error_reason("unmapped", error=error) == "device_unreachable"
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("missing_services_api", "missing_service"),
+        ("service_not_executed", "guard_skipped"),
+        (None, "unknown"),
+    ],
+)
+def test_classify_error_reason_supports_explicit_reason_mappings(
+    reason: str | None,
+    expected: str,
+) -> None:
+    """Mapped reasons should resolve without relying on free-form error hints."""
+    assert classify_error_reason(reason, error=None) == expected


### PR DESCRIPTION
### Motivation
- Improve branch/line coverage for the `classify_error_reason` helper by exercising explicit reason-to-classification mappings and the empty-input fallback.

### Description
- Add a parametrized test in `tests/components/pawcontrol/test_error_classification_coverage.py` that asserts explicit mappings (`missing_services_api` → `missing_service`, `service_not_executed` → `guard_skipped`) and verifies the `reason=None` fallback returns `unknown`.

### Testing
- Ran `PYTEST_ADDOPTS='-n0 -p no:hypothesispytest' pytest tests/components/pawcontrol/test_error_classification_coverage.py -q`, which passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da972e156c8331b1e9808f26abd963)