### PR TITLE
Add targeted coverage for data export failure branches

### DIFF
--- a/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
+++ b/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
@@ -282,7 +282,7 @@ async def test_async_export_data_rejects_unsupported_data_type(
     """Unknown export types should raise a user-facing validation error."""
     manager = await _create_manager(mock_hass, tmp_path)
 
-    with pytest.raises(HomeAssistantError, match="Unsupported export data type"):
+    with pytest.raises(HomeAssistantError, match=r"^Unsupported export data type: sleeping$"):
         await manager.async_export_data("buddy", "sleeping")
 
 

--- a/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
+++ b/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
@@ -251,6 +251,41 @@ async def test_async_export_data_all_allow_partial_captures_homeassistant_and_io
     assert payload["errors"]["routes"].startswith("I/O error: disk offline")
 
 
+@pytest.mark.asyncio
+async def test_async_export_data_all_allow_partial_raises_when_every_export_fails(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    """allow_partial should still fail when no export artifact can be produced."""
+    manager = await _create_manager(mock_hass, tmp_path)
+    manager._get_runtime_data = lambda: SimpleNamespace()  # type: ignore[method-assign]
+    manager._async_add_executor_job = AsyncMock(  # type: ignore[method-assign]
+        side_effect=OSError("disk full"),
+    )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="Failed to export any data type while allow_partial=True",
+    ):
+        await manager.async_export_data(
+            "buddy",
+            "all",
+            allow_partial=True,
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_export_data_rejects_unsupported_data_type(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    """Unknown export types should raise a user-facing validation error."""
+    manager = await _create_manager(mock_hass, tmp_path)
+
+    with pytest.raises(HomeAssistantError, match="Unsupported export data type"):
+        await manager.async_export_data("buddy", "sleeping")
+
+
 def test_cache_repair_summary_classifies_normal_corrupt_and_error_states(
     mock_hass: object,
     tmp_path: Path,

--- a/tests/components/pawcontrol/test_door_sensor_manager_settings.py
+++ b/tests/components/pawcontrol/test_door_sensor_manager_settings.py
@@ -5,16 +5,15 @@ from __future__ import annotations
 from datetime import timedelta
 from types import SimpleNamespace
 
-import pytest
-
 from homeassistant.util import dt as dt_util
+import pytest
 
 from custom_components.pawcontrol.door_sensor_manager import (
     DoorSensorConfig,
     WalkDetectionState,
-    _DoorSensorManagerCacheMonitor,
     _apply_settings_to_config,
     _classify_timestamp,
+    _DoorSensorManagerCacheMonitor,
     _settings_to_payload,
     ensure_door_sensor_settings_config,
 )


### PR DESCRIPTION
### Motivation
- Increase branch coverage for `custom_components/pawcontrol/data_manager.py` export paths by exercising partial-export failure and unsupported-export-type branches.

### Description
- Added two async tests to `tests/components/pawcontrol/test_data_manager_targeted_matrix.py`: `test_async_export_data_all_allow_partial_raises_when_every_export_fails` and `test_async_export_data_rejects_unsupported_data_type`, which simulate executor I/O failures and unknown export types respectively.

### Testing
- Ran `pytest -q -o addopts='' tests/components/pawcontrol/test_data_manager_targeted_matrix.py` and the file completed successfully with `12 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da972e156c8331b1e9808f26abd963)