### PR TITLE
Improve data manager export coverage test reliability

### DIFF
--- a/tests/components/pawcontrol/test_data_manager_export_coverage.py
+++ b/tests/components/pawcontrol/test_data_manager_export_coverage.py
@@ -21,6 +21,16 @@ async def _create_manager(mock_hass: object, tmp_path: Path) -> PawControlDataMa
     )
     manager._async_load_storage = AsyncMock(return_value={})  # type: ignore[method-assign]
     manager._write_storage = AsyncMock()  # type: ignore[method-assign]
+
+    async def _executor_job(func: object, *args: object) -> object:
+        if callable(func):
+            result = func(*args)
+            if hasattr(result, "__await__"):
+                return await result  # type: ignore[no-any-return]
+            return result
+        raise TypeError("Executor job target must be callable")
+
+    manager._async_add_executor_job = _executor_job  # type: ignore[method-assign]
     await manager.async_initialize()
     return manager
 
@@ -331,6 +341,40 @@ async def test_async_export_data_all_allow_partial_raises_when_every_export_fail
         match="Failed to export any data type while allow_partial=True",
     ):
         await manager.async_export_data("buddy", "all", allow_partial=True)
+
+
+@pytest.mark.asyncio
+async def test_async_export_data_all_allow_partial_collects_oserror_details(
+    mock_hass: object,
+    tmp_path: Path,
+) -> None:
+    manager = await _create_manager(mock_hass, tmp_path)
+    manager._dog_profiles["buddy"].feeding_history = [
+        {"timestamp": "2026-01-05T07:30:00+00:00", "portion_size": 10.0},
+    ]
+    manager._dog_profiles["buddy"].walk_history = []
+    manager._dog_profiles["buddy"].health_history = []
+    manager._dog_profiles["buddy"].medication_history = []
+    manager._get_runtime_data = lambda: SimpleNamespace(  # type: ignore[method-assign]
+        garden_manager=SimpleNamespace(
+            async_export_sessions=AsyncMock(
+                return_value=tmp_path / DOMAIN / "exports" / "garden.json",
+            ),
+        ),
+        gps_geofence_manager=SimpleNamespace(
+            async_export_routes=AsyncMock(side_effect=OSError("routes read-only")),
+        ),
+    )
+
+    manifest_path = await manager.async_export_data(
+        "buddy",
+        "all",
+        allow_partial=True,
+    )
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert payload["errors"]["routes"] == "I/O error: routes read-only"
+    assert "feeding" in payload["exports"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
### Motivation
- Export-related unit tests were flaky because executor-backed file-writing callbacks were being mocked away, preventing export branches that write files from executing.
- Add a focused regression that asserts `OSError`/I/O error handling for `async_export_data(..., data_type="all", allow_partial=True)` so manifest error aggregation is covered.

### Description
- Inject a deterministic async test double for `_async_add_executor_job` in the shared `_create_manager` test factory so executor callbacks run synchronously under test and file exports are actually written (`tests/components/pawcontrol/test_data_manager_export_coverage.py`).
- Add `test_async_export_data_all_allow_partial_collects_oserror_details` to validate that `OSError` failures are recorded in the manifest as `"I/O error: ..."` while successful exports remain in the manifest.

### Testing
- Ran `pytest -q -o addopts='' -p no:_hypothesis_pytestplugin tests/components/pawcontrol/test_data_manager_export_coverage.py` and all tests in that file passed (18 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69daa2a55fc083318709579d18beb675)