### PR TITLE
Harden entity attribute normalization in date/datetime/text platforms

### DIFF
--- a/custom_components/pawcontrol/date.py
+++ b/custom_components/pawcontrol/date.py
@@ -50,7 +50,7 @@ from .types import (
     JSONMutableMapping,
     ensure_dog_modules_mapping,
 )
-from .utils import async_call_add_entities
+from .utils import async_call_add_entities, normalise_entity_attributes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -369,7 +369,7 @@ class PawControlDateBase(PawControlDogEntityBase, DateEntity, RestoreEntity):
                     1,
                 )
 
-        return self._finalize_entity_attributes(attributes)
+        return normalise_entity_attributes(self._finalize_entity_attributes(attributes))
 
     async def async_added_to_hass(self) -> None:
         """Called when entity is added to Home Assistant.

--- a/custom_components/pawcontrol/datetime.py
+++ b/custom_components/pawcontrol/datetime.py
@@ -38,6 +38,7 @@ from .types import (
 from .utils import (
     async_call_add_entities,
     ensure_utc_datetime,
+    normalise_entity_attributes,
     resolve_default_feeding_amount,
 )
 
@@ -254,7 +255,7 @@ class PawControlDateTimeBase(PawControlDogEntityBase, DateTimeEntity, RestoreEnt
         attributes = self._build_base_state_attributes(
             {"datetime_type": self._datetime_type},
         )
-        return self._finalize_entity_attributes(attributes)
+        return normalise_entity_attributes(self._finalize_entity_attributes(attributes))
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""

--- a/custom_components/pawcontrol/text.py
+++ b/custom_components/pawcontrol/text.py
@@ -57,7 +57,7 @@ from .types import (
     ensure_dog_text_metadata_snapshot,
     ensure_dog_text_snapshot,
 )
-from .utils import async_call_add_entities
+from .utils import async_call_add_entities, normalise_entity_attributes
 
 # ``ATTR_ENTITY_ID`` moved/changed over time; fall back to the canonical key.
 ATTR_ENTITY_ID = getattr(ha_const, "ATTR_ENTITY_ID", "entity_id")
@@ -385,7 +385,7 @@ class PawControlTextBase(PawControlDogEntityBase, TextEntity, RestoreEntity):
             },
         )
 
-        return self._finalize_entity_attributes(merged)
+        return normalise_entity_attributes(self._finalize_entity_attributes(merged))
 
     def _clamp_value(self, value: str) -> str:
         """Clamp ``value`` to the configured maximum length when necessary."""


### PR DESCRIPTION
### Motivation
- The project quality checks flagged missing JSON-serialization normalization in several entity platforms, causing `JSON_SERIALIZATION` errors for the `text`, `date`, and `datetime` modules.  
- Ensure entity `extra_state_attributes` are normalized consistently to satisfy serialization checks while preserving existing attribute shapes and runtime behavior.

### Description
- Import `normalise_entity_attributes` from `custom_components.pawcontrol.utils` into `text.py`, `date.py`, and `datetime.py`.  
- Wrap the final attribute return in each platform's `extra_state_attributes` with `normalise_entity_attributes(self._finalize_entity_attributes(...))` to guarantee normalized, JSON-serializable payloads.  
- Changes are minimal and local to attribute finalization in the three platform modules to avoid altering other logic or attribute structure.

### Testing
- Ran `ruff check` on the modified files with auto-fix and no issues reported for style on those files.  
- Ran unit tests for the affected platforms with `pytest -q -o addopts='' tests/unit/test_text_coverage.py tests/unit/test_date_coverage.py tests/unit/test_datetime_coverage.py` and received `104 passed` (all targeted tests passed).  
- Executed the overall quality script with `python -m scripts.verify_quality_compliance` which still reports unrelated project-wide MyPy/decorator issues, but the prior `JSON_SERIALIZATION` errors for `text.py`, `date.py`, and `datetime.py` were removed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684e8cdf883318738dbfd52cda207)