### PR TITLE
Fix reconfigure profile validation and add regression coverage for non-string entity_profile

### DIFF
--- a/custom_components/pawcontrol/config_flow_main.py
+++ b/custom_components/pawcontrol/config_flow_main.py
@@ -1727,14 +1727,6 @@ class PawControlConfigFlow(
         )
 
         if user_input is not None:
-            try:
-                profile_raw = user_input.get("entity_profile")
-                new_profile = (
-                    str(profile_raw).strip() if profile_raw is not None else ""
-                )
-                if not new_profile:
-                    raise vol.Invalid("invalid_profile")
-            except (TypeError, ValueError, vol.Invalid) as err:
             requested_profile = user_input.get("entity_profile")
             if not isinstance(requested_profile, str):
                 return self.async_show_form(
@@ -1753,29 +1745,27 @@ class PawControlConfigFlow(
                         ),
                     ),
                 )
-            if requested_profile in VALID_PROFILES:
-                try:
-                    profile_data = cast(
-                        ReconfigureProfileInput,
-                        PROFILE_SCHEMA(dict(user_input)),
-                    )
-                    new_profile = profile_data["entity_profile"]
-                except vol.Invalid as err:
-                    return self.async_show_form(
-                        step_id="reconfigure",
-                        data_schema=form_schema,
-                        errors={"base": "invalid_profile"},
-                        description_placeholders=dict(
-                            cast(
-                                Mapping[str, str],
-                                freeze_placeholders(
-                                    {**base_placeholders, "error_details": str(err)},
-                                ),
+
+            try:
+                profile_data = cast(
+                    ReconfigureProfileInput,
+                    PROFILE_SCHEMA(dict(user_input)),
+                )
+                new_profile = profile_data["entity_profile"]
+            except vol.Invalid as err:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {**base_placeholders, "error_details": str(err)},
                             ),
                         ),
-                    )
-            else:
-                new_profile = requested_profile
+                    ),
+                )
 
             if new_profile == current_profile:
                 return self.async_show_form(

--- a/tests/components/pawcontrol/test_config_flow_path_matrix.py
+++ b/tests/components/pawcontrol/test_config_flow_path_matrix.py
@@ -217,6 +217,46 @@ async def test_reconfigure_paths_and_updates(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("profile_input", [None, 7, object()])
+async def test_reconfigure_returns_invalid_profile_when_entity_profile_not_string(
+    hass,
+    monkeypatch: pytest.MonkeyPatch,
+    profile_input: object,
+) -> None:
+    """Non-string profile input should produce a stable invalid profile form error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_DOGS: [
+                {
+                    DOG_ID_FIELD: "buddy",
+                    DOG_NAME_FIELD: "Buddy",
+                    DOG_MODULES_FIELD: {"gps": True},
+                }
+            ],
+            "entity_profile": "standard",
+        },
+        options={"entity_profile": "standard"},
+    )
+    entry.add_to_hass(hass)
+
+    flow = PawControlConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": entry.entry_id}
+
+    async def _placeholders(*_args, **_kwargs):
+        return {"current_profile": "standard"}
+
+    monkeypatch.setattr(flow, "_build_reconfigure_placeholders", _placeholders)
+
+    result = await flow.async_step_reconfigure({"entity_profile": profile_input})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "invalid_profile"}
+
+
+@pytest.mark.asyncio
 async def test_reconfigure_returns_invalid_profile_when_profile_schema_rejects_input(
     hass,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
### Motivation
- Restore correct control flow in the reconfigure step so invalid or non-string `entity_profile` inputs reliably surface an `invalid_profile` form error.
- Improve branch coverage for the `async_step_reconfigure` validation paths to prevent regressions caused by malformed inputs.

### Description
- Repair `async_step_reconfigure` in `custom_components/pawcontrol/config_flow_main.py` by eliminating the broken `except`/indentation path and consolidating profile validation into a clear sequence that first verifies the input type and then validates via `PROFILE_SCHEMA` inside a `try/except` block.
- Ensure non-string `entity_profile` values immediately return the reconfigure form with `errors={"base": "invalid_profile"}` and a helpful `error_details` placeholder.
- Add a parametrised regression test `test_reconfigure_returns_invalid_profile_when_entity_profile_not_string` to `tests/components/pawcontrol/test_config_flow_path_matrix.py` covering `None`, `7`, and `object()` payloads to lock in behaviour.

### Testing
- Ran `ruff format` and `ruff check` for the modified files and they passed for the changed files.
- Executed `pytest -q tests/components/pawcontrol/test_config_flow_path_matrix.py` and the suite passed (`... [100%]`).
- Executed `pytest -q tests/unit/test_config_flow_main.py -k reconfigure` and the targeted reconfigure tests passed (`..... [100%]`).
- Ran the full `pytest -q` which exercised additional unrelated pre-existing failures in other modules (these failures are outside the scope of this PR and not caused by the reconfigure fix).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d6203ea083318bfc02df597f4a79)