### PR TITLE
Add test for CoordinatorDataAccessMixin.get_module_data fallback on empty runtime payload

### DIFF
--- a/tests/unit/test_coordinator_accessors.py
+++ b/tests/unit/test_coordinator_accessors.py
@@ -84,6 +84,15 @@ def test_get_module_data_missing_dog_returns_typed_or_untyped_fallback() -> None
     assert coordinator.get_module_data("unknown", "notifications") == {}
 
 
+def test_get_module_data_handles_empty_runtime_payload_for_known_dog() -> None:
+    """Known dogs with empty runtime payloads still use deterministic fallbacks."""
+    coordinator = _DummyCoordinator()
+    coordinator._data["alpha"] = cast(Any, {})
+
+    assert coordinator.get_module_data("alpha", "gps") == {"status": "unknown"}
+    assert coordinator.get_module_data("alpha", "notifications") == {}
+
+
 def test_get_module_data_validates_payload_shape_for_typed_and_untyped_modules() -> (
     None
 ):


### PR DESCRIPTION
### Motivation
- Ensure deterministic fallback behaviour when a known dog has an empty/falsy runtime payload so typed modules return `{"status": "unknown"}` and untyped modules return `{}`.

### Description
- Added a unit test `test_get_module_data_handles_empty_runtime_payload_for_known_dog` in `tests/unit/test_coordinator_accessors.py` that sets a known dog's runtime payload to an empty mapping and asserts typed and untyped fallback results from `CoordinatorDataAccessMixin.get_module_data`.

### Testing
- Ran `pytest -o addopts='' tests/unit/test_coordinator_accessors.py -q` and the test suite passed (`10 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9c4dde688331bf7cf733180e0f84)