### PR TITLE
fix: restore FeedingBatchEntry runtime import in test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ pawcontrol_compat.ensure_homeassistant_exception_symbols()
 
 from homeassistant.config_entries import ConfigEntry
 
+from custom_components.pawcontrol.feeding_manager import FeedingBatchEntry
 from custom_components.pawcontrol.types import (
     CoordinatorDogData,
     FeedingManagerDogSetupPayload,
@@ -53,10 +54,7 @@ from tests.helpers.factories import (
 )
 
 if TYPE_CHECKING:
-    from custom_components.pawcontrol.feeding_manager import (
-        FeedingBatchEntry,
-        FeedingManager,
-    )
+    from custom_components.pawcontrol.feeding_manager import FeedingManager
     from custom_components.pawcontrol.walk_manager import WalkManager
 
 


### PR DESCRIPTION
### Motivation
- Restore the `FeedingBatchEntry` symbol to module scope in `tests/conftest.py` to avoid a `NameError` at runtime from leaving the type only in a `TYPE_CHECKING` block.

### Description
- Add a runtime import `from custom_components.pawcontrol.feeding_manager import FeedingBatchEntry` in `tests/conftest.py` and keep `FeedingManager` as a `TYPE_CHECKING`-only import to minimize import surface changes.

### Testing
- Running `python -c "import importlib; importlib.import_module('tests.conftest')"` succeeded, confirming the module now imports without the missing symbol error.
- `ruff check tests/conftest.py` reported existing lint issues (`E402`, `D417`) unrelated to this change and therefore failed in this environment. 
- Attempted `pytest -q` on the target test file failed due to environment `pytest` options (`-n/--dist`) not being available here, so the full test run could not be executed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e140950c048331b01d58b13d95ec57)