### PR TITLE
Improve utils serialization robustness and add branch coverage

### DIFF
--- a/custom_components/pawcontrol/utils/serialize.py
+++ b/custom_components/pawcontrol/utils/serialize.py
@@ -7,7 +7,7 @@ Quality Scale: Platinum
 Python: 3.14+
 """
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Set as AbstractSet
 from dataclasses import asdict, is_dataclass
 from datetime import datetime, timedelta
 from typing import Any
@@ -149,13 +149,17 @@ def _serialize_value(value: Any) -> Any:
         # Recursively serialize dataclass fields
         return {k: _serialize_value(v) for k, v in asdict(value).items()}
 
-    # Handle dict (recursively)
-    if isinstance(value, dict):
-        return {k: _serialize_value(v) for k, v in value.items()}
+    # Handle mappings (recursively) and coerce keys to JSON-safe strings.
+    if isinstance(value, Mapping):
+        return {str(k): _serialize_value(v) for k, v in value.items()}
 
     # Handle list/tuple (recursively)
     if isinstance(value, list | tuple):
         return [_serialize_value(item) for item in value]
+
+    # Handle set/frozenset with deterministic ordering for stable payloads.
+    if isinstance(value, AbstractSet):
+        return [_serialize_value(item) for item in sorted(value, key=repr)]
 
     # Handle primitives (str, int, float, bool)
     if isinstance(value, str | int | float | bool):

--- a/tests/components/pawcontrol/test_utils_serialize.py
+++ b/tests/components/pawcontrol/test_utils_serialize.py
@@ -109,6 +109,19 @@ def test_serialize_value_supports_tuple_and_primitive_types() -> None:
     assert _serialize_value(7) == 7
 
 
+def test_serialize_value_coerces_mapping_keys_and_normalizes_sets() -> None:
+    """Serializer should force string keys and keep set output deterministic."""
+    payload = {
+        5: {timedelta(seconds=3), timedelta(seconds=1)},
+        "nested": {"key": {2, 1}},
+    }
+
+    assert _serialize_value(payload) == {
+        "5": [1, 3],
+        "nested": {"key": [1, 2]},
+    }
+
+
 def test_module_reload_syncs_parent_utils_re_exports() -> None:
     """Reloading should refresh ``custom_components.pawcontrol.utils`` exports."""
     parent = importlib.import_module("custom_components.pawcontrol.utils")


### PR DESCRIPTION
### Motivation
- Entity attribute serialization must handle non-dict mappings and set-like collections deterministically to avoid unstable JSON/state payloads and uncovered branches.
- The serializer previously only treated plain `dict` keys and did not provide stable ordering for `set`/`frozenset`, leaving coverage gaps and potential nondeterministic diagnostics output.

### Description
- Replace the dict-only branch with a `Mapping` check and coerce mapping keys to `str` in `_serialize_value` to produce JSON-safe keys via `str(k)`.
- Add `Set as AbstractSet` handling and normalize set-like collections by returning a deterministically ordered list using `sorted(value, key=repr)` before recursive serialization.
- Add a focused regression test `test_serialize_value_coerces_mapping_keys_and_normalizes_sets` to validate mapping key coercion and deterministic set normalization behavior.
- Keep existing helpers (`serialize_datetime`, `serialize_timedelta`, `serialize_dataclass`, `serialize_entity_attributes`) unchanged except for the more robust recursive `_serialize_value` behavior.

### Testing
- Ran `pytest -q tests/components/pawcontrol/test_utils_serialize.py` and it passed successfully (`...` / all tests green).
- Ran `ruff check` and `ruff format --check` against the modified files which passed without issues.
- Ran `mypy custom_components/pawcontrol/utils/serialize.py` which returned `Success: no issues found`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8c65268a483319391af371afda8c9)