### PR TITLE
Fix pytest bootstrap config for local and CI reliability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ Documentation = "https://github.com/BigDaddy1990/pawcontrol/blob/main/README.md"
 Issues = "https://github.com/BigDaddy1990/pawcontrol/issues"
 
 [tool.pytest.ini_options]
-addopts = "-p no:pytest_cov -p pytest-homeassistant-custom-component --cov=custom_components/pawcontrol --cov-report=term-missing --cov-report=xml:coverage.xml --cov-report=html:htmlcov --cov-branch -q -ra --strict-markers --strict-config --tb=short --maxfail=20 -n auto"
+addopts = "-p no:pytest_cov -p pytest_homeassistant_custom_component -q -ra --strict-markers --strict-config --tb=short --maxfail=20"
 markers = [
   "asyncio: mark a test as using asyncio",
   "ci_only: mark a test to run only in CI",


### PR DESCRIPTION
### Motivation
- Fix pytest startup errors caused by an invalid plugin reference and hardcoded optional plugin flags so tests run in minimal environments.

### Description
- Updated `tool.pytest.ini_options.addopts` in `pyproject.toml` to use the importable plugin name `pytest_homeassistant_custom_component` and removed default `--cov` and `-n auto` flags to avoid requiring `pytest-cov` and `pytest-xdist`.

### Testing
- Ran `pytest -q tests/test_placeholder.py` and `pytest -q tests/test_pyproject_runtime_dependencies.py tests/test_setup_validation.py`, and both test runs completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e684e8cdf883318738dbfd52cda207)