### PR TITLE
tests: increase input validation branch coverage

### DIFF
--- a/tests/components/pawcontrol/test_input_validation.py
+++ b/tests/components/pawcontrol/test_input_validation.py
@@ -418,3 +418,40 @@ def test_validate_dict_handles_float_and_url_rules() -> None:
     assert result.is_valid is False
     assert "threshold: Value 10.5 > maximum 5.0" in result.errors
     assert result.sanitized_value == {"endpoint": "https://example.com"}
+
+
+def test_given_dispatch_mapping_to_noncallable_when_validating_then_fallback_to_raw_value() -> (
+    None
+):
+    """Validation dispatch should gracefully fall back when mapping is not callable."""
+    validator = InputValidator()
+    validator._validator_dispatch["custom"] = "validate_missing"
+    schema = {"meta": {"type": "custom"}}
+
+    result = validator.validate_dict({"meta": {"source": "manual"}}, schema)
+
+    assert result.is_valid is True
+    assert result.errors == []
+    assert result.sanitized_value == {"meta": {"source": "manual"}}
+
+
+def test_given_validator_kwargs_when_normalized_then_only_supported_keys_are_forwarded() -> (
+    None
+):
+    """Validator kwargs normalization should drop unsupported schema attributes."""
+    validator = InputValidator()
+    schema = {
+        "count": {
+            "type": "int",
+            "min_value": 1,
+            "max_value": 5,
+            "required": True,
+            "description": "ignored metadata",
+        }
+    }
+
+    result = validator.validate_dict({"count": "3"}, schema)
+
+    assert result.is_valid is True
+    assert result.errors == []
+    assert result.sanitized_value == {"count": 3}


### PR DESCRIPTION
### Motivation

- Close branch-coverage gaps in the input validation helpers by exercising fallback and kwargs-normalisation code paths.

### Description

- Add two targeted unit tests to `tests/components/pawcontrol/test_input_validation.py` that exercise `InputValidator.validate_dict` dispatch fallback when the mapped validator name is non-callable and verify validator kwargs are normalised so only supported keys are forwarded.
- Tests assert behaviour-focused outcomes: the raw value is preserved for unknown/non-callable dispatch entries and numeric schema metadata is ignored while validated values are returned.

### Testing

- Ran the modified test file with `pytest -q -o addopts='' tests/components/pawcontrol/test_input_validation.py`, which completed successfully with `38 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9e070dbc8331895503cbba901bb2)