### PR TITLE
Fix pyproject TOML parse and update pre-commit workflows to Node 24-compatible actions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -84,4 +84,3 @@ jobs:
           python -m scripts.sync_localization_flags \
             --allowlist scripts/sync_localization_flags.allowlist \
             --check
-

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -53,7 +53,9 @@ jobs:
           uv pip install --system -r requirements_test.txt --prerelease=allow
           uv pip install --system --upgrade pre-commit ruff pyupgrade flake8-type-checking reorder-python-imports
           uv cache prune --ci
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+         version: ">=0.4.0"
       - run: ruff check --fix || true
       - run: ruff format || true
       - name: Run pre-commit with fixes

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -53,7 +53,7 @@ jobs:
           uv pip install --system -r requirements_test.txt --prerelease=allow
           uv pip install --system --upgrade pre-commit ruff pyupgrade flake8-type-checking reorder-python-imports
           uv cache prune --ci
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4
       - run: ruff check --fix || true
       - run: ruff format || true
       - name: Run pre-commit with fixes
@@ -80,7 +80,3 @@ jobs:
           python -m scripts.sync_localization_flags \
             --allowlist scripts/sync_localization_flags.allowlist \
             --check
-
-      - name: pre-commit-ci-lite
-        uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -82,3 +82,5 @@ jobs:
           python -m scripts.sync_localization_flags \
             --allowlist scripts/sync_localization_flags.allowlist \
             --check
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()

--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -56,8 +56,10 @@ jobs:
       - uses: astral-sh/ruff-action@v3
         with:
          version: ">=0.4.0"
-      - run: ruff check --fix || true
-      - run: ruff format || true
+      - run: ruff check --fix
+      - run: ruff format
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()
       - name: Run pre-commit with fixes
         run: |
           ruff check . --fix || true
@@ -66,11 +68,11 @@ jobs:
           ruff check . --extend-select RUF100 || true
           ruff check . --preview || true
           ruff check . --output-format=github || true
-          ruff format || true
+          ruff format
           python scripts/enforce_docstring_baseline.py --update
           python -m scripts.sync_contributor_guides
           pre-commit run --all-files || true
-          pre-commit run --hook-stage manual python-typing-update --all-files || true
+          pre-commit run --hook-stage manual python-typing-update --all-files
 
       - name: Verify contributor guides
         run: |
@@ -82,5 +84,4 @@ jobs:
           python -m scripts.sync_localization_flags \
             --allowlist scripts/sync_localization_flags.allowlist \
             --check
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()
+

--- a/.github/workflows/pre-commit-ci-lite.yml
+++ b/.github/workflows/pre-commit-ci-lite.yml
@@ -44,7 +44,10 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-      - uses: astral-sh/ruff-action@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+         version: ">=0.4.0"
       - run: ruff check --fix || true
       - run: ruff format || true
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit-ci/lite-action@v1.1.0
+        if: always()

--- a/.github/workflows/pre-commit-ci-lite.yml
+++ b/.github/workflows/pre-commit-ci-lite.yml
@@ -44,9 +44,7 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           enable-cache: true
-      - uses: astral-sh/ruff-action@v3
+      - uses: astral-sh/ruff-action@v4
       - run: ruff check --fix || true
       - run: ruff format || true
       - uses: pre-commit/action@v3.0.1
-      - uses: pre-commit-ci/lite-action@v1.1.0
-        if: always()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ output-format= "github"
 detect-string-imports = true
 direction = "dependencies"
 string-imports-min-dots = 2
-type-checking-imports = true
+include-type-checking-imports = true
 
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,6 @@ line-ending = "lf"
 docstring-code-format = true
 docstring-code-line-length = "dynamic"
 skip-magic-trailing-comma = false
-line-length = 88
 
 [tool.ruff.lint]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ detect-string-imports = true
 direction = "dependencies"
 string-imports-min-dots = 2
 type-checking-imports = true
-include-dependencies = true
 
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,8 @@ output-format= "github"
 detect-string-imports = true
 direction = "dependencies"
 string-imports-min-dots = 2
-include-type-checking-imports = true
+type-checking-imports = true
+include-dependencies = true
 
 [tool.ruff.format]
 preview = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ output-format= "github"
 detect-string-imports = true
 direction = "dependencies"
 string-imports-min-dots = 2
-type-checking-imports: true
+type-checking-imports = true
 
 [tool.ruff.format]
 preview = true


### PR DESCRIPTION
### Motivation
- Resolve a `pre-commit` parsing failure caused by invalid TOML syntax in the Ruff analyze settings. 
- Remove GitHub Actions steps that target Node.js 20 to avoid deprecation warnings on hosted runners.

### Description
- Fix TOML syntax in `pyproject.toml` by changing `type-checking-imports: true` to `type-checking-imports = true` under `[tool.ruff.analyze]`.
- Update `astral-sh/ruff-action` usage from `@v3` to `@v4` in `.github/workflows/pre-commit-ci-lite.yml` and `.github/workflows/autofix.yml` to use a Node 24-compatible release. 
- Remove `pre-commit-ci/lite-action@v1.1.0` invocations from the two workflows to eliminate Node 20-targeted action usage while keeping the existing Ruff and `pre-commit/action@v3.0.1` steps.

### Testing
- Successfully parsed `pyproject.toml` using Python `tomllib` (load succeeded).
- Confirmed workflow changes with `rg`/search so only `astral-sh/ruff-action@v4` remains and `pre-commit-ci/lite-action` references were removed.
- Queried GitHub releases to verify `astral-sh/ruff-action` latest `v4.0.0` and `pre-commit-ci/lite-action` latest `v1.1.0` before removal.
- Attempted `pre-commit run --all-files` in this environment but it failed because `pre-commit` is not installed, so full local pre-commit execution was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dbca79033c8331bb8afa011caac63c)