### PR TITLE
tests: cover async_setup_services failure branches

### DIFF
--- a/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
+++ b/tests/components/pawcontrol/test_data_manager_targeted_matrix.py
@@ -282,7 +282,9 @@ async def test_async_export_data_rejects_unsupported_data_type(
     """Unknown export types should raise a user-facing validation error."""
     manager = await _create_manager(mock_hass, tmp_path)
 
-    with pytest.raises(HomeAssistantError, match=r"^Unsupported export data type: sleeping$"):
+    with pytest.raises(
+        HomeAssistantError, match=r"^Unsupported export data type: sleeping$"
+    ):
         await manager.async_export_data("buddy", "sleeping")
 
 

--- a/tests/components/pawcontrol/test_door_sensor_manager_settings.py
+++ b/tests/components/pawcontrol/test_door_sensor_manager_settings.py
@@ -1,7 +1,5 @@
 """Coverage tests for door sensor settings normalization and diagnostics helpers."""
 
-from __future__ import annotations
-
 from datetime import timedelta
 from types import SimpleNamespace
 

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1948,6 +1948,7 @@ async def test_async_setup_services_propagates_registration_failures(
     with pytest.raises(RuntimeError, match="register boom"):
         await services.async_setup_services(hass)  # type: ignore[arg-type]
 
+
 @pytest.mark.unit
 def test_capture_cache_diagnostics_returns_snapshot() -> None:
     """Helper should normalise diagnostics payloads provided by the data manager."""

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1921,8 +1921,6 @@ async def test_async_setup_services_propagates_registration_failures(
                 raise RuntimeError("register boom")
             super().async_register(domain, service, handler, schema)
 
-    coordinator = _CoordinatorStub(SimpleNamespace())
-    runtime_data = SimpleNamespace(performance_stats={})
     hass = SimpleNamespace(
         services=_FailingServiceRegistry(),
         data={},
@@ -1930,20 +1928,10 @@ async def test_async_setup_services_propagates_registration_failures(
         bus=_BusStub(),
     )
     hass.config_entries = SimpleNamespace(async_entries=lambda _domain: [])
-    coordinator.hass = hass
 
-    monkeypatch.setattr(
-        services,
-        "_coordinator_resolver",
-        lambda _hass: _ResolverStub(coordinator),
-    )
     monkeypatch.setattr(
         services, "async_dispatcher_connect", lambda *args, **kwargs: lambda: None
     )
-    monkeypatch.setattr(
-        services, "async_track_time_change", lambda *args, **kwargs: lambda: None
-    )
-    monkeypatch.setattr(services, "get_runtime_data", lambda *_args: runtime_data)
 
     with pytest.raises(RuntimeError, match="register boom"):
         await services.async_setup_services(hass)  # type: ignore[arg-type]

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1867,6 +1867,88 @@ async def test_async_setup_services_replaces_listener_and_invalidates_on_domain_
 
 
 @pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_setup_services_propagates_dispatcher_connection_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service setup should fail fast when dispatcher hookup crashes."""
+    coordinator = _CoordinatorStub(SimpleNamespace())
+    runtime_data = SimpleNamespace(performance_stats={})
+    hass = SimpleNamespace(
+        services=_ServiceRegistryStub(),
+        data={},
+        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
+        bus=_BusStub(),
+    )
+    hass.config_entries = SimpleNamespace(async_entries=lambda _domain: [])
+    coordinator.hass = hass
+
+    monkeypatch.setattr(
+        services,
+        "_coordinator_resolver",
+        lambda _hass: _ResolverStub(coordinator),
+    )
+    monkeypatch.setattr(
+        services,
+        "async_dispatcher_connect",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("dispatcher boom")),
+    )
+    monkeypatch.setattr(
+        services, "async_track_time_change", lambda *args, **kwargs: lambda: None
+    )
+    monkeypatch.setattr(services, "get_runtime_data", lambda *_args: runtime_data)
+
+    with pytest.raises(RuntimeError, match="dispatcher boom"):
+        await services.async_setup_services(hass)  # type: ignore[arg-type]
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_async_setup_services_propagates_registration_failures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Service setup should surface registration errors from hass service API."""
+
+    class _FailingServiceRegistry(_ServiceRegistryStub):
+        def async_register(
+            self,
+            domain: str,
+            service: str,
+            handler: Callable[..., Awaitable[None]],
+            schema: object | None = None,
+        ) -> None:
+            if service == services.SERVICE_SEND_NOTIFICATION:
+                raise RuntimeError("register boom")
+            super().async_register(domain, service, handler, schema)
+
+    coordinator = _CoordinatorStub(SimpleNamespace())
+    runtime_data = SimpleNamespace(performance_stats={})
+    hass = SimpleNamespace(
+        services=_FailingServiceRegistry(),
+        data={},
+        config=SimpleNamespace(latitude=1.0, longitude=2.0, language="en"),
+        bus=_BusStub(),
+    )
+    hass.config_entries = SimpleNamespace(async_entries=lambda _domain: [])
+    coordinator.hass = hass
+
+    monkeypatch.setattr(
+        services,
+        "_coordinator_resolver",
+        lambda _hass: _ResolverStub(coordinator),
+    )
+    monkeypatch.setattr(
+        services, "async_dispatcher_connect", lambda *args, **kwargs: lambda: None
+    )
+    monkeypatch.setattr(
+        services, "async_track_time_change", lambda *args, **kwargs: lambda: None
+    )
+    monkeypatch.setattr(services, "get_runtime_data", lambda *_args: runtime_data)
+
+    with pytest.raises(RuntimeError, match="register boom"):
+        await services.async_setup_services(hass)  # type: ignore[arg-type]
+
+@pytest.mark.unit
 def test_capture_cache_diagnostics_returns_snapshot() -> None:
     """Helper should normalise diagnostics payloads provided by the data manager."""
     payload = {


### PR DESCRIPTION
### Motivation
- Increase branch coverage for `custom_components/pawcontrol/services.py` by exercising negative/error paths in the service setup flow around coordinator listener hookup and Home Assistant service registration.

### Description
- Add `test_async_setup_services_propagates_dispatcher_connection_failures` to simulate `async_dispatcher_connect` raising and to assert `async_setup_services` surfaces that error.
- Add `test_async_setup_services_propagates_registration_failures` which stubs `hass.services.async_register` to raise for a specific service and asserts the error is propagated by `async_setup_services`.
- Both tests live in `tests/unit/test_services.py` and use the existing resolver/registry stubs and `monkeypatch` to drive the failure scenarios.

### Testing
- Ran `pytest -q -o addopts='' tests/unit/test_services.py -k 'async_setup_services_propagates or async_setup_services_registers_expected_services or async_setup_services_replaces_listener'` and observed `4 passed, 144 deselected`.
- The new tests passed in CI-local execution and exercise the previously untested negative branches of `async_setup_services`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69da9e070dbc8331895503cbba901bb2)