### PR TITLE
Fix reconfigure profile validation and strengthen config-flow coverage

### DIFF
--- a/custom_components/pawcontrol/config_flow_main.py
+++ b/custom_components/pawcontrol/config_flow_main.py
@@ -1727,14 +1727,6 @@ class PawControlConfigFlow(
         )
 
         if user_input is not None:
-            try:
-                profile_raw = user_input.get("entity_profile")
-                new_profile = (
-                    str(profile_raw).strip() if profile_raw is not None else ""
-                )
-                if not new_profile:
-                    raise vol.Invalid("invalid_profile")
-            except (TypeError, ValueError, vol.Invalid) as err:
             requested_profile = user_input.get("entity_profile")
             if not isinstance(requested_profile, str):
                 return self.async_show_form(
@@ -1749,6 +1741,24 @@ class PawControlConfigFlow(
                                     **base_placeholders,
                                     "error_details": "entity_profile must be a string",
                                 },
+                            ),
+                        ),
+                    ),
+                )
+            try:
+                new_profile = requested_profile.strip()
+                if not new_profile:
+                    raise vol.Invalid("invalid_profile")
+            except (TypeError, ValueError, vol.Invalid) as err:
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {**base_placeholders, "error_details": str(err)},
                             ),
                         ),
                     ),
@@ -1775,7 +1785,22 @@ class PawControlConfigFlow(
                         ),
                     )
             else:
-                new_profile = requested_profile
+                return self.async_show_form(
+                    step_id="reconfigure",
+                    data_schema=form_schema,
+                    errors={"base": "invalid_profile"},
+                    description_placeholders=dict(
+                        cast(
+                            Mapping[str, str],
+                            freeze_placeholders(
+                                {
+                                    **base_placeholders,
+                                    "error_details": "invalid_profile",
+                                },
+                            ),
+                        ),
+                    ),
+                )
 
             if new_profile == current_profile:
                 return self.async_show_form(

--- a/tests/components/pawcontrol/test_config_flow_path_matrix.py
+++ b/tests/components/pawcontrol/test_config_flow_path_matrix.py
@@ -259,6 +259,32 @@ async def test_reconfigure_returns_invalid_profile_when_profile_schema_rejects_i
 
 
 @pytest.mark.asyncio
+async def test_reconfigure_returns_invalid_profile_for_non_string_input(
+    hass,
+) -> None:
+    """Non-string profile input should be rejected before schema parsing."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_DOGS: [{DOG_ID_FIELD: "buddy", DOG_NAME_FIELD: "Buddy"}]},
+        options={"entity_profile": "standard"},
+    )
+    entry.add_to_hass(hass)
+
+    flow = PawControlConfigFlow()
+    flow.hass = hass
+    flow.context = {"entry_id": entry.entry_id}
+
+    result = await flow.async_step_reconfigure({"entity_profile": 99})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reconfigure"
+    assert result["errors"] == {"base": "invalid_profile"}
+    assert result["description_placeholders"]["error_details"] == (
+        "entity_profile must be a string"
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("profile_input", "expected_data"),
     [


### PR DESCRIPTION
### Motivation
- Tests failed to collect due to a malformed `except`/indentation block in `async_step_reconfigure` which caused import-time errors and blocked validation.
- The reconfigure path accepted invalid `entity_profile` payloads (non-string, empty, or unknown values) which could produce incorrect updates.
- Improve branch coverage and lock in correct behavior with a focused regression test.

### Description
- Repair `async_step_reconfigure` in `custom_components/pawcontrol/config_flow_main.py` by removing the broken control flow and adding explicit validation that rejects non-string, empty/whitespace-only, and unknown `entity_profile` values with `async_show_form` errors.
- When `entity_profile` is non-string, the flow now returns a form error with `errors={"base": "invalid_profile"}` and `description_placeholders` explaining `entity_profile must be a string`.
- When `entity_profile` is empty or invalid, the flow returns a form error with `errors={"base": "invalid_profile"}` and `description_placeholders` containing the validation message.
- Add a regression test `test_reconfigure_returns_invalid_profile_for_non_string_input` in `tests/components/pawcontrol/test_config_flow_path_matrix.py` that verifies non-string input is rejected and the error details are surfaced.

### Testing
- Running `pytest -q tests/components/pawcontrol/test_config_flow_path_matrix.py` passed after the fix and the new regression test exercised the non-string input path successfully.
- Running `pytest -q tests/components/pawcontrol/test_config_flow_entrypoint.py tests/components/pawcontrol/test_day1_flow_lifecycle_targets.py` passed after the fix and confirmed entrypoint and lifecycle targets remain green.
- `ruff format` and `ruff check` were executed against the modified files and completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e8d6203ea083318bfc02df597f4a79)