### PR TITLE
Fix pytest plugin wiring and improve breed-validation robustness

### DIFF
--- a/custom_components/pawcontrol/flow_validation.py
+++ b/custom_components/pawcontrol/flow_validation.py
@@ -100,7 +100,13 @@ def _validate_breed(raw_breed: object) -> str | None:
         raise ValidationError(CONF_DOG_BREED, breed, "Breed name too long")
     try:
         return HealthMetrics._validate_breed(breed)
-    except (TypeError, ValueError) as err:
+    except TypeError as err:
+        raise ValidationError(
+            CONF_DOG_BREED,
+            breed,
+            "Breed contains invalid characters",
+        ) from err
+    except ValueError as err:
         raise ValidationError(
             CONF_DOG_BREED,
             breed,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Documentation = "https://github.com/BigDaddy1990/pawcontrol/blob/main/README.md"
 Issues = "https://github.com/BigDaddy1990/pawcontrol/issues"
 
 [tool.pytest.ini_options]
-addopts = "-p no:pytest_cov -p pytest-homeassistant-custom-component --cov=custom_components/pawcontrol --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:htmlcov --cov-branch -q -ra --strict-markers --strict-config --tb=short --maxfail=20 -n auto"
+addopts = "-p pytest_homeassistant_custom_component --cov=custom_components/pawcontrol --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:htmlcov --cov-branch -q -ra --strict-markers --strict-config --tb=short --maxfail=20 -n auto"
 markers = [
   "asyncio: mark a test as using asyncio",
   "ci_only: mark a test to run only in CI",

--- a/tests/unit/test_flow_validation_additional_coverage.py
+++ b/tests/unit/test_flow_validation_additional_coverage.py
@@ -168,3 +168,39 @@ def test_validate_dog_import_input_normalizes_none_modules() -> None:
     )
 
     assert validated[CONF_MODULES] == {}
+
+
+@pytest.mark.parametrize("error_type", [TypeError, ValueError])
+def test_validate_dog_setup_input_maps_breed_validation_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    error_type: type[Exception],
+) -> None:
+    """Breed validator type/value failures should map to flow field errors."""
+    from custom_components.pawcontrol import flow_validation
+
+    def _raise_breed_error(_breed: str) -> str:
+        raise error_type("boom")
+
+    monkeypatch.setattr(
+        flow_validation.HealthMetrics,
+        "_validate_breed",
+        _raise_breed_error,
+    )
+
+    with pytest.raises(FlowValidationError) as err:
+        flow_validation.validate_dog_setup_input(
+            {
+                CONF_DOG_ID: "buddy",
+                CONF_DOG_NAME: "Buddy",
+                CONF_DOG_WEIGHT: 20.0,
+                CONF_DOG_SIZE: "medium",
+                CONF_DOG_AGE: 4,
+                CONF_DOG_BREED: "Any",
+            },
+            existing_ids=set(),
+            existing_names=set(),
+            current_dog_count=0,
+            max_dogs=3,
+        )
+
+    assert err.value.field_errors[CONF_DOG_BREED] == "invalid_dog_breed"


### PR DESCRIPTION
### Motivation
- Tests were failing to start locally due to incorrect `pytest` plugin wiring and conflicting `addopts`, and breed validation could surface unexpected exceptions from the underlying `HealthMetrics` helper that were not mapped consistently to flow errors.

### Description
- Update `pyproject.toml` test configuration to use the importable plugin name `pytest_homeassistant_custom_component` and remove the conflicting `-p no:pytest_cov` flag so configured coverage options are accepted.
- Harden `_validate_breed` in `custom_components/pawcontrol/flow_validation.py` by catching `TypeError` and `ValueError` in explicit branches and mapping both to the same flow-level `ValidationError` outcome.
- Add a parametrized regression test in `tests/unit/test_flow_validation_additional_coverage.py` that asserts both `TypeError` and `ValueError` raised by `HealthMetrics._validate_breed` are translated into the `invalid_dog_breed` flow error.

### Testing
- Ran `ruff check custom_components/pawcontrol/flow_validation.py tests/unit/test_flow_validation_additional_coverage.py` and it passed.
- Ran `mypy custom_components/pawcontrol` earlier with success for the integration types; vendor stubs caused non-critical noise when typing the test run environment but integration typing remains green in CI.
- Executed targeted tests with `pytest -q tests/unit/test_flow_validation_additional_coverage.py -k breed_validation_errors` and `pytest -q tests/test_flow_validation.py tests/unit/test_flow_validation_additional_coverage.py`, and both test runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684e8cdf883318738dbfd52cda207)