### PR TITLE
Harden reconfigure profile validation and add regression coverage

### DIFF
--- a/custom_components/pawcontrol/config_flow_main.py
+++ b/custom_components/pawcontrol/config_flow_main.py
@@ -1735,6 +1735,19 @@ class PawControlConfigFlow(
                 if not new_profile:
                     raise vol.Invalid("invalid_profile")
             except (TypeError, ValueError, vol.Invalid) as err:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {**base_placeholders, "error_details": str(err)},
+                            ),
+                        ),
+                    ),
+                )
             requested_profile = user_input.get("entity_profile")
             if not isinstance(requested_profile, str):
                 return self.async_show_form(
@@ -1753,29 +1766,45 @@ class PawControlConfigFlow(
                         ),
                     ),
                 )
-            if requested_profile in VALID_PROFILES:
-                try:
-                    profile_data = cast(
-                        ReconfigureProfileInput,
-                        PROFILE_SCHEMA(dict(user_input)),
-                    )
-                    new_profile = profile_data["entity_profile"]
-                except vol.Invalid as err:
-                    return self.async_show_form(
-                        step_id="reconfigure",
-                        data_schema=form_schema,
-                        errors={"base": "invalid_profile"},
-                        description_placeholders=dict(
-                            cast(
-                                Mapping[str, str],
-                                freeze_placeholders(
-                                    {**base_placeholders, "error_details": str(err)},
-                                ),
+            if requested_profile not in VALID_PROFILES:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {
+                                    **base_placeholders,
+                                    "error_details": "entity_profile must be one of the "
+                                    "supported profiles",
+                                },
                             ),
                         ),
-                    )
-            else:
-                new_profile = requested_profile
+                    ),
+                )
+
+            try:
+                profile_data = cast(
+                    ReconfigureProfileInput,
+                    PROFILE_SCHEMA(dict(user_input)),
+                )
+                new_profile = profile_data["entity_profile"]
+            except vol.Invalid as err:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {**base_placeholders, "error_details": str(err)},
+                            ),
+                        ),
+                    ),
+                )
 
             if new_profile == current_profile:
                 return self.async_show_form(

--- a/docs/docstring_baseline.json
+++ b/docs/docstring_baseline.json
@@ -1,5 +1,5 @@
 {
-  "total_defs": 5002,
-  "documented_defs": 4523,
-  "coverage": 0.9042383046781287
+  "total_defs": 5003,
+  "documented_defs": 4524,
+  "coverage": 0.9042574455326804
 }

--- a/tests/components/pawcontrol/test_config_flow_path_matrix.py
+++ b/tests/components/pawcontrol/test_config_flow_path_matrix.py
@@ -259,6 +259,41 @@ async def test_reconfigure_returns_invalid_profile_when_profile_schema_rejects_i
 
 
 @pytest.mark.asyncio
+async def test_reconfigure_rejects_non_string_entity_profile_input(
+    hass,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Non-string profile payloads should return a typed invalid-profile error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DOGS: [{DOG_ID_FIELD: "buddy", DOG_NAME_FIELD: "Buddy"}],
+            "entity_profile": "standard",
+        },
+        options={"entity_profile": "standard"},
+    )
+    entry.add_to_hass(hass)
+
+    flow = PawControlConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": entry.entry_id}
+
+    async def _placeholders(*_args, **_kwargs):
+        return {"current_profile": "standard"}
+
+    monkeypatch.setattr(flow, "_build_reconfigure_placeholders", _placeholders)
+
+    result = await flow.async_step_reconfigure({"entity_profile": {"bad": "type"}})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "invalid_profile"}
+    assert result["description_placeholders"]["error_details"] == (
+        "entity_profile must be a string"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("profile_input", "expected_data"),
     [


### PR DESCRIPTION
### Motivation
- Fix an `async_step_reconfigure` validation path that raised an `IndentationError` / crashed import when profile coercion failed, causing test/runtime failures.
- Ensure reconfigure input is strictly validated so non-string or unsupported `entity_profile` payloads return a user-visible `invalid_profile` form instead of progressing to update logic.
- Add a focused regression to prevent this class of regressions and improve branch coverage for the reconfigure flow.

### Description
- Return a proper form error on coercion/schema failures in `async_step_reconfigure` by handling the earlier `except` case and surfacing `invalid_profile` with descriptive placeholders in `custom_components/pawcontrol/config_flow_main.py`.
- Enforce that `entity_profile` must be a string and one of `VALID_PROFILES` before attempting schema validation or applying updates, while still running `PROFILE_SCHEMA` for supported inputs.
- Preserve detailed `invalid_profile` `description_placeholders` so UI shows error details when schema validation fails.
- Add a regression test `test_reconfigure_rejects_non_string_entity_profile_input` in `tests/components/pawcontrol/test_config_flow_path_matrix.py` that asserts non-string payloads produce the expected form result and `error_details` text.

### Testing
- Ran `pytest -q tests/components/pawcontrol/test_config_flow_path_matrix.py -k reconfigure` and the reconfigure-targeted tests passed.
- Ran `pytest -q tests/components/pawcontrol/test_config_flow_entrypoint.py tests/components/pawcontrol/test_day1_flow_lifecycle_targets.py` and both test files passed.
- Ran `ruff check custom_components/pawcontrol/config_flow_main.py tests/components/pawcontrol/test_config_flow_path_matrix.py` and lint checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d6203ea083318bfc02df597f4a79)